### PR TITLE
Pin oapi-codegen version to latest that uses the /deepmap path

### DIFF
--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@ test:
 bootstrap:
     go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
     go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
-    go install github.com/deepmap/oapi-codegen/v2/cmd/oapi-codegen@latest
+    go install github.com/deepmap/oapi-codegen/v2/cmd/oapi-codegen@v2.2.0
     go install golang.org/x/tools/cmd/godoc@latest
 gen:
   protoc --experimental_allow_proto3_optional --proto_path=apis/proto --go_opt=module="github.com/pinecone-io/go-pinecone" --go-grpc_opt=module="github.com/pinecone-io/go-pinecone" --go_out=. --go-grpc_out=. apis/proto/pinecone/data/v1/vector_service.proto


### PR DESCRIPTION
## Problem

`oapi-codegen` [recently changed its location](https://github.com/oapi-codegen/oapi-codegen?tab=readme-ov-file#action-required-the-repository-for-this-project-has-changed). In order to keep code changes in our `go` repo as minimal as possible, we need to change our `justfile` so that it goes from grabbing the `@latest` release of `oapi-codegen` to grabbing the latest version that _still uses the old path_, which is version `2.2.0`. 

## Solution

Pin version of `oapi-codegen` at `2.2.0`. 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [x] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

CI passes.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207603952846961