### PR TITLE
Receive and pass `context.Context` by value in `IndexConnection` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 > **Warning**
-> 
+>
 > **Under active development** This SDK is pre-1.0 and should be considered unstable. Before a 1.0 release, there are
 > no guarantees of backward compatibility between minor versions.
 
@@ -8,18 +8,20 @@
 Official Pinecone Go Client
 
 ## Features
-go-pinecone contains 
 
-* gRPC bindings for Data Plane operations on Vectors
-* REST bindings for Control Plane operations on Indexes and Collections
+go-pinecone contains
+
+- gRPC bindings for Data Plane operations on Vectors
+- REST bindings for Control Plane operations on Indexes and Collections
 
 See [Pinecone API Docs](https://docs.pinecone.io/reference/) for more info.
- 
 
 ## Installation
+
 go-pinecone requires a Go version with [modules](https://github.com/golang/go/wiki/Modules) support.
 
 To add a dependency on go-pinecone:
+
 ```shell
 go get github.com/pinecone-io/go-pinecone/pinecone
 ```
@@ -65,7 +67,7 @@ func main() {
 		return
 	}
 
-	res, err := idx.DescribeIndexStats(&ctx)
+	res, err := idx.DescribeIndexStats(ctx)
 	if err != nil {
 		fmt.Println("Error:", err)
 		return
@@ -76,13 +78,14 @@ func main() {
 ```
 
 ## Support
+
 To get help using go-pinecone, reach out to support@pinecone.io.
 
 ## Development
 
 ### Prereqs
 
-1. A [current version of Go](https://go.dev/doc/install) (recommended 1.21+) 
+1. A [current version of Go](https://go.dev/doc/install) (recommended 1.21+)
 2. The [just](https://github.com/casey/just?tab=readme-ov-file#installation) command runner
 3. The [protobuf-compiler](https://grpc.io/docs/protoc-installation/)
 
@@ -96,6 +99,7 @@ and one serverless index. Copy the api key and index names to a `.env` file. See
 ### API Definitions submodule
 
 The API Definitions are in a private submodule. To checkout or update the submodules execute in the root of the project:
+
 ```shell
 git submodule update --init --recursive
 ```

--- a/pinecone/index_connection_test.go
+++ b/pinecone/index_connection_test.go
@@ -3,11 +3,12 @@ package pinecone
 import (
 	"context"
 	"fmt"
+	"os"
+	"testing"
+
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"os"
-	"testing"
 )
 
 type IndexConnectionTests struct {
@@ -124,14 +125,14 @@ func (ts *IndexConnectionTests) TestNewIndexConnectionNamespace() {
 
 func (ts *IndexConnectionTests) TestFetchVectors() {
 	ctx := context.Background()
-	res, err := ts.idxConn.FetchVectors(&ctx, ts.vectorIds)
+	res, err := ts.idxConn.FetchVectors(ctx, ts.vectorIds)
 	assert.NoError(ts.T(), err)
 	assert.NotNil(ts.T(), res)
 }
 
 func (ts *IndexConnectionTests) TestFetchVectorsSourceTag() {
 	ctx := context.Background()
-	res, err := ts.idxConnSourceTag.FetchVectors(&ctx, ts.vectorIds)
+	res, err := ts.idxConnSourceTag.FetchVectors(ctx, ts.vectorIds)
 	assert.NoError(ts.T(), err)
 	assert.NotNil(ts.T(), res)
 }
@@ -148,7 +149,7 @@ func (ts *IndexConnectionTests) TestQueryByVector() {
 	}
 
 	ctx := context.Background()
-	res, err := ts.idxConn.QueryByVectorValues(&ctx, req)
+	res, err := ts.idxConn.QueryByVectorValues(ctx, req)
 	assert.NoError(ts.T(), err)
 	assert.NotNil(ts.T(), res)
 }
@@ -165,7 +166,7 @@ func (ts *IndexConnectionTests) TestQueryByVectorSourceTag() {
 	}
 
 	ctx := context.Background()
-	res, err := ts.idxConnSourceTag.QueryByVectorValues(&ctx, req)
+	res, err := ts.idxConnSourceTag.QueryByVectorValues(ctx, req)
 	assert.NoError(ts.T(), err)
 	assert.NotNil(ts.T(), res)
 }
@@ -177,7 +178,7 @@ func (ts *IndexConnectionTests) TestQueryById() {
 	}
 
 	ctx := context.Background()
-	res, err := ts.idxConn.QueryByVectorId(&ctx, req)
+	res, err := ts.idxConn.QueryByVectorId(ctx, req)
 	assert.NoError(ts.T(), err)
 	assert.NotNil(ts.T(), res)
 }
@@ -189,14 +190,14 @@ func (ts *IndexConnectionTests) TestQueryByIdSourceTag() {
 	}
 
 	ctx := context.Background()
-	res, err := ts.idxConnSourceTag.QueryByVectorId(&ctx, req)
+	res, err := ts.idxConnSourceTag.QueryByVectorId(ctx, req)
 	assert.NoError(ts.T(), err)
 	assert.NotNil(ts.T(), res)
 }
 
 func (ts *IndexConnectionTests) TestDeleteVectorsById() {
 	ctx := context.Background()
-	err := ts.idxConn.DeleteVectorsById(&ctx, ts.vectorIds)
+	err := ts.idxConn.DeleteVectorsById(ctx, ts.vectorIds)
 	assert.NoError(ts.T(), err)
 
 	ts.loadData() //reload deleted data
@@ -204,7 +205,7 @@ func (ts *IndexConnectionTests) TestDeleteVectorsById() {
 
 func (ts *IndexConnectionTests) TestDeleteVectorsByFilter() {
 	ctx := context.Background()
-	err := ts.idxConn.DeleteVectorsByFilter(&ctx, &Filter{})
+	err := ts.idxConn.DeleteVectorsByFilter(ctx, &Filter{})
 	assert.NoError(ts.T(), err)
 
 	ts.loadData() //reload deleted data
@@ -212,7 +213,7 @@ func (ts *IndexConnectionTests) TestDeleteVectorsByFilter() {
 
 func (ts *IndexConnectionTests) TestDeleteAllVectorsInNamespace() {
 	ctx := context.Background()
-	err := ts.idxConn.DeleteAllVectorsInNamespace(&ctx)
+	err := ts.idxConn.DeleteAllVectorsInNamespace(ctx)
 	assert.NoError(ts.T(), err)
 
 	ts.loadData() //reload deleted data
@@ -220,14 +221,14 @@ func (ts *IndexConnectionTests) TestDeleteAllVectorsInNamespace() {
 
 func (ts *IndexConnectionTests) TestDescribeIndexStats() {
 	ctx := context.Background()
-	res, err := ts.idxConn.DescribeIndexStats(&ctx)
+	res, err := ts.idxConn.DescribeIndexStats(ctx)
 	assert.NoError(ts.T(), err)
 	assert.NotNil(ts.T(), res)
 }
 
 func (ts *IndexConnectionTests) TestDescribeIndexStatsFiltered() {
 	ctx := context.Background()
-	res, err := ts.idxConn.DescribeIndexStatsFiltered(&ctx, &Filter{})
+	res, err := ts.idxConn.DescribeIndexStatsFiltered(ctx, &Filter{})
 	assert.NoError(ts.T(), err)
 	assert.NotNil(ts.T(), res)
 }
@@ -237,7 +238,7 @@ func (ts *IndexConnectionTests) TestListVectors() {
 	req := &ListVectorsRequest{}
 
 	ctx := context.Background()
-	res, err := ts.idxConn.ListVectors(&ctx, req)
+	res, err := ts.idxConn.ListVectors(ctx, req)
 	assert.NoError(ts.T(), err)
 	assert.NotNil(ts.T(), res)
 }
@@ -263,7 +264,7 @@ func (ts *IndexConnectionTests) loadData() {
 	}
 
 	ctx := context.Background()
-	_, err := ts.idxConn.UpsertVectors(&ctx, vectors)
+	_, err := ts.idxConn.UpsertVectors(ctx, vectors)
 	assert.NoError(ts.T(), err)
 }
 
@@ -288,12 +289,12 @@ func (ts *IndexConnectionTests) loadDataSourceTag() {
 	}
 
 	ctx := context.Background()
-	_, err := ts.idxConnSourceTag.UpsertVectors(&ctx, vectors)
+	_, err := ts.idxConnSourceTag.UpsertVectors(ctx, vectors)
 	assert.NoError(ts.T(), err)
 }
 
 func (ts *IndexConnectionTests) truncateData() {
 	ctx := context.Background()
-	err := ts.idxConn.DeleteAllVectorsInNamespace(&ctx)
+	err := ts.idxConn.DeleteAllVectorsInNamespace(ctx)
 	assert.NoError(ts.T(), err)
 }


### PR DESCRIPTION
## Problem
From this issue: https://github.com/pinecone-io/go-pinecone/issues/19

We're receiving and passing `*context.Context` in `IndexConnection` methods. This differs from our `Client` methods and is non-standard for how most libraries handle `Context`.

## Solution
- Swap to receiving and passing `context.Context` by value rather than a pointer in `IndexConnection` methods, update README example to account.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
CI Testing, make sure you can `just test` locally or `go build`
