### PR TITLE
Bump `getPackageVersion()` to v0.5.0, allow `:` in source tag normalization

### DIFF
--- a/internal/useragent/useragent.go
+++ b/internal/useragent/useragent.go
@@ -36,7 +36,7 @@ func buildSourceTagField(userAgent string) string {
 	// Limit charset to [a-z0-9_ ]
 	var strBldr strings.Builder
 	for _, char := range userAgent {
-		if (char >= 'a' && char <= 'z') || (char >= '0' && char <= '9') || char == '_' || char == ' ' {
+		if (char >= 'a' && char <= 'z') || (char >= '0' && char <= '9') || char == '_' || char == ' ' || char == ':' {
 			strBldr.WriteRune(char)
 		}
 	}

--- a/internal/useragent/useragent.go
+++ b/internal/useragent/useragent.go
@@ -7,7 +7,7 @@ import (
 
 func getPackageVersion() string {
 	// update at release time
-	return "v0.4.2-pre"
+	return "v0.5.0"
 }
 
 func BuildUserAgent(sourceTag string) string {

--- a/internal/useragent/useragent_test.go
+++ b/internal/useragent/useragent_test.go
@@ -78,4 +78,9 @@ func TestBuildUserAgentSourceTagIsNormalized(t *testing.T) {
 	if !strings.Contains(result, "source_tag=my_source_tag") {
 		t.Errorf("BuildUserAgent(\"%s\"): expected user-agent to contain 'source_tag=my_source_tag_123', but got %s", sourceTag, result)
 	}
+
+	sourceTag = "   My Source Tag  123 : !! "
+	if !strings.Contains(result, "source_tag=my_source_tag:") {
+		t.Errorf("BuildUserAgent(\"%s\"): expected user-agent to contain 'source_tag=my_source_tag_123', but got %s", sourceTag, result)
+	}
 }


### PR DESCRIPTION
## Problem
We want to release a new patch version of the Go SDK, and we need to bump the version for the user-agent. We also want to allow source tag normalization to accept `:`.

## Solution

- Update `getPackageVersion` to `v0.5.0`.
- Update `buildSourceTagField()` to allow `:` as a character.

The new patch includes:
- Fixing context.Context being a pointer instead of value in our networking functions.
- Adding optional configurations for headers / metadata in REST / gRPC operations.
- Fixing issues with json marshaling in our structs.
- Adding consistent error handling to control plane operations. 

## Type of Change

- [] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [] None of the above: chore for version bumping)

## Test Plan
user-agent values can be validated through DataDog, unit test to cover the addition to source tag normalization
