### PR TITLE
Add `json:""` marshaling annotations to response structs

### DIFF
--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -386,12 +386,13 @@ func toCollection(cm *control.CollectionModel) *Collection {
 	if cm == nil {
 		return nil
 	}
+
 	return &Collection{
 		Name:        cm.Name,
-		Size:        cm.Size,
+		Size:        derefOrDefault(cm.Size, 0),
 		Status:      CollectionStatus(cm.Status),
-		Dimension:   cm.Dimension,
-		VectorCount: cm.VectorCount,
+		Dimension:   derefOrDefault(cm.Dimension, 0),
+		VectorCount: derefOrDefault(cm.VectorCount, 0),
 		Environment: cm.Environment,
 	}
 }
@@ -411,6 +412,13 @@ func minOne(x int32) int32 {
 		return 1
 	}
 	return x
+}
+
+func derefOrDefault[T any](ptr *T, defaultValue T) T {
+	if ptr == nil {
+		return defaultValue
+	}
+	return *ptr
 }
 
 func buildClientOptions(in NewClientParams) ([]control.ClientOption, error) {

--- a/pinecone/index_connection.go
+++ b/pinecone/index_connection.go
@@ -14,18 +14,18 @@ import (
 )
 
 type IndexConnection struct {
-	Namespace  string
-	apiKey     string
+	Namespace          string
+	apiKey             string
 	additionalMetadata map[string]string
-	dataClient *data.VectorServiceClient
-	grpcConn   *grpc.ClientConn
+	dataClient         *data.VectorServiceClient
+	grpcConn           *grpc.ClientConn
 }
 
 type newIndexParameters struct {
-	apiKey string
-	host string
-	namespace string
-	sourceTag string
+	apiKey             string
+	host               string
+	namespace          string
+	sourceTag          string
 	additionalMetadata map[string]string
 }
 
@@ -94,6 +94,7 @@ func (idx *IndexConnection) FetchVectors(ctx context.Context, ids []string) (*Fe
 	for id, vector := range res.Vectors {
 		vectors[id] = toVector(vector)
 	}
+	fmt.Printf("VECTORS: %+v\n", vectors)
 
 	return &FetchVectorsResponse{
 		Vectors: vectors,
@@ -132,7 +133,7 @@ func (idx *IndexConnection) ListVectors(ctx context.Context, in *ListVectorsRequ
 
 	return &ListVectorsResponse{
 		VectorIds:           vectorIds,
-		Usage:               &Usage{ReadUnits: res.Usage.ReadUnits},
+		Usage:               &Usage{ReadUnits: derefOrDefault(res.Usage.ReadUnits, 0)},
 		NextPaginationToken: toPaginationToken(res.Pagination),
 	}, nil
 }
@@ -335,7 +336,7 @@ func toUsage(u *data.Usage) *Usage {
 		return nil
 	}
 	return &Usage{
-		ReadUnits: u.ReadUnits,
+		ReadUnits: derefOrDefault(u.ReadUnits, 0),
 	}
 }
 
@@ -372,7 +373,7 @@ func (idx *IndexConnection) akCtx(ctx context.Context) context.Context {
 	newMetadata := []string{}
 	newMetadata = append(newMetadata, "api-key", idx.apiKey)
 
-	for key, value := range idx.additionalMetadata{
+	for key, value := range idx.additionalMetadata {
 		newMetadata = append(newMetadata, key, value)
 	}
 

--- a/pinecone/index_connection.go
+++ b/pinecone/index_connection.go
@@ -75,8 +75,8 @@ func (idx *IndexConnection) UpsertVectors(ctx context.Context, in []*Vector) (ui
 }
 
 type FetchVectorsResponse struct {
-	Vectors map[string]*Vector
-	Usage   *Usage
+	Vectors map[string]*Vector `json:"vectors,omitempty"`
+	Usage   *Usage             `json:"usage,omitempty"`
 }
 
 func (idx *IndexConnection) FetchVectors(ctx context.Context, ids []string) (*FetchVectorsResponse, error) {
@@ -108,9 +108,9 @@ type ListVectorsRequest struct {
 }
 
 type ListVectorsResponse struct {
-	VectorIds           []*string
-	Usage               *Usage
-	NextPaginationToken *string
+	VectorIds           []*string `json:"vector_ids,omitempty"`
+	Usage               *Usage    `json:"usage,omitempty"`
+	NextPaginationToken *string   `json:"next_pagination_token,omitempty"`
 }
 
 func (idx *IndexConnection) ListVectors(ctx context.Context, in *ListVectorsRequest) (*ListVectorsResponse, error) {
@@ -147,8 +147,8 @@ type QueryByVectorValuesRequest struct {
 }
 
 type QueryVectorsResponse struct {
-	Matches []*ScoredVector
-	Usage   *Usage
+	Matches []*ScoredVector `json:"matches,omitempty"`
+	Usage   *Usage          `json:"usage,omitempty"`
 }
 
 func (idx *IndexConnection) QueryByVectorValues(ctx context.Context, in *QueryByVectorValuesRequest) (*QueryVectorsResponse, error) {
@@ -236,10 +236,10 @@ func (idx *IndexConnection) UpdateVector(ctx context.Context, in *UpdateVectorRe
 }
 
 type DescribeIndexStatsResponse struct {
-	Dimension        uint32
-	IndexFullness    float32
-	TotalVectorCount uint32
-	Namespaces       map[string]*NamespaceSummary
+	Dimension        uint32                       `json:"dimension"`
+	IndexFullness    float32                      `json:"index_fullness"`
+	TotalVectorCount uint32                       `json:"total_vector_count"`
+	Namespaces       map[string]*NamespaceSummary `json:"namespaces,omitempty"`
 }
 
 func (idx *IndexConnection) DescribeIndexStats(ctx context.Context) (*DescribeIndexStatsResponse, error) {

--- a/pinecone/index_connection_test.go
+++ b/pinecone/index_connection_test.go
@@ -289,13 +289,13 @@ func (ts *IndexConnectionTests) TestListVectors() {
 
 func TestMarshalingFetchVectorsResponse(t *testing.T) {
 	tests := []struct {
-		name     string
-		response FetchVectorsResponse
-		want     string
+		name  string
+		input FetchVectorsResponse
+		want  string
 	}{
 		{
 			name: "All fields present",
-			response: FetchVectorsResponse{
+			input: FetchVectorsResponse{
 				Vectors: map[string]*Vector{
 					"vec-1": {Id: "vec-1", Values: []float32{0.01, 0.01, 0.01}},
 					"vec-2": {Id: "vec-2", Values: []float32{0.02, 0.02, 0.02}},
@@ -305,13 +305,13 @@ func TestMarshalingFetchVectorsResponse(t *testing.T) {
 			want: `{"vectors":{"vec-1":{"id":"vec-1","values":[0.01,0.01,0.01]},"vec-2":{"id":"vec-2","values":[0.02,0.02,0.02]}},"usage":{"read_units":5}}`,
 		},
 		{
-			name:     "Fields omitted",
-			response: FetchVectorsResponse{},
-			want:     `{}`,
+			name:  "Fields omitted",
+			input: FetchVectorsResponse{},
+			want:  `{}`,
 		},
 		{
-			name: "Nil fields",
-			response: FetchVectorsResponse{
+			name: "Fields empty",
+			input: FetchVectorsResponse{
 				Vectors: nil,
 				Usage:   nil,
 			},
@@ -321,7 +321,7 @@ func TestMarshalingFetchVectorsResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			bytes, err := json.Marshal(tt.response)
+			bytes, err := json.Marshal(tt.input)
 			if err != nil {
 				t.Fatalf("Failed to marshal FetchVectorsResponse: %v", err)
 			}
@@ -338,13 +338,13 @@ func TestMarshalingListVectorsResponse(t *testing.T) {
 	vectorId2 := "vec-2"
 	paginationToken := "next-token"
 	tests := []struct {
-		name     string
-		response ListVectorsResponse
-		want     string
+		name  string
+		input ListVectorsResponse
+		want  string
 	}{
 		{
 			name: "All fields present",
-			response: ListVectorsResponse{
+			input: ListVectorsResponse{
 				VectorIds:           []*string{&vectorId1, &vectorId2},
 				Usage:               &Usage{ReadUnits: toUInt32(5)},
 				NextPaginationToken: &paginationToken,
@@ -352,13 +352,13 @@ func TestMarshalingListVectorsResponse(t *testing.T) {
 			want: `{"vector_ids":["vec-1","vec-2"],"usage":{"read_units":5},"next_pagination_token":"next-token"}`,
 		},
 		{
-			name:     "Fields omitted",
-			response: ListVectorsResponse{},
-			want:     `{}`,
+			name:  "Fields omitted",
+			input: ListVectorsResponse{},
+			want:  `{}`,
 		},
 		{
-			name: "Nil fields",
-			response: ListVectorsResponse{
+			name: "Fields empty",
+			input: ListVectorsResponse{
 				VectorIds:           nil,
 				Usage:               nil,
 				NextPaginationToken: nil,
@@ -369,7 +369,7 @@ func TestMarshalingListVectorsResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			bytes, err := json.Marshal(tt.response)
+			bytes, err := json.Marshal(tt.input)
 			if err != nil {
 				t.Fatalf("Failed to marshal ListVectorsResponse: %v", err)
 			}
@@ -383,13 +383,13 @@ func TestMarshalingListVectorsResponse(t *testing.T) {
 
 func TestMarshalingQueryVectorsResponse(t *testing.T) {
 	tests := []struct {
-		name     string
-		response QueryVectorsResponse
-		want     string
+		name  string
+		input QueryVectorsResponse
+		want  string
 	}{
 		{
 			name: "All fields present",
-			response: QueryVectorsResponse{
+			input: QueryVectorsResponse{
 				Matches: []*ScoredVector{
 					{Vector: &Vector{Id: "vec-1", Values: []float32{0.01, 0.01, 0.01}}, Score: 0.1},
 					{Vector: &Vector{Id: "vec-2", Values: []float32{0.02, 0.02, 0.02}}, Score: 0.2},
@@ -399,20 +399,20 @@ func TestMarshalingQueryVectorsResponse(t *testing.T) {
 			want: `{"matches":[{"vector":{"id":"vec-1","values":[0.01,0.01,0.01]},"score":0.1},{"vector":{"id":"vec-2","values":[0.02,0.02,0.02]},"score":0.2}],"usage":{"read_units":5}}`,
 		},
 		{
-			name:     "Fields omitted",
-			response: QueryVectorsResponse{},
-			want:     `{}`,
+			name:  "Fields omitted",
+			input: QueryVectorsResponse{},
+			want:  `{}`,
 		},
 		{
-			name:     "Nil fields",
-			response: QueryVectorsResponse{Matches: nil, Usage: nil},
-			want:     `{}`,
+			name:  "Fields empty",
+			input: QueryVectorsResponse{Matches: nil, Usage: nil},
+			want:  `{}`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			bytes, err := json.Marshal(tt.response)
+			bytes, err := json.Marshal(tt.input)
 			if err != nil {
 				t.Fatalf("Failed to marshal QueryVectorsResponse: %v", err)
 			}
@@ -426,13 +426,13 @@ func TestMarshalingQueryVectorsResponse(t *testing.T) {
 
 func TestMarshalingDescribeIndexStatsResponse(t *testing.T) {
 	tests := []struct {
-		name     string
-		response DescribeIndexStatsResponse
-		want     string
+		name  string
+		input DescribeIndexStatsResponse
+		want  string
 	}{
 		{
 			name: "All fields present",
-			response: DescribeIndexStatsResponse{
+			input: DescribeIndexStatsResponse{
 				Dimension:        3,
 				IndexFullness:    0.5,
 				TotalVectorCount: 100,
@@ -443,25 +443,25 @@ func TestMarshalingDescribeIndexStatsResponse(t *testing.T) {
 			want: `{"dimension":3,"index_fullness":0.5,"total_vector_count":100,"namespaces":{"namespace-1":{"vector_count":50}}}`,
 		},
 		{
-			name:     "Fields omitted",
-			response: DescribeIndexStatsResponse{},
-			want:     `{"dimension":0,"index_fullness":0,"total_vector_count":0}`,
+			name:  "Fields omitted",
+			input: DescribeIndexStatsResponse{},
+			want:  `{"dimension":0,"index_fullness":0,"total_vector_count":0}`,
 		},
 		{
-			name: "Nil namespaces",
-			response: DescribeIndexStatsResponse{
-				Dimension:        5,
+			name: "Fields empty",
+			input: DescribeIndexStatsResponse{
+				Dimension:        0,
 				IndexFullness:    0,
 				TotalVectorCount: 0,
 				Namespaces:       nil,
 			},
-			want: `{"dimension":5,"index_fullness":0,"total_vector_count":0}`,
+			want: `{"dimension":0,"index_fullness":0,"total_vector_count":0}`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			bytes, err := json.Marshal(tt.response)
+			bytes, err := json.Marshal(tt.input)
 			if err != nil {
 				t.Fatalf("Failed to marshal DescribeIndexStatsResponse: %v", err)
 			}

--- a/pinecone/models.go
+++ b/pinecone/models.go
@@ -52,10 +52,10 @@ type Index struct {
 
 type Collection struct {
 	Name        string           `json:"name"`
-	Size        *int64           `json:"size,omitempty"`
+	Size        int64            `json:"size"`
 	Status      CollectionStatus `json:"status"`
-	Dimension   *int32           `json:"dimension,omitempty"`
-	VectorCount *int32           `json:"vector_count,omitempty"`
+	Dimension   int32            `json:"dimension"`
+	VectorCount int32            `json:"vector_count"`
 	Environment string           `json:"environment"`
 }
 
@@ -108,7 +108,7 @@ type NamespaceSummary struct {
 }
 
 type Usage struct {
-	ReadUnits *uint32 `json:"read_units,omitempty"`
+	ReadUnits uint32 `json:"read_units"`
 }
 
 type Filter = structpb.Struct

--- a/pinecone/models.go
+++ b/pinecone/models.go
@@ -32,31 +32,31 @@ const (
 )
 
 type IndexStatus struct {
-	Ready bool
-	State IndexStatusState
+	Ready bool             `json:"ready"`
+	State IndexStatusState `json:"state"`
 }
 
 type IndexSpec struct {
-	Pod        *PodSpec
-	Serverless *ServerlessSpec
+	Pod        *PodSpec        `json:"pod,omitempty"`
+	Serverless *ServerlessSpec `json:"serverless,omitempty"`
 }
 
 type Index struct {
-	Name      string
-	Dimension int32
-	Host      string
-	Metric    IndexMetric
-	Spec      *IndexSpec
-	Status    *IndexStatus
+	Name      string       `json:"name"`
+	Dimension int32        `json:"dimension"`
+	Host      string       `json:"host"`
+	Metric    IndexMetric  `json:"metric"`
+	Spec      *IndexSpec   `json:"spec,omitempty"`
+	Status    *IndexStatus `json:"status,omitempty"`
 }
 
 type Collection struct {
-	Name        string
-	Size        *int64
-	Status      CollectionStatus
-	Dimension   *int32
-	VectorCount *int32
-	Environment string
+	Name        string           `json:"name"`
+	Size        *int64           `json:"size,omitempty"`
+	Status      CollectionStatus `json:"status"`
+	Dimension   *int32           `json:"dimension,omitempty"`
+	VectorCount *int32           `json:"vector_count,omitempty"`
+	Environment string           `json:"environment"`
 }
 
 type CollectionStatus string
@@ -68,47 +68,47 @@ const (
 )
 
 type PodSpecMetadataConfig struct {
-	Indexed *[]string
+	Indexed *[]string `json:"indexed,omitempty"`
 }
 
 type PodSpec struct {
-	Environment      string
-	PodType          string
-	PodCount         int32
-	Replicas         int32
-	ShardCount       int32
-	SourceCollection *string
-	MetadataConfig   *PodSpecMetadataConfig
+	Environment      string                 `json:"environment"`
+	PodType          string                 `json:"pod_type"`
+	PodCount         int32                  `json:"pod_count"`
+	Replicas         int32                  `json:"replicas"`
+	ShardCount       int32                  `json:"shard_count"`
+	SourceCollection *string                `json:"source_collection,omitempty"`
+	MetadataConfig   *PodSpecMetadataConfig `json:"metadata_config,omitempty"`
 }
 
 type ServerlessSpec struct {
-	Cloud  Cloud
-	Region string
+	Cloud  Cloud  `json:"cloud"`
+	Region string `json:"region"`
 }
 
 type Vector struct {
-	Id           string
-	Values       []float32
-	SparseValues *SparseValues
-	Metadata     *Metadata
+	Id           string        `json:"id"`
+	Values       []float32     `json:"values,omitempty"`
+	SparseValues *SparseValues `json:"sparse_values,omitempty"`
+	Metadata     *Metadata     `json:"metadata,omitempty"`
 }
 
 type ScoredVector struct {
-	Vector *Vector
-	Score  float32
+	Vector *Vector `json:"vector,omitempty"`
+	Score  float32 `json:"score"`
 }
 
 type SparseValues struct {
-	Indices []uint32
-	Values  []float32
+	Indices []uint32  `json:"indices,omitempty"`
+	Values  []float32 `json:"values,omitempty"`
 }
 
 type NamespaceSummary struct {
-	VectorCount uint32
+	VectorCount uint32 `json:"vector_count"`
 }
 
 type Usage struct {
-	ReadUnits *uint32
+	ReadUnits *uint32 `json:"read_units,omitempty"`
 }
 
 type Filter = structpb.Struct

--- a/pinecone/models_test.go
+++ b/pinecone/models_test.go
@@ -7,7 +7,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func TestMarshalingIndexStatus(t *testing.T) {
+func TestMarshalIndexStatus(t *testing.T) {
 	tests := []struct {
 		name  string
 		input IndexStatus
@@ -44,7 +44,7 @@ func TestMarshalingIndexStatus(t *testing.T) {
 	}
 }
 
-func TestMarshalingServerlessSpec(t *testing.T) {
+func TestMarshalServerlessSpec(t *testing.T) {
 	tests := []struct {
 		name  string
 		input ServerlessSpec
@@ -82,7 +82,7 @@ func TestMarshalingServerlessSpec(t *testing.T) {
 	}
 }
 
-func TestMarshalingPodSpec(t *testing.T) {
+func TestMarshalPodSpec(t *testing.T) {
 	sourceCollection := "source-collection"
 	tests := []struct {
 		name  string
@@ -138,7 +138,7 @@ func TestMarshalingPodSpec(t *testing.T) {
 	}
 }
 
-func TestMarshalingIndexSpec(t *testing.T) {
+func TestMarshalIndexSpec(t *testing.T) {
 	sourceCollection := "source-collection"
 	tests := []struct {
 		name  string
@@ -260,10 +260,10 @@ func TestMarshalCollection(t *testing.T) {
 			name: "All fields present",
 			input: Collection{
 				Name:        "test-collection",
-				Size:        toInt64(15328),
+				Size:        15328,
 				Status:      "Ready",
-				Dimension:   toInt32(132),
-				VectorCount: toInt32(15000),
+				Dimension:   132,
+				VectorCount: 15000,
 				Environment: "us-west-2",
 			},
 			want: `{"name":"test-collection","size":15328,"status":"Ready","dimension":132,"vector_count":15000,"environment":"us-west-2"}`,
@@ -271,19 +271,19 @@ func TestMarshalCollection(t *testing.T) {
 		{
 			name:  "Fields omitted",
 			input: Collection{},
-			want:  `{"name":"","status":"","environment":""}`,
+			want:  `{"name":"","size":0,"status":"","dimension":0,"vector_count":0,"environment":""}`,
 		},
 		{
 			name: "Fields empty",
 			input: Collection{
 				Name:        "",
-				Size:        nil,
+				Size:        0,
 				Status:      "",
-				Dimension:   nil,
-				VectorCount: nil,
+				Dimension:   0,
+				VectorCount: 0,
 				Environment: "",
 			},
-			want: `{"name":"","status":"","environment":""}`,
+			want: `{"name":"","size":0,"status":"","dimension":0,"vector_count":0,"environment":""}`,
 		},
 	}
 
@@ -526,17 +526,17 @@ func TestMarshalUsage(t *testing.T) {
 	}{
 		{
 			name:  "All fields present",
-			input: Usage{ReadUnits: toUInt32(100)},
+			input: Usage{ReadUnits: 100},
 			want:  `{"read_units":100}`,
 		},
 		{
 			name:  "Fields omitted",
 			input: Usage{},
-			want:  `{}`,
+			want:  `{"read_units":0}`,
 		},
 		{
 			name:  "Fields empty",
-			input: Usage{ReadUnits: toUInt32(0)},
+			input: Usage{ReadUnits: 0},
 			want:  `{"read_units":0}`,
 		},
 	}
@@ -554,12 +554,4 @@ func TestMarshalUsage(t *testing.T) {
 		})
 	}
 
-}
-
-func toInt64(i int64) *int64 {
-	return &i
-}
-
-func toInt32(i int32) *int32 {
-	return &i
 }

--- a/pinecone/models_test.go
+++ b/pinecone/models_test.go
@@ -1,0 +1,565 @@
+package pinecone
+
+import (
+	"encoding/json"
+	"testing"
+
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestMarshalingIndexStatus(t *testing.T) {
+	tests := []struct {
+		name  string
+		input IndexStatus
+		want  string
+	}{
+		{
+			name:  "All fields present",
+			input: IndexStatus{Ready: true, State: "Ready"},
+			want:  `{"ready":true,"state":"Ready"}`,
+		},
+		{
+			name:  "Fields omitted",
+			input: IndexStatus{},
+			want:  `{"ready":false,"state":""}`,
+		},
+		{
+			name:  "Fields empty",
+			input: IndexStatus{Ready: false, State: ""},
+			want:  `{"ready":false,"state":""}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(c *testing.T) {
+			got, err := json.Marshal(tt.input)
+			if err != nil {
+				c.Errorf("Failed to marshal IndexStatus: %v", err)
+				return
+			}
+			if string(got) != tt.want {
+				c.Errorf("Marshal IndexStatus got = %s, want = %s", string(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestMarshalingServerlessSpec(t *testing.T) {
+	tests := []struct {
+		name  string
+		input ServerlessSpec
+		want  string
+	}{
+		{
+			name:  "All fields present",
+			input: ServerlessSpec{Cloud: "aws", Region: "us-west-"},
+			want:  `{"cloud":"aws","region":"us-west-"}`,
+		},
+		{
+			name:  "Fields omitted",
+			input: ServerlessSpec{},
+			want:  `{"cloud":"","region":""}`,
+		},
+		{
+			name:  "Fields empty",
+			input: ServerlessSpec{Cloud: "", Region: ""},
+			want:  `{"cloud":"","region":""}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(c *testing.T) {
+			got, err := json.Marshal(tt.input)
+			if err != nil {
+				c.Errorf("Failed to marshal ServerlessSpec: %v", err)
+				return
+			}
+			if string(got) != tt.want {
+				c.Errorf("Marshal ServerlessSpec got = %s, want = %s", string(got), tt.want)
+			}
+
+		})
+	}
+}
+
+func TestMarshalingPodSpec(t *testing.T) {
+	sourceCollection := "source-collection"
+	tests := []struct {
+		name  string
+		input PodSpec
+		want  string
+	}{
+		{
+			name: "All fields present",
+			input: PodSpec{
+				Environment:      "us-west2-gcp",
+				PodType:          "p1.x1",
+				PodCount:         1,
+				Replicas:         1,
+				ShardCount:       1,
+				SourceCollection: &sourceCollection,
+				MetadataConfig: &PodSpecMetadataConfig{
+					Indexed: &[]string{"genre"},
+				},
+			},
+			want: `{"environment":"us-west2-gcp","pod_type":"p1.x1","pod_count":1,"replicas":1,"shard_count":1,"source_collection":"source-collection","metadata_config":{"indexed":["genre"]}}`,
+		},
+		{
+			name:  "Fields omitted",
+			input: PodSpec{},
+			want:  `{"environment":"","pod_type":"","pod_count":0,"replicas":0,"shard_count":0}`,
+		},
+		{
+			name: "Fields empty",
+			input: PodSpec{
+				Environment:      "",
+				PodType:          "",
+				PodCount:         0,
+				Replicas:         0,
+				ShardCount:       0,
+				SourceCollection: nil,
+				MetadataConfig:   nil,
+			},
+			want: `{"environment":"","pod_type":"","pod_count":0,"replicas":0,"shard_count":0}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(c *testing.T) {
+			got, err := json.Marshal(tt.input)
+			if err != nil {
+				c.Errorf("Failed to marshal PodSpec: %v", err)
+				return
+			}
+			if string(got) != tt.want {
+				c.Errorf("Marshal PodSpec got = %s, want = %s", string(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestMarshalingIndexSpec(t *testing.T) {
+	sourceCollection := "source-collection"
+	tests := []struct {
+		name  string
+		input IndexSpec
+		want  string
+	}{
+		{
+			name: "Pod spec",
+			input: IndexSpec{Pod: &PodSpec{
+				Environment:      "us-west2-gcp",
+				PodType:          "p1.x1",
+				PodCount:         1,
+				Replicas:         1,
+				ShardCount:       1,
+				SourceCollection: &sourceCollection,
+				MetadataConfig: &PodSpecMetadataConfig{
+					Indexed: &[]string{"genre"},
+				},
+			}},
+			want: `{"pod":{"environment":"us-west2-gcp","pod_type":"p1.x1","pod_count":1,"replicas":1,"shard_count":1,"source_collection":"source-collection","metadata_config":{"indexed":["genre"]}}}`,
+		},
+		{
+			name:  "Serverless spec",
+			input: IndexSpec{Serverless: &ServerlessSpec{Cloud: "aws", Region: "us-west-"}},
+			want:  `{"serverless":{"cloud":"aws","region":"us-west-"}}`,
+		},
+		{
+			name:  "Fields omitted",
+			input: IndexSpec{},
+			want:  `{}`,
+		},
+		{
+			name:  "Fields empty",
+			input: IndexSpec{Pod: nil, Serverless: nil},
+			want:  `{}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(c *testing.T) {
+			got, err := json.Marshal(tt.input)
+			if err != nil {
+				c.Errorf("Failed to marshal IndexSpec: %v", err)
+				return
+			}
+			if string(got) != tt.want {
+				c.Errorf("Marshal IndexSpec got = %s, want = %s", string(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestMarshalIndex(t *testing.T) {
+	tests := []struct {
+		name  string
+		input Index
+		want  string
+	}{
+		{
+			name: "All fields present",
+			input: Index{
+				Name:      "test-index",
+				Dimension: 128,
+				Host:      "index-host-1.io",
+				Metric:    "cosine",
+				Spec: &IndexSpec{
+					Serverless: &ServerlessSpec{
+						Cloud:  "aws",
+						Region: "us-west-2",
+					},
+				},
+				Status: &IndexStatus{
+					Ready: true,
+					State: "Ready",
+				},
+			},
+			want: `{"name":"test-index","dimension":128,"host":"index-host-1.io","metric":"cosine","spec":{"serverless":{"cloud":"aws","region":"us-west-2"}},"status":{"ready":true,"state":"Ready"}}`,
+		},
+		{
+			name:  "Fields omitted",
+			input: Index{},
+			want:  `{"name":"","dimension":0,"host":"","metric":""}`,
+		},
+		{
+			name: "Fields empty",
+			input: Index{
+				Name:      "",
+				Dimension: 0,
+				Host:      "",
+				Metric:    "",
+				Spec:      nil,
+				Status:    nil,
+			},
+			want: `{"name":"","dimension":0,"host":"","metric":""}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(c *testing.T) {
+			got, err := json.Marshal(tt.input)
+			if err != nil {
+				c.Errorf("Failed to marshal Index: %v", err)
+				return
+			}
+			if string(got) != tt.want {
+				c.Errorf("Marshal Index got = %s, want = %s", string(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestMarshalCollection(t *testing.T) {
+	tests := []struct {
+		name  string
+		input Collection
+		want  string
+	}{
+		{
+			name: "All fields present",
+			input: Collection{
+				Name:        "test-collection",
+				Size:        toInt64(15328),
+				Status:      "Ready",
+				Dimension:   toInt32(132),
+				VectorCount: toInt32(15000),
+				Environment: "us-west-2",
+			},
+			want: `{"name":"test-collection","size":15328,"status":"Ready","dimension":132,"vector_count":15000,"environment":"us-west-2"}`,
+		},
+		{
+			name:  "Fields omitted",
+			input: Collection{},
+			want:  `{"name":"","status":"","environment":""}`,
+		},
+		{
+			name: "Fields empty",
+			input: Collection{
+				Name:        "",
+				Size:        nil,
+				Status:      "",
+				Dimension:   nil,
+				VectorCount: nil,
+				Environment: "",
+			},
+			want: `{"name":"","status":"","environment":""}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(c *testing.T) {
+			got, err := json.Marshal(tt.input)
+			if err != nil {
+				c.Errorf("Failed to marshal Collection: %v", err)
+				return
+			}
+			if string(got) != tt.want {
+				c.Errorf("Marshal Collection got = %s, want = %s", string(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestMarshalPodSpecMetadataConfig(t *testing.T) {
+	tests := []struct {
+		name  string
+		input PodSpecMetadataConfig
+		want  string
+	}{
+		{
+			name:  "All fields present",
+			input: PodSpecMetadataConfig{Indexed: &[]string{"genre", "artist"}},
+			want:  `{"indexed":["genre","artist"]}`,
+		},
+		{
+			name:  "Fields omitted",
+			input: PodSpecMetadataConfig{},
+			want:  `{}`,
+		},
+		{
+			name:  "Fields empty",
+			input: PodSpecMetadataConfig{Indexed: nil},
+			want:  `{}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(c *testing.T) {
+			got, err := json.Marshal(tt.input)
+			if err != nil {
+				c.Errorf("Failed to marshal PodSpecMetadataConfig: %v", err)
+				return
+			}
+			if string(got) != tt.want {
+				c.Errorf("Marshal PodSpecMetadataConfig got = %s, want = %s", string(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestMarshalVector(t *testing.T) {
+	metadata, err := structpb.NewStruct(map[string]interface{}{"genre": "rock"})
+	if err != nil {
+		t.Fatalf("Failed to create metadata: %v", err)
+	}
+
+	tests := []struct {
+		name  string
+		input Vector
+		want  string
+	}{
+		{
+			name: "All fields present",
+			input: Vector{
+				Id:       "vector-1",
+				Values:   []float32{0.1, 0.2, 0.3},
+				Metadata: metadata,
+				SparseValues: &SparseValues{
+					Indices: []uint32{1, 2, 3},
+					Values:  []float32{0.1, 0.2, 0.3},
+				},
+			},
+			want: `{"id":"vector-1","values":[0.1,0.2,0.3],"sparse_values":{"indices":[1,2,3],"values":[0.1,0.2,0.3]},"metadata":{"genre":"rock"}}`,
+		},
+		{
+			name:  "Fields omitted",
+			input: Vector{},
+			want:  `{"id":""}`,
+		},
+		{
+			name:  "Fields empty",
+			input: Vector{Id: "", Values: nil, SparseValues: nil, Metadata: nil},
+			want:  `{"id":""}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(c *testing.T) {
+			got, err := json.Marshal(tt.input)
+			if err != nil {
+				c.Errorf("Failed to marshal Vector: %v", err)
+				return
+			}
+			if string(got) != tt.want {
+				c.Errorf("Marshal Vector got = %s, want = %s", string(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestMarshalScoredVector(t *testing.T) {
+	metadata, err := structpb.NewStruct(map[string]interface{}{"genre": "rock"})
+	if err != nil {
+		t.Fatalf("Failed to create metadata: %v", err)
+	}
+
+	tests := []struct {
+		name  string
+		input ScoredVector
+		want  string
+	}{
+		{
+			name: "All fields present",
+			input: ScoredVector{
+				Vector: &Vector{
+					Id:       "vector-1",
+					Values:   []float32{0.1, 0.2, 0.3},
+					Metadata: metadata,
+					SparseValues: &SparseValues{
+						Indices: []uint32{1, 2, 3},
+						Values:  []float32{0.1, 0.2, 0.3},
+					},
+				},
+				Score: 0.9,
+			},
+			want: `{"vector":{"id":"vector-1","values":[0.1,0.2,0.3],"sparse_values":{"indices":[1,2,3],"values":[0.1,0.2,0.3]},"metadata":{"genre":"rock"}},"score":0.9}`,
+		},
+		{
+			name:  "Fields omitted",
+			input: ScoredVector{},
+			want:  `{"score":0}`,
+		},
+		{
+			name:  "Fields empty",
+			input: ScoredVector{Vector: nil, Score: 0},
+			want:  `{"score":0}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(c *testing.T) {
+			got, err := json.Marshal(tt.input)
+			if err != nil {
+				c.Errorf("Failed to marshal ScoredVector: %v", err)
+				return
+			}
+			if string(got) != tt.want {
+				c.Errorf("Marshal ScoredVector got = %s, want = %s", string(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestMarshalSparseValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		input SparseValues
+		want  string
+	}{
+		{
+			name: "All fields present",
+			input: SparseValues{
+				Indices: []uint32{1, 2, 3},
+				Values:  []float32{0.1, 0.2, 0.3},
+			},
+			want: `{"indices":[1,2,3],"values":[0.1,0.2,0.3]}`,
+		},
+		{
+			name:  "Fields omitted",
+			input: SparseValues{},
+			want:  `{}`,
+		},
+		{
+			name:  "Fields empty",
+			input: SparseValues{Indices: nil, Values: nil},
+			want:  `{}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(c *testing.T) {
+			got, err := json.Marshal(tt.input)
+			if err != nil {
+				c.Errorf("Failed to marshal SparseValues: %v", err)
+				return
+			}
+			if string(got) != tt.want {
+				c.Errorf("Marshal SparseValues got = %s, want = %s", string(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestMarshalNamespaceSummary(t *testing.T) {
+	tests := []struct {
+		name  string
+		input NamespaceSummary
+		want  string
+	}{
+		{
+			name:  "All fields present",
+			input: NamespaceSummary{VectorCount: 15000},
+			want:  `{"vector_count":15000}`,
+		},
+		{
+			name:  "Fields omitted",
+			input: NamespaceSummary{},
+			want:  `{"vector_count":0}`,
+		},
+		{
+			name:  "Fields empty",
+			input: NamespaceSummary{VectorCount: 0},
+			want:  `{"vector_count":0}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(c *testing.T) {
+			got, err := json.Marshal(tt.input)
+			if err != nil {
+				c.Errorf("Failed to marshal NamespaceSummary: %v", err)
+				return
+			}
+			if string(got) != tt.want {
+				c.Errorf("Marshal NamespaceSummary got = %s, want = %s", string(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestMarshalUsage(t *testing.T) {
+	tests := []struct {
+		name  string
+		input Usage
+		want  string
+	}{
+		{
+			name:  "All fields present",
+			input: Usage{ReadUnits: toUInt32(100)},
+			want:  `{"read_units":100}`,
+		},
+		{
+			name:  "Fields omitted",
+			input: Usage{},
+			want:  `{}`,
+		},
+		{
+			name:  "Fields empty",
+			input: Usage{ReadUnits: toUInt32(0)},
+			want:  `{"read_units":0}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(c *testing.T) {
+			got, err := json.Marshal(tt.input)
+			if err != nil {
+				c.Errorf("Failed to marshal Usage: %v", err)
+				return
+			}
+			if string(got) != tt.want {
+				c.Errorf("Marshal Usage got = %s, want = %s", string(got), tt.want)
+			}
+		})
+	}
+
+}
+
+func toInt64(i int64) *int64 {
+	return &i
+}
+
+func toInt32(i int32) *int32 {
+	return &i
+}


### PR DESCRIPTION
## Problem
There's been some UX feedback regarding marshaling of some of our response structs.

Primarily, we're not using `json:"key_name"` annotation for our struct fields so they default to capitalized keys in JSON output when marshaled. IE: `{ "Usage": { "ReadUnits": 5 }}`. We'd like these lower case and matched with our API spec.

There are also instances where we're returning pointers for certain `*int32` fields which can be irritating to consumers needing to dereference and nil-check. In certain cases we can default any nil pointer values to 0 before returning things.

There's no testing for the marshaling on any of our custom structs.

## Solution
I may have gone a bit overboard with the testing here. The bulk of this is tests and the tests are all very similar, definitely open to opinions on removing if people find them unnecessary, but changing up how the JSON is produced is pretty easy and it's an important point of integration in my mind, so maybe worth testing for.

I also wasn't clear if adding these annotations to our request structs made sense either, so I left those out for now. Overall I'm still working on getting a better understanding of Go syntax and expectations.

- Add JSON marshaling annotations to the response structs in `models.go` and `index_connection.go`.
- Update `Collection` and `Usage` structs to default integer values rather than using pointers.
- Add new `models_test.go` file to run through some validation on struct marshaling, also add unit tests to `index_connection_test.go`.

Originally I thought `omitempty` for some of these pointers may be helpful from a consumer standpoint, but I'm actually not sure the more I've thought about it. Does it make sense to omit more or less things? Other feedback here would be much appreciated.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
Unit tests to explicitly stress marshaling the structs via `json.Marshal()`.
