### PR TITLE
Add error handling to REST operations in `Client`

### DIFF
--- a/pinecone/errors.go
+++ b/pinecone/errors.go
@@ -1,0 +1,12 @@
+package pinecone
+
+import "fmt"
+
+type PineconeError struct {
+	Code int
+	Msg  error
+}
+
+func (pe *PineconeError) Error() string {
+	return fmt.Sprintf("%+v", pe.Msg)
+}


### PR DESCRIPTION
## Problem
We're currently not including the code with error responses from `Client`. Additionally, we don't seem to be gracefully handling possible `ErrorResponse` bodies alongside more generic JSON and string responses.

There's an issue tracking this problem here: https://github.com/pinecone-io/go-pinecone/issues/17

Ultimately, we want to surface more useful information to users through errors.

## Solution
This PR focuses on improving the errors that are returned from REST operations in `Client` methods.

- Decode the `http.Response` `Body` once, and then use the `[]byte` value to decode into either errors or response structs.
  - Update `decodeIndex` and `decodeCollection` to take in `[]byte` rather than `io.ReadCloser`. Most of this was done to avoid reading the body to EOF. 
- Add `errorResponseMap` which is used to build up the error information.
- Add `decodeErrorResponse`, `handleErrorResponseBody`, and `formatError` to deal with parsing error payloads and turning them into more readable output.
- Add `PineconeError` which extends the `error` interface and wraps errors in a struct consumers are able to use if they'd like via reflection.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
Unit tests and a few integration tests have been added to validate `handleErrorResponseBody` and that we're returning `PineconeError` from failed network operations.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207208972408344