### PR TITLE
Adds optional source_tag to User-Agent

### DIFF
--- a/internal/provider/header.go
+++ b/internal/provider/header.go
@@ -1,0 +1,20 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+)
+
+type customHeader struct {
+	name  string
+	value string
+}
+
+func NewHeaderProvider(name string, value string) *customHeader {
+	return &customHeader{name: name, value: value}
+}
+
+func (h *customHeader) Intercept(ctx context.Context, req *http.Request) error {
+	req.Header.Set(h.name, h.value)
+	return nil
+}

--- a/internal/provider/header_test.go
+++ b/internal/provider/header_test.go
@@ -1,0 +1,32 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestCustomHeaderIntercept(t *testing.T) {
+	expectedName := "X-Custom-Header"
+	expectedValue := "Custom-Value"
+	header := NewHeaderProvider(expectedName, expectedValue)
+
+	req, err := http.NewRequest("GET", "https://example.com", nil)
+	if err != nil {
+		t.Fatalf("Failed to create HTTP request: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Call the Intercept method (method being tested)
+	err = header.Intercept(ctx, req)
+	if err != nil {
+		t.Errorf("Intercept failed: %v", err)
+	}
+
+	// Verify that the custom header is set correctly
+	if req.Header.Get(expectedName) != expectedValue {
+		t.Errorf("Expected header '%s' to have value '%s', got '%s'", expectedName, expectedValue,
+			req.Header.Get(expectedName))
+	}
+}

--- a/internal/useragent/useragent.go
+++ b/internal/useragent/useragent.go
@@ -5,6 +5,11 @@ import (
 	"strings"
 )
 
+func getPackageVersion() string {
+	// update at release time
+	return "v0.5.0-pre"
+}
+
 func BuildUserAgent(sourceTag string) string {
 	return buildUserAgent("go-client", sourceTag)
 }
@@ -14,8 +19,7 @@ func BuildUserAgentGRPC(sourceTag string) string {
 }
 
 func buildUserAgent(appName string, sourceTag string) string {
-	// need to set to actual current version
-	appVersion := "0.0.1"
+	appVersion := getPackageVersion()
 
 	sourceTagInfo := ""
 	if sourceTag != "" {

--- a/internal/useragent/useragent.go
+++ b/internal/useragent/useragent.go
@@ -2,7 +2,6 @@ package useragent
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 )
 
@@ -31,8 +30,13 @@ func buildSourceTagField(userAgent string) string {
 	userAgent = strings.ToLower(userAgent)
 
 	// Limit charset to [a-z0-9_ ]
-	re := regexp.MustCompile(`[^a-z0-9_ ]`)
-	userAgent = re.ReplaceAllString(userAgent, "")
+	var strBldr strings.Builder
+	for _, char := range userAgent {
+		if (char >= 'a' && char <= 'z') || (char >= '0' && char <= '9') || char == '_' || char == ' ' {
+			strBldr.WriteRune(char)
+		}
+	}
+	userAgent = strBldr.String()
 
 	// Trim left/right whitespace
 	userAgent = strings.TrimSpace(userAgent)

--- a/internal/useragent/useragent.go
+++ b/internal/useragent/useragent.go
@@ -1,4 +1,4 @@
-package util
+package useragent
 
 import (
 	"fmt"

--- a/internal/useragent/useragent_test.go
+++ b/internal/useragent/useragent_test.go
@@ -1,13 +1,14 @@
 package useragent
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
 
 func TestBuildUserAgentNoSourceTag(t *testing.T) {
 	sourceTag := ""
-	expectedStartWith := "go-client/"
+	expectedStartWith := fmt.Sprintf("go-client/%s", getPackageVersion())
 	result := BuildUserAgent(sourceTag)
 	if !strings.HasPrefix(result, expectedStartWith) {
 		t.Errorf("BuildUserAgent(): expected user-agent to start with %s, but got %s", expectedStartWith, result)
@@ -19,7 +20,7 @@ func TestBuildUserAgentNoSourceTag(t *testing.T) {
 
 func TestBuildUserAgentWithSourceTag(t *testing.T) {
 	sourceTag := "my_source_tag"
-	expectedStartWith := "go-client/"
+	expectedStartWith := fmt.Sprintf("go-client/%s", getPackageVersion())
 	result := BuildUserAgent(sourceTag)
 	if !strings.HasPrefix(result, expectedStartWith) {
 		t.Errorf("BuildUserAgent(): expected user-agent to start with %s, but got %s", expectedStartWith, result)
@@ -31,7 +32,7 @@ func TestBuildUserAgentWithSourceTag(t *testing.T) {
 
 func TestBuildUserAgentGRPCNoSourceTag(t *testing.T) {
 	sourceTag := ""
-	expectedStartWith := "go-client[grpc]/"
+	expectedStartWith := fmt.Sprintf("go-client[grpc]/%s", getPackageVersion())
 	result := BuildUserAgentGRPC(sourceTag)
 	if !strings.HasPrefix(result, expectedStartWith) {
 		t.Errorf("BuildUserAgent(): expected user-agent to start with %s, but got %s", expectedStartWith, result)
@@ -43,7 +44,7 @@ func TestBuildUserAgentGRPCNoSourceTag(t *testing.T) {
 
 func TestBuildUserAgentGRPCWithSourceTag(t *testing.T) {
 	sourceTag := "my_source_tag"
-	expectedStartWith := "go-client[grpc]/"
+	expectedStartWith := fmt.Sprintf("go-client[grpc]/%s", getPackageVersion())
 	result := BuildUserAgentGRPC(sourceTag)
 	if !strings.HasPrefix(result, expectedStartWith) {
 		t.Errorf("BuildUserAgent(): expected user-agent to start with %s, but got %s", expectedStartWith, result)

--- a/internal/useragent/useragent_test.go
+++ b/internal/useragent/useragent_test.go
@@ -1,0 +1,80 @@
+package useragent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildUserAgentNoSourceTag(t *testing.T) {
+	sourceTag := ""
+	expectedStartWith := "go-client/"
+	result := BuildUserAgent(sourceTag)
+	if !strings.HasPrefix(result, expectedStartWith) {
+		t.Errorf("BuildUserAgent(): expected user-agent to start with %s, but got %s", expectedStartWith, result)
+	}
+	if strings.Contains(result, "source_tag") {
+		t.Errorf("BuildUserAgent(): expected user-agent to not contain 'source_tag', but got %s", result)
+	}
+}
+
+func TestBuildUserAgentWithSourceTag(t *testing.T) {
+	sourceTag := "my_source_tag"
+	expectedStartWith := "go-client/"
+	result := BuildUserAgent(sourceTag)
+	if !strings.HasPrefix(result, expectedStartWith) {
+		t.Errorf("BuildUserAgent(): expected user-agent to start with %s, but got %s", expectedStartWith, result)
+	}
+	if !strings.Contains(result, "source_tag=my_source_tag") {
+		t.Errorf("BuildUserAgent(): expected user-agent to contain 'source_tag=my_source_tag', but got %s", result)
+	}
+}
+
+func TestBuildUserAgentGRPCNoSourceTag(t *testing.T) {
+	sourceTag := ""
+	expectedStartWith := "go-client[grpc]/"
+	result := BuildUserAgentGRPC(sourceTag)
+	if !strings.HasPrefix(result, expectedStartWith) {
+		t.Errorf("BuildUserAgent(): expected user-agent to start with %s, but got %s", expectedStartWith, result)
+	}
+	if strings.Contains(result, "source_tag") {
+		t.Errorf("BuildUserAgent(): expected user-agent to not contain 'source_tag', but got %s", result)
+	}
+}
+
+func TestBuildUserAgentGRPCWithSourceTag(t *testing.T) {
+	sourceTag := "my_source_tag"
+	expectedStartWith := "go-client[grpc]/"
+	result := BuildUserAgentGRPC(sourceTag)
+	if !strings.HasPrefix(result, expectedStartWith) {
+		t.Errorf("BuildUserAgent(): expected user-agent to start with %s, but got %s", expectedStartWith, result)
+	}
+	if !strings.Contains(result, "source_tag=my_source_tag") {
+		t.Errorf("BuildUserAgent(): expected user-agent to contain 'source_tag=my_source_tag', but got %s", result)
+	}
+}
+
+func TestBuildUserAgentSourceTagIsNormalized(t *testing.T) {
+	sourceTag := "my source tag!!!!"
+	result := BuildUserAgent(sourceTag)
+	if !strings.Contains(result, "source_tag=my_source_tag") {
+		t.Errorf("BuildUserAgent(\"%s\"): expected user-agent to contain 'source_tag=my_source_tag', but got %s", sourceTag, result)
+	}
+
+	sourceTag = "My Source Tag"
+	result = BuildUserAgent(sourceTag)
+	if !strings.Contains(result, "source_tag=my_source_tag") {
+		t.Errorf("BuildUserAgent(\"%s\"): expected user-agent to contain 'source_tag=my_source_tag', but got %s", sourceTag, result)
+	}
+
+	sourceTag = "   My Source Tag  123  "
+	result = BuildUserAgent(sourceTag)
+	if !strings.Contains(result, "source_tag=my_source_tag") {
+		t.Errorf("BuildUserAgent(\"%s\"): expected user-agent to contain 'source_tag=my_source_tag_123', but got %s", sourceTag, result)
+	}
+
+	sourceTag = "   My Source Tag  123 #### !! "
+	result = BuildUserAgent(sourceTag)
+	if !strings.Contains(result, "source_tag=my_source_tag") {
+		t.Errorf("BuildUserAgent(\"%s\"): expected user-agent to contain 'source_tag=my_source_tag_123', but got %s", sourceTag, result)
+	}
+}

--- a/internal/util/user_agent.go
+++ b/internal/util/user_agent.go
@@ -1,0 +1,44 @@
+package util
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+func BuildUserAgent(sourceTag string) string {
+	return buildUserAgent("go-client", sourceTag)
+}
+
+func BuildUserAgentGRPC(sourceTag string) string {
+	return buildUserAgent("go-client[grpc]", sourceTag)
+}
+
+func buildUserAgent(appName string, sourceTag string) string {
+	// need to set to actual current version
+	appVersion := "0.0.1"
+
+	sourceTagInfo := ""
+	if sourceTag != "" {
+		sourceTagInfo = buildSourceTagField(sourceTag)
+	}
+	userAgent := fmt.Sprintf("%s/%s%s", appName, appVersion, sourceTagInfo)
+	return userAgent
+}
+
+func buildSourceTagField(userAgent string) string {
+	// Lowercase
+	userAgent = strings.ToLower(userAgent)
+
+	// Limit charset to [a-z0-9_ ]
+	re := regexp.MustCompile(`[^a-z0-9_ ]`)
+	userAgent = re.ReplaceAllString(userAgent, "")
+
+	// Trim left/right whitespace
+	userAgent = strings.TrimSpace(userAgent)
+
+	// Condense multiple spaces to one, and replace with underscore
+	userAgent = strings.Join(strings.Fields(userAgent), "_")
+
+	return fmt.Sprintf("; source_tag=%s;", userAgent)
+}

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -6,7 +6,8 @@ import (
 	"fmt"
 	"github.com/deepmap/oapi-codegen/v2/pkg/securityprovider"
 	"github.com/pinecone-io/go-pinecone/internal/gen/control"
-	"github.com/pinecone-io/go-pinecone/internal/util"
+	"github.com/pinecone-io/go-pinecone/internal/provider"
+	"github.com/pinecone-io/go-pinecone/internal/useragent"
 	"io"
 	"net/http"
 )
@@ -17,23 +18,10 @@ type Client struct {
 	sourceTag  string
 }
 
-type CustomHeader struct {
-	userAgent string
-}
-
-func NewUserAgentProvider(userAgent string) *CustomHeader {
-	return &CustomHeader{userAgent: userAgent}
-}
-
-func (s *CustomHeader) Intercept(ctx context.Context, req *http.Request) error {
-	req.Header.Set("User-Agent", s.userAgent)
-	return nil
-}
-
 type NewClientParams struct {
 	ApiKey string
 	// optional fields
-	SourceTag  string
+	SourceTag string
 }
 
 func NewClient(in NewClientParams) (*Client, error) {
@@ -42,7 +30,7 @@ func NewClient(in NewClientParams) (*Client, error) {
 		return nil, err
 	}
 
-	userAgentProvider := NewUserAgentProvider(util.BuildUserAgent(in.SourceTag))
+	userAgentProvider := provider.NewHeaderProvider("User-Agent", useragent.BuildUserAgent(in.SourceTag))
 
 	client, err := control.NewClient("https://api.pinecone.io",
 		control.WithRequestEditorFn(apiKeyProvider.Intercept),

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -19,9 +19,8 @@ type Client struct {
 }
 
 type NewClientParams struct {
-	ApiKey string
-	// optional fields
-	SourceTag string
+	ApiKey    string
+	SourceTag string // optional
 }
 
 func NewClient(in NewClientParams) (*Client, error) {

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -2,11 +2,13 @@ package pinecone
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"testing"
+
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"os"
-	"testing"
 )
 
 type ClientTests struct {
@@ -50,6 +52,41 @@ func (ts *ClientTests) SetupSuite() {
 	// Left here as a convenience during active development.
 	//deleteUUIDNamedResources(context.Background(), &ts.client)
 
+}
+
+func (ts *ClientTests) TestNewClientParamsSet() {
+	apiKey := "test-api-key"
+	client, err := NewClient(NewClientParams{ApiKey: apiKey})
+	if err != nil {
+		ts.FailNow(err.Error())
+	}
+	if client.apiKey != apiKey {
+		ts.FailNow(fmt.Sprintf("Expected client to have apiKey '%s', but got '%s'", apiKey, client.apiKey))
+	}
+	if client.sourceTag != "" {
+		ts.FailNow(fmt.Sprintf("Expected client to have empty sourceTag, but got '%s'", client.sourceTag))
+	}
+	if len(client.restClient.RequestEditors) != 2 {
+		ts.FailNow("Expected 2 request editors on client")
+	}
+}
+
+func (ts *ClientTests) TestNewClientParamsSetSourceTag() {
+	apiKey := "test-api-key"
+	sourceTag := "test-source-tag"
+	client, err := NewClient(NewClientParams{ApiKey: apiKey, SourceTag: sourceTag})
+	if err != nil {
+		ts.FailNow(err.Error())
+	}
+	if client.apiKey != apiKey {
+		ts.FailNow(fmt.Sprintf("Expected client to have apiKey '%s', but got '%s'", apiKey, client.apiKey))
+	}
+	if client.sourceTag != sourceTag {
+		ts.FailNow(fmt.Sprintf("Expected client to have sourceTag '%s', but got '%s'", sourceTag, client.sourceTag))
+	}
+	if len(client.restClient.RequestEditors) != 2 {
+		ts.FailNow("Expected 2 request editors on client")
+	}
 }
 
 func (ts *ClientTests) TestListIndexes() {

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -12,6 +12,8 @@ import (
 type ClientTests struct {
 	suite.Suite
 	client          Client
+	clientSourceTag Client
+	sourceTag       string
 	podIndex        string
 	serverlessIndex string
 }
@@ -36,6 +38,13 @@ func (ts *ClientTests) SetupSuite() {
 	}
 	ts.client = *client
 
+	ts.sourceTag = "test_source_tag"
+	clientSourceTag, err := NewClient(NewClientParams{ApiKey: apiKey, SourceTag: ts.sourceTag})
+	if err != nil {
+		ts.FailNow(err.Error())
+	}
+	ts.clientSourceTag = *clientSourceTag
+
 	// this will clean up the project deleting all indexes and collections that are
 	// named a UUID. Generally not needed as all tests are cleaning up after themselves
 	// Left here as a convenience during active development.
@@ -45,6 +54,12 @@ func (ts *ClientTests) SetupSuite() {
 
 func (ts *ClientTests) TestListIndexes() {
 	indexes, err := ts.client.ListIndexes(context.Background())
+	require.NoError(ts.T(), err)
+	require.Greater(ts.T(), len(indexes), 0, "Expected at least one index to exist")
+}
+
+func (ts *ClientTests) TestListIndexesSourceTag() {
+	indexes, err := ts.clientSourceTag.ListIndexes(context.Background())
 	require.NoError(ts.T(), err)
 	require.Greater(ts.T(), len(indexes), 0, "Expected at least one index to exist")
 }
@@ -93,8 +108,20 @@ func (ts *ClientTests) TestDescribeServerlessIndex() {
 	require.Equal(ts.T(), ts.serverlessIndex, index.Name, "Index name does not match")
 }
 
+func (ts *ClientTests) TestDescribeServerlessIndexSourceTag() {
+	index, err := ts.clientSourceTag.DescribeIndex(context.Background(), ts.serverlessIndex)
+	require.NoError(ts.T(), err)
+	require.Equal(ts.T(), ts.serverlessIndex, index.Name, "Index name does not match")
+}
+
 func (ts *ClientTests) TestDescribePodIndex() {
 	index, err := ts.client.DescribeIndex(context.Background(), ts.podIndex)
+	require.NoError(ts.T(), err)
+	require.Equal(ts.T(), ts.podIndex, index.Name, "Index name does not match")
+}
+
+func (ts *ClientTests) TestDescribePodIndexSourceTag() {
+	index, err := ts.clientSourceTag.DescribeIndex(context.Background(), ts.podIndex)
 	require.NoError(ts.T(), err)
 	require.Equal(ts.T(), ts.podIndex, index.Name, "Index name does not match")
 }

--- a/pinecone/index_connection.go
+++ b/pinecone/index_connection.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"github.com/pinecone-io/go-pinecone/internal/gen/data"
+	"github.com/pinecone-io/go-pinecone/internal/util"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
@@ -18,7 +19,7 @@ type IndexConnection struct {
 	grpcConn   *grpc.ClientConn
 }
 
-func newIndexConnection(apiKey string, host string, namespace string) (*IndexConnection, error) {
+func newIndexConnection(apiKey string, host string, namespace string, sourceTag string) (*IndexConnection, error) {
 	config := &tls.Config{}
 	target := fmt.Sprintf("%s:443", host)
 	conn, err := grpc.Dial(
@@ -26,6 +27,7 @@ func newIndexConnection(apiKey string, host string, namespace string) (*IndexCon
 		grpc.WithTransportCredentials(credentials.NewTLS(config)),
 		grpc.WithAuthority(target),
 		grpc.WithBlock(),
+		grpc.WithUserAgent(util.BuildUserAgentGRPC(sourceTag)),
 	)
 
 	if err != nil {

--- a/pinecone/index_connection.go
+++ b/pinecone/index_connection.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"github.com/pinecone-io/go-pinecone/internal/gen/data"
-	"github.com/pinecone-io/go-pinecone/internal/util"
+	"github.com/pinecone-io/go-pinecone/internal/useragent"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
@@ -27,7 +27,7 @@ func newIndexConnection(apiKey string, host string, namespace string, sourceTag 
 		grpc.WithTransportCredentials(credentials.NewTLS(config)),
 		grpc.WithAuthority(target),
 		grpc.WithBlock(),
-		grpc.WithUserAgent(util.BuildUserAgentGRPC(sourceTag)),
+		grpc.WithUserAgent(useragent.BuildUserAgentGRPC(sourceTag)),
 	)
 
 	if err != nil {

--- a/pinecone/index_connection_test.go
+++ b/pinecone/index_connection_test.go
@@ -59,7 +59,7 @@ func (ts *IndexConnectionTests) SetupSuite() {
 	namespace, err := uuid.NewV7()
 	assert.NoError(ts.T(), err)
 
-	idxConn, err := newIndexConnection(ts.apiKey, ts.host, namespace.String())
+	idxConn, err := newIndexConnection(ts.apiKey, ts.host, namespace.String(), "")
 	assert.NoError(ts.T(), err)
 	ts.idxConn = idxConn
 

--- a/pinecone/index_connection_test.go
+++ b/pinecone/index_connection_test.go
@@ -80,6 +80,48 @@ func (ts *IndexConnectionTests) TearDownSuite() {
 	assert.NoError(ts.T(), err)
 }
 
+func (ts *IndexConnectionTests) TestNewIndexConnection() {
+	apiKey := "test-api-key"
+	namespace := ""
+	sourceTag := ""
+	idxConn, err := newIndexConnection(apiKey, ts.host, namespace, sourceTag)
+	assert.NoError(ts.T(), err)
+
+	if idxConn.apiKey != apiKey {
+		ts.FailNow(fmt.Sprintf("Expected idxConn to have apiKey '%s', but got '%s'", apiKey, idxConn.apiKey))
+	}
+	if idxConn.Namespace != "" {
+		ts.FailNow(fmt.Sprintf("Expected idxConn to have empty namespace, but got '%s'", idxConn.Namespace))
+	}
+	if idxConn.dataClient == nil {
+		ts.FailNow("Expected idxConn to have non-nil dataClient")
+	}
+	if idxConn.grpcConn == nil {
+		ts.FailNow("Expected idxConn to have non-nil grpcConn")
+	}
+}
+
+func (ts *IndexConnectionTests) TestNewIndexConnectionNamespace() {
+	apiKey := "test-api-key"
+	namespace := "test-namespace"
+	sourceTag := "test-source-tag"
+	idxConn, err := newIndexConnection(apiKey, ts.host, namespace, sourceTag)
+	assert.NoError(ts.T(), err)
+
+	if idxConn.apiKey != apiKey {
+		ts.FailNow(fmt.Sprintf("Expected idxConn to have apiKey '%s', but got '%s'", apiKey, idxConn.apiKey))
+	}
+	if idxConn.Namespace != namespace {
+		ts.FailNow(fmt.Sprintf("Expected idxConn to have namespace '%s', but got '%s'", namespace, idxConn.Namespace))
+	}
+	if idxConn.dataClient == nil {
+		ts.FailNow("Expected idxConn to have non-nil dataClient")
+	}
+	if idxConn.grpcConn == nil {
+		ts.FailNow("Expected idxConn to have non-nil grpcConn")
+	}
+}
+
 func (ts *IndexConnectionTests) TestFetchVectors() {
 	ctx := context.Background()
 	res, err := ts.idxConn.FetchVectors(&ctx, ts.vectorIds)


### PR DESCRIPTION
Allows setting source_tag in UserAgent.

Usage:
```go
	client, err := pinecone.NewClient(pinecone.NewClientParams{
		ApiKey: "my-api-key",
		SourceTag: "foo",
	})
```