### PR TITLE
Add docstrings for client.go

### DIFF
--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -19,7 +19,7 @@ import (
 
 // Client holds the parameters for connecting to the Pinecone service. It is returned by the NewClient and NewClientBase
 // functions. To use Client, first build the parameters of the request using NewClientParams (or NewClientBaseParams).
-// Then, pass those parameters into the NewClient (or NewBaseClient) function to create a new Client object.
+// Then, pass those parameters into the NewClient (or NewClientBase) function to create a new Client object.
 // Once instantiated, you can use Client to execute control plane API requests (e.g. create an index, list indexes,
 // etc.). Read more about different control plane API routes at [pinecone.io/docs].
 //
@@ -27,8 +27,8 @@ import (
 //
 // Fields:
 //   - headers: An optional map of additional HTTP headers to include in each API request to the control plane,
-//    Provided through NewClientParams.Headers or NewClientBaseParams.Headers.
-//   - restClient: The underlying REST client (managed internally) used to communicate with the Pinecone control plane API.
+//   provided through NewClientParams.Headers or NewClientBaseParams.Headers.
+//   - restClient: The underlying REST client used to communicate with the Pinecone control plane API.
 //   - sourceTag: An optional string used to help Pinecone attribute API activity, provided through NewClientParams.SourceTag
 //  or NewClientBaseParams.SourceTag.
 //
@@ -48,12 +48,16 @@ import (
 //  idx, err := pc.DescribeIndex(ctx, "your-index-name")
 //  if err != nil {
 //	  log.Fatalf("Failed to describe index \"%s\". Error:%s", idx.Name, err)
-//  }
+//  } else {
+//	  fmt.Printf("Successfully found the \"%s\" index!\n", idx.Name)
+//	}
 //
 // 	idxConnection, err := pc.Index(idx.Host)
 //	if err != nil {
 //	  log.Fatalf("Failed to create IndexConnection for Host: %v. Error: %v", idx.Host, err)
-//	}
+//	} else {
+//	  log.Println("IndexConnection created successfully!")
+//  }
 //
 // [pinecone.io/docs]: https://docs.pinecone.io/reference/api/control-plane/list_indexes
 type Client struct {
@@ -62,7 +66,7 @@ type Client struct {
 	sourceTag  string
 }
 
-// NewClientParams holds the parameters for creating a new Client while authenticating with an API key.
+// NewClientParams holds the parameters for creating a new Client instance while authenticating via an API key.
 //
 // Fields:
 //   - ApiKey: The API key used to authenticate with the Pinecone control plane API.
@@ -81,11 +85,11 @@ type NewClientParams struct {
 	SourceTag  string            // optional
 }
 
-// NewClientBaseParams holds the parameters for creating a new Client while passing custom authentication headers.
+// NewClientBaseParams holds the parameters for creating a new Client instance while passing custom authentication
+// headers.
 //
 // Fields:
-//   - Headers: An optional map of additional HTTP headers to include in each API request to the control plane,
-//   provided through NewClientParams.Headers or NewClientBaseParams.Headers.
+//   - Headers: An optional map of additional HTTP headers to include in each API request to the control plane.
 //   "Authorization" and "X-Project-Id" headers are required if authenticating using a JWT.
 //   - Host: The host URL of the Pinecone control plane API. If not provided,
 //   the default value is "https://api.pinecone.io".
@@ -104,15 +108,12 @@ type NewClientBaseParams struct {
 // This function sets up the control plane client with the necessary configuration for authentication and communication.
 //
 // Parameters:
-//   - in: A NewClientParams object that includes the API key used to authenticate with the Pinecone control plane
-//  API. See NewClientParams for more information.
+//   - in: A NewClientParams object. See NewClientParams for more information.
 //
 // Note: It is important to handle the error returned by this function to ensure that the
 // control plane client has been created successfully before attempting to make API calls.
 //
-// Returns a pointer to an initialized Client instance on success or an error describing the issue encountered.
-// Possible errors include issues with setting up the API key provider or problems initializing the
-// underlying REST client.
+// Returns a pointer to an initialized Client instance or an error.
 //
 // Example:
 //  ctx := context.Background()
@@ -125,7 +126,9 @@ type NewClientBaseParams struct {
 //  pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//  }
+//  } else {
+//	  fmt.Println("Successfully created a new Client object!")
+//	}
 func NewClient(in NewClientParams) (*Client, error) {
 	osApiKey := os.Getenv("PINECONE_API_KEY")
 	hasApiKey := (valueOrFallback(in.ApiKey, osApiKey) != "")
@@ -157,9 +160,7 @@ func NewClient(in NewClientParams) (*Client, error) {
 // Note: It is important to handle the error returned by this function to ensure that the
 // control plane client has been created successfully before attempting to make API calls.
 //
-// Returns a pointer to an initialized Client instance on success or an error describing the issue encountered.
-// Possible errors include issues with setting up the headers or problems initializing the
-// underlying REST client.
+// Returns a pointer to an initialized Client instance or an error.
 //
 // Example:
 //  ctx := context.Background()
@@ -175,7 +176,9 @@ func NewClient(in NewClientParams) (*Client, error) {
 //  pc, err := pinecone.NewClientBase(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//  }
+//  } else {
+//	  fmt.Println("Successfully created a new Client object!")
+//	}
 func NewClientBase(in NewClientBaseParams) (*Client, error) {
 	clientOptions := buildClientBaseOptions(in)
 	var err error
@@ -215,17 +218,23 @@ func NewClientBase(in NewClientBaseParams) (*Client, error) {
 //  pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
+//  } else {
+//	  fmt.Println("Successfully created a new Client object!")
 //  }
 //
 //  idx, err := pc.DescribeIndex(ctx, "your-index-name")
 //  if err != nil {
-//	  fmt.Printf("Failed to describe index \"%s\". Error:%s", idx.Name, err)
-//  }
+//	  log.Fatalf("Failed to describe index \"%s\". Error:%s", idx.Name, err)
+//  } else {
+//	  fmt.Printf("Successfully found the \"%s\" index!\n", idx.Name)
+//	}
 //
 // 	idxConnection, err := pc.Index(idx.Host)
 //	if err != nil {
-//	  fmt.Println("Failed to create IndexConnection for Host: %v. Error: %v", idx.Host, err)
-//	}
+//	  log.Fatalf("Failed to create IndexConnection for Host: %v. Error: %v", idx.Host, err)
+//	} else {
+//	  log.Println("IndexConnection created successfully!")
+//  }
  func (c *Client) Index(host string) (*IndexConnection, error) {
 	return c.IndexWithAdditionalMetadata(host, "", nil)
 }
@@ -236,7 +245,7 @@ func NewClientBase(in NewClientBaseParams) (*Client, error) {
 //   - host: The host URL of a Pinecone index.
 //   - namespace: The namespace where index operations will be performed.
 //
-// Returns a pointer to an IndexConnection or an error.
+// Returns a pointer to an IndexConnection instance or an error.
 //
 // Example:
 //  ctx := context.Background()
@@ -249,17 +258,23 @@ func NewClientBase(in NewClientBaseParams) (*Client, error) {
 //  pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//  }
+//  } else {
+//	  fmt.Println("Successfully created a new Client object!")
+//	}
 //
 //  idx, err := pc.DescribeIndex(ctx, "your-index-name")
 //  if err != nil {
 //	  log.Fatalf("Failed to describe index \"%s\". Error:%s", idx.Name, err)
-//  }
+//  } else {
+//	  fmt.Printf("Successfully found the \"%s\" index!\n", idx.Name)
+//	}
 //
 // 	idxConnection, err := pc.IndexWithNamespace(idx.Host, "custom-namespace")
 //	if err != nil {
 //	  log.Fatalf("Failed to create IndexConnection for Host: %v. Error: %v", idx.Host, err)
-//	}
+//	} else {
+//	  log.Println("IndexConnection created successfully!")
+//  }
 func (c *Client) IndexWithNamespace(host string, namespace string) (*IndexConnection, error) {
 	return c.IndexWithAdditionalMetadata(host, namespace, nil)
 }
@@ -272,7 +287,7 @@ func (c *Client) IndexWithNamespace(host string, namespace string) (*IndexConnec
 //   - namespace: The namespace where index operations will be performed.
 //   - additionalMetadata: Additional metadata to be sent with each RPC request.
 //
-// Returns a pointer to an IndexConnection or error.
+// Returns a pointer to an IndexConnection instance or error.
 //
 // Example:
 //  ctx := context.Background()
@@ -285,12 +300,16 @@ func (c *Client) IndexWithNamespace(host string, namespace string) (*IndexConnec
 //  pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//  }
+//  } else {
+//	  fmt.Println("Successfully created a new Client object!")
+//	}
 //
 //  idx, err := pc.DescribeIndex(ctx, "your-index-name")
 //  if err != nil {
 //	  log.Fatalf("Failed to describe index \"%s\". Error:%s", idx.Name, err)
-//  }
+//  } else {
+//	  fmt.Printf("Successfully found the \"%s\" index!\n", idx.Name)
+//	}
 //
 //  indexMetadata := map[string]string{
 //	  "indexMetadata": "custom-index-level-metadata",
@@ -341,11 +360,13 @@ func (c *Client) IndexWithAdditionalMetadata(host string, namespace string, addi
 //  pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//  }
+//  } else {
+//	  fmt.Println("Successfully created a new Client object!")
+//	}
 //
 //  idxs, err := pc.ListIndexes(ctx)
 //	if err != nil {
-//	  log.Fatalf("Failed to list indexes:", err)
+//	  log.Fatalf("Failed to list indexes: %v", err)
 //  } else {
 //	  fmt.Println("Your project has the following indexes:")
 //	  for _, idx := range idxs {
@@ -405,7 +426,9 @@ func (c *Client) ListIndexes(ctx context.Context) ([]*Index, error) {
 //  pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//  }
+//  } else {
+//	  fmt.Println("Successfully created a new Client object!")
+//	}
 //
 //  idx, err := pc.CreatePodIndex(ctx, &pinecone.CreatePodIndexRequest{
 //    Name:        "my-pod-index",
@@ -417,7 +440,7 @@ func (c *Client) ListIndexes(ctx context.Context) ([]*Index, error) {
 //  )
 //
 //  if err != nil {
-//	  log.Fatalf("Failed to create pod index:", err)
+//	  log.Fatalf("Failed to create pod index: %v", err)
 //	} else {
 //	  fmt.Printf("Successfully created pod index: %s", idx.Name)
 //  }
@@ -480,7 +503,9 @@ func (req CreatePodIndexRequest) TotalCount() *int {
 //  pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//  }
+//  } else {
+//	  fmt.Println("Successfully created a new Client object!")
+//	}
 //
 //  idx, err := pc.CreatePodIndex(ctx, &pinecone.CreatePodIndexRequest{
 //    Name:        "my-pod-index",
@@ -569,7 +594,9 @@ func (c *Client) CreatePodIndex(ctx context.Context, in *CreatePodIndexRequest) 
 //  pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//  }
+//  } else {
+//	  fmt.Println("Successfully created a new Client object!")
+//	}
 //
 //  idx, err := pc.CreateServerlessIndex(ctx, &pinecone.CreateServerlessIndexRequest{
 //    Name:    "my-serverless-index",
@@ -584,7 +611,7 @@ func (c *Client) CreatePodIndex(ctx context.Context, in *CreatePodIndexRequest) 
 //    log.Fatalf("Failed to create serverless index: %s", idx.Name)
 //  } else {
 //    fmt.Printf("Successfully created serverless index: %s", idx.Name)
-// }
+//  }
 //
 // [Serverless]: https://docs.pinecone.io/guides/indexes/understanding-indexes#serverless-indexes
 // [similarity]: https://docs.pinecone.io/guides/indexes/understanding-indexes#distance-metrics
@@ -618,7 +645,9 @@ type CreateServerlessIndexRequest struct {
 //  pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//  }
+//  } else {
+//	  fmt.Println("Successfully created a new Client object!")
+//	}
 //
 //  idx, err := pc.CreateServerlessIndex(ctx, &pinecone.CreateServerlessIndexRequest{
 //    Name:    "my-serverless-index",
@@ -633,7 +662,7 @@ type CreateServerlessIndexRequest struct {
 //    log.Fatalf("Failed to create serverless index: %s", idx.Name)
 //  } else {
 //    fmt.Printf("Successfully created serverless index: %s", idx.Name)
-// }
+//  }
 func (c *Client) CreateServerlessIndex(ctx context.Context, in *CreateServerlessIndexRequest) (*Index, error) {
 	metric := control.IndexMetric(in.Metric)
 	req := control.CreateIndexRequest{
@@ -681,7 +710,9 @@ func (c *Client) CreateServerlessIndex(ctx context.Context, in *CreateServerless
 //  pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//  }
+//  } else {
+//	  fmt.Println("Successfully created a new Client object!")
+//	}
 //
 //  idx, err := pc.DescribeIndex(ctx, "the-name-of-my-index")
 //  if err != nil {
@@ -723,13 +754,15 @@ func (c *Client) DescribeIndex(ctx context.Context, idxName string) (*Index, err
 //  pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//  }
+//  } else {
+//	  fmt.Println("Successfully created a new Client object!")
+//	}
 //
 // 	indexName := "the-name-of-my-index"
 //
 //	err = pc.DeleteIndex(ctx, indexName)
 //	if err != nil {
-//	  fmt.Println("Error:", err)
+//	  log.Fatalf("Error: %v", err)
 //	} else {
 //    fmt.Printf("Index \"%s\" deleted successfully", indexName)
 //	}
@@ -765,14 +798,16 @@ func (c *Client) DeleteIndex(ctx context.Context, idxName string) error {
 //	  SourceTag: "your_source_identifier", // optional
 //	}
 //
-// pc, err := pinecone.NewClient(clientParams)
+//  pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//  }
+//  } else {
+//	  fmt.Println("Successfully created a new Client object!")
+//	}
 //
 //  collections, err := pc.ListCollections(ctx)
 //	if err != nil {
-//	  fmt.Println("Failed to list collections:", err)
+//	  log.Fatalf("Failed to list collections: %v", err)
 //	} else {
 //	  if len(collections) == 0 {
 //	    fmt.Printf("No collections found in project")
@@ -840,11 +875,13 @@ func (c *Client) ListCollections(ctx context.Context) ([]*Collection, error) {
 //  pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//  }
+//  } else {
+//	  fmt.Println("Successfully created a new Client object!")
+//	}
 //
 //  collection, err := pc.DescribeCollection(ctx, "my-collection")
 //  if err != nil {
-//	  fmt.Println("Error describing collection:", err)
+//	  log.Fatalf("Error describing collection: %v", err)
 //	} else {
 //	  fmt.Printf("Collection: %+v\n", *collection)
 //	}
@@ -882,10 +919,12 @@ func (c *Client) DescribeCollection(ctx context.Context, collectionName string) 
 //	  SourceTag: "your_source_identifier", // optional
 //	}
 //
-// pc, err := pinecone.NewClient(clientParams)
+//  pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//  }
+//  } else {
+//	  fmt.Println("Successfully created a new Client object!")
+//	}
 //
 //  collection, err := pc.CreateCollection(ctx, &pinecone.CreateCollectionRequest{
 //    Name:   "my-collection",
@@ -893,7 +932,7 @@ func (c *Client) DescribeCollection(ctx context.Context, collectionName string) 
 //    },
 //  )
 //  if err != nil {
-//	  log.Fatalf("Failed to create collection: %s", err)
+//	  log.Fatalf("Failed to create collection: %v", err)
 //	} else {
 //	  fmt.Printf("Successfully created collection \"%s\".", collection.Name)
 //	}
@@ -923,10 +962,12 @@ type CreateCollectionRequest struct {
 //	  SourceTag: "your_source_identifier", // optional
 //	}
 //
-// pc, err := pinecone.NewClient(clientParams)
+//  pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//  }
+//  } else {
+//	  fmt.Println("Successfully created a new Client object!")
+//	}
 //
 //  collection, err := pc.CreateCollection(ctx, &pinecone.CreateCollectionRequest{
 //    Name:   "my-collection",
@@ -934,7 +975,7 @@ type CreateCollectionRequest struct {
 //    }
 //  )
 // 	if err != nil {
-//	  log.Fatalf("Failed to create collection: %s", err)
+//	  log.Fatalf("Failed to create collection: %v", err)
 //	} else {
 //	  fmt.Printf("Successfully created collection \"%s\".", collection.Name)
 //	}
@@ -978,10 +1019,12 @@ func (c *Client) CreateCollection(ctx context.Context, in *CreateCollectionReque
 //	  SourceTag: "your_source_identifier", // optional
 //	}
 //
-// pc, err := pinecone.NewClient(clientParams)
+//  pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//  }
+//  } else {
+//	  fmt.Println("Successfully created a new Client object!")
+//	}
 //
 //  collectionName := "my-collection"
 //

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -192,7 +192,7 @@ func NewClientBase(in NewClientBaseParams) (*Client, error) {
 
 	controlHostOverride := valueOrFallback(in.Host, os.Getenv("PINECONE_CONTROLLER_HOST"))
 	if controlHostOverride != "" {
-		controlHostOverride, err = ensureURLSchema(controlHostOverride)
+		controlHostOverride, err = ensureURLScheme(controlHostOverride)
 		if err != nil {
 			return nil, err
 		}
@@ -1157,7 +1157,7 @@ func buildClientBaseOptions(in NewClientBaseParams) []control.ClientOption {
 	return clientOptions
 }
 
-func ensureURLSchema(inputURL string) (string, error) {
+func ensureURLScheme(inputURL string) (string, error) {
 	parsedURL, err := url.Parse(inputURL)
 	if err != nil {
 		return "", fmt.Errorf("invalid URL: %v", err)

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -16,6 +16,48 @@ import (
 	"github.com/pinecone-io/go-pinecone/internal/useragent"
 )
 
+// Client provides a high-level interface for interacting with the Pinecone control plane API.
+// It encapsulates the necessary authentication, request creation, and response handling for the API's operations.
+//
+// The Client is designed to be long-lived and reused across multiple operations.
+//
+// Fields:
+//   - headers: The HTTP headers you would like attached to your API request.
+//   - restClient: The underlying REST client used to communicate with the Pinecone control plane API.
+//     This field is internal and managed by Client.
+//   - sourceTag: An optional string used to help Pinecone attribute API activity to our partners.
+//
+// To use Client, first build the parameters of your request using NewClientParams,
+// providing your API key. Then pass those parameters into the NewClient function to create a new Client.
+// Once instantiated, you can call Client's methods to perform actions such as creating, deleting,
+// and describing indexes and collections.
+//
+// Example:
+//  ctx := context.Background()
+//
+//  clientParams := pinecone.NewClientParams{
+//    ApiKey:    getEnvVars("PINECONE_API_KEY"),
+//    SourceTag: "your_source_identifier", // optional
+//   }
+//
+//  pc, err := pinecone.NewClient(clientParams)
+//  if err != nil {
+//    log.Fatalf("Failed to create Client: %v", err)
+//   }
+//
+//  idxs, err := pc.ListIndexes(ctx)
+//	if err != nil {
+//	  fmt.Println("Error:", err)
+//    return
+//	 }
+//
+//	for _, idx := range idxs {
+//	  fmt.Println(idx)
+//	 }
+//
+// Note that Client methods are designed to be safe for concurrent use by multiple
+// goroutines, assuming that its configuration (e.g., the API key) is not modified after
+// initialization.
 type Client struct {
 	headers    map[string]string
 	restClient *control.Client

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -320,8 +320,8 @@ func (c *Client) IndexWithAdditionalMetadata(host string, namespace string, addi
 
 	// merge additionalMetadata with authHeader
 	if additionalMetadata != nil {
-		for k, _ := range authHeader {
-			additionalMetadata[k] = authHeader[k]
+		for _, key := range authHeader {
+			additionalMetadata[key] = authHeader[key]
 		}
 	} else {
 		additionalMetadata = authHeader

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -176,7 +176,7 @@ func NewClient(in NewClientParams) (*Client, error) {
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
 //  }
-	func NewClientBase(in NewClientBaseParams) (*Client, error) {
+func NewClientBase(in NewClientBaseParams) (*Client, error) {
 	clientOptions := buildClientBaseOptions(in)
 	var err error
 

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -36,14 +36,14 @@ import (
 //  ctx := context.Background()
 //
 //  clientParams := pinecone.NewClientParams{
-//    ApiKey:    getEnvVars("PINECONE_API_KEY"),
-//    SourceTag: "your_source_identifier", // optional
-//   }
+//	  ApiKey:    "YOUR_API_KEY",
+//	  SourceTag: "your_source_identifier", // optional
+//	}
 //
 //  pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//   }
+//  }
 //
 //  idxs, err := pc.ListIndexes(ctx)
 //	if err != nil {
@@ -92,6 +92,9 @@ type NewClientBaseParams struct {
 //   - RestClient: An optional custom HTTP client to use for communication with the control plane API.
 //   - SourceTag: An optional string used to help Pinecone attribute API activity to our partners.
 //
+// Note: It is important to handle the error returned by this function to ensure that the
+// control plane client has been created successfully before attempting to make API calls.
+//
 // Returns a pointer to an initialized Client instance on success. In case of
 // failure, it returns nil and an error describing the issue encountered. Possible errors
 // include issues with setting up the API key provider or problems initializing the
@@ -101,26 +104,14 @@ type NewClientBaseParams struct {
 //  ctx := context.Background()
 //
 //  clientParams := pinecone.NewClientParams{
-//    ApiKey:    getEnvVars("PINECONE_API_KEY"),
-//    SourceTag: "your_source_identifier", // optional
-//   }
+//	  ApiKey:    "YOUR_API_KEY",
+//	  SourceTag: "your_source_identifier", // optional
+//	}
 //
 //  pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//   }
-//
-//  idxs, err := pc.ListIndexes(ctx)
-//	if err != nil {
-//	  fmt.Println("Error:", err)
-//	 }
-//
-//	for _, idx := range idxs {
-//	  fmt.Println(idx)
-//	 }
-//
-// It is important to handle the error returned by this function to ensure that the
-// control plane client has been created successfully before attempting to make API calls.
+//  }
 func NewClient(in NewClientParams) (*Client, error) {
 	osApiKey := os.Getenv("PINECONE_API_KEY")
 	hasApiKey := (valueOrFallback(in.ApiKey, osApiKey) != "")
@@ -154,6 +145,9 @@ func NewClient(in NewClientParams) (*Client, error) {
 //   - RestClient: An optional custom HTTP client to use for communication with the control plane API.
 //   - SourceTag: An optional string used to help Pinecone attribute API activity to our partners.
 //
+// Note: It is important to handle the error returned by this function to ensure that the
+// control plane client has been created successfully before attempting to make API calls.
+//
 // Returns a pointer to an initialized Client instance on success. In case of
 // failure, it returns nil and an error describing the issue encountered. Possible errors
 // include issues with setting up the headers or problems initializing the
@@ -166,26 +160,14 @@ func NewClient(in NewClientParams) (*Client, error) {
 //    Headers: map[string]string{
 //     "Authorization": "Bearer " + "<your JWT token>"
 //     "X-Project-Id": "<Your Pinecone project ID>"
-//      },
+//    },
 //    SourceTag: "your_source_identifier", // optional
-//    }
+//  }
 //
 //  pc, err := pinecone.NewClientBase(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//   }
-//
-//  idxs, err := pc.ListIndexes(ctx)
-//	if err != nil {
-//	  fmt.Println("Error:", err)
-//	 }
-//
-//	for _, idx := range idxs {
-//	  fmt.Println(idx)
-//	 }
-//
-// It is important to handle the error returned by this function to ensure that the
-// control plane client has been created successfully before attempting to make API calls.
+//  }
 func NewClientBase(in NewClientBaseParams) (*Client, error) {
 	clientOptions := buildClientBaseOptions(in)
 	var err error
@@ -218,26 +200,24 @@ func NewClientBase(in NewClientBaseParams) (*Client, error) {
 //  ctx := context.Background()
 //
 //  clientParams := pinecone.NewClientParams{
-//    ApiKey:    getEnvVars("PINECONE_API_KEY"),
-//    SourceTag: "your_source_identifier", // optional
-//   }
+//	  ApiKey:    "YOUR_API_KEY",
+//	  SourceTag: "your_source_identifier", // optional
+//	}
 //
 //  pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//   }
+//  }
 //
-//  idxs, err := pc.ListIndexes(ctx)
-//	if err != nil {
-//	  fmt.Println("Error:", err)
-//	 }
-//
-//  idx, err := pc.Index(idxs[0].Host) // You can now use idx to interact with your index.
-//  defer idx.Close()
-//
+//  idx, err := pc.DescribeIndex(ctx, "your-index-name")
 //  if err != nil {
-//    fmt.Println("Error:", err)
-//   }
+//	  fmt.Printf("Failed to describe index \"%s\". Error:%s", idx.Name, err)
+//  }
+//
+// 	idxConnection, err := pc.Index(idx.Host)
+//	if err != nil {
+//	  fmt.Println("Failed to create IndexConnection for Host: %v. Error: %v", idx.Host, err)
+//	}
  func (c *Client) Index(host string) (*IndexConnection, error) {
 	return c.IndexWithAdditionalMetadata(host, "", nil)
 }
@@ -254,32 +234,30 @@ func NewClientBase(in NewClientBaseParams) (*Client, error) {
 //  ctx := context.Background()
 //
 //  clientParams := pinecone.NewClientParams{
-//    ApiKey:    getEnvVars("PINECONE_API_KEY"),
-//    SourceTag: "your_source_identifier", // optional
-//   }
+//	  ApiKey:    "YOUR_API_KEY",
+//	  SourceTag: "your_source_identifier", // optional
+//	}
 //
 //  pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//   }
+//  }
 //
-//  idxs, err := pc.ListIndexes(ctx)
-//	if err != nil {
-//	  fmt.Println("Error:", err)
-//	 }
-//
-//  idx, err := pc.IndexWithNamespace(idxs[0].Host, <"sample-namespace">) // You can now use idx to interact with your index.
-//  defer idx.Close()
-//
+//  idx, err := pc.DescribeIndex(ctx, "your-index-name")
 //  if err != nil {
-//    fmt.Println("Error:", err)
-//   }
+//	  fmt.Printf("Failed to describe index \"%s\". Error:%s", idx.Name, err)
+//  }
+//
+// 	idxConnection, err := pc.IndexWithNamespace(idx.Host, "custom-namespace")
+//	if err != nil {
+//	  fmt.Println("Failed to create IndexConnection for Host: %v. Error: %v", idx.Host, err)
+//	}
 func (c *Client) IndexWithNamespace(host string, namespace string) (*IndexConnection, error) {
 	return c.IndexWithAdditionalMetadata(host, namespace, nil)
 }
 
 // IndexWithAdditionalMetadata creates an IndexConnection to the specified host within the specified namespace,
-// with the addition of custom metadata fields.
+// with the addition of custom metadata.
 //
 // Parameters:
 //   - host: The host URL of your Pinecone index.
@@ -293,30 +271,31 @@ func (c *Client) IndexWithNamespace(host string, namespace string) (*IndexConnec
 //  ctx := context.Background()
 //
 //  clientParams := pinecone.NewClientParams{
-//    ApiKey:    getEnvVars("PINECONE_API_KEY"),
-//    SourceTag: "your_source_identifier", // optional
-//   }
+//	  ApiKey:    "YOUR_API_KEY",
+//	  SourceTag: "your_source_identifier", // optional
+//	}
 //
 //  pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//   }
+//  }
 //
-//  idxs, err := pc.ListIndexes(ctx)
-//	if err != nil {
-//	  fmt.Println("Error:", err)
-//	 }
-//
-//  idx, err := pc.IndexWithAdditionalMetadata(
-//                idxs[0].Host,
-//                <"sample-namespace">,
-//                map[string]string{"custom-request-metadata": "custom-metadata-values"}
-//              ) // You can now use idx to interact with your index.
-//  defer idx.Close()
-//
+//  idx, err := pc.DescribeIndex(ctx, "your-index-name")
 //  if err != nil {
-//    fmt.Println("Error:", err)
-//   }
+//	  fmt.Printf("Failed to describe index \"%s\". Error:%s", idx.Name, err)
+//  }
+//
+//  indexMetadata := map[string]string{
+//	  "indexMetadata": "custom-index-level-metadata",
+//	}
+//
+//  idxConnection, err := pc.IndexWithAdditionalMetadata(idx.Host, "custom-namespace", indexMetadata)
+//	if err != nil {
+//	  fmt.Printf("Failed to create IndexConnection: %v", err)
+//	} else {
+//    fmt.Printf("IndexConnection created successfully for index: %s , with namespace \"%s\"\n", idx.Name,
+//    idxConnection.Namespace)
+//	}
 func (c *Client) IndexWithAdditionalMetadata(host string, namespace string, additionalMetadata map[string]string) (*IndexConnection, error) {
 	authHeader := c.extractAuthHeader()
 
@@ -347,23 +326,24 @@ func (c *Client) IndexWithAdditionalMetadata(host string, namespace string, addi
 //
 // Example:
 //  clientParams := pinecone.NewClientParams{
-//    ApiKey:    getEnvVars("PINECONE_API_KEY"),
-//    SourceTag: "your_source_identifier", // optional
-//   }
+//	  ApiKey:    "YOUR_API_KEY",
+//	  SourceTag: "your_source_identifier", // optional
+//	}
 //
 //  pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//   }
+//  }
 //
 //  idxs, err := pc.ListIndexes(ctx)
 //	if err != nil {
-//	  fmt.Println("Error:", err)
-//	 }
-//
-//	for _, idx := range idxs {
-//	  fmt.Println(idx)
-//	 }
+//	  fmt.Println("Failed to list indexes:", err)
+//  } else {
+//	  fmt.Println("Your project has the following indexes:")
+//	  for _, idx := range idxs {
+//	    fmt.Printf("- \"%s\"\n", idx.Name)
+//	  }
+//  }
 func (c *Client) ListIndexes(ctx context.Context) ([]*Index, error) {
 	res, err := c.restClient.ListIndexes(ctx)
 	if err != nil {
@@ -402,20 +382,20 @@ func (c *Client) ListIndexes(ctx context.Context) ([]*Index, error) {
 //   - SourceCollection: The Collection from which to create the index.
 //   - MetadataConfig: The metadata configuration for the index.
 //
-// To create a new Pods-based index, use the CreatePodIndex method on the Client object.
+// To create a new pods-based index, use the CreatePodIndex method on the Client object.
 //
 // Example:
 //  ctx := context.Background()
 //
 //  clientParams := pinecone.NewClientParams{
-//    ApiKey:    getEnvVars("PINECONE_API_KEY"),
-//    SourceTag: "your_source_identifier", // optional
-//   }
+//	  ApiKey:    "YOUR_API_KEY",
+//	  SourceTag: "your_source_identifier", // optional
+//	}
 //
 //  pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//   }
+//  }
 //
 //  idx, err := pc.CreatePodIndex(ctx, &pinecone.CreatePodIndexRequest{
 //    Name:        "my-pod-index",
@@ -423,11 +403,14 @@ func (c *Client) ListIndexes(ctx context.Context) ([]*Index, error) {
 //    Metric:      pinecone.Cosine,
 //    Environment: "us-west1-gcp",
 //    PodType:     "s1",
-//   })
+//    },
+//  )
 //
 //  if err != nil {
-//    fmt.Println("Error:", err)
-//   }
+//	  fmt.Println("Failed to create pod index:", err)
+//	} else {
+//	  fmt.Printf("Successfully created pod index: %s", idx.Name)
+//  }
 type CreatePodIndexRequest struct {
 	Name             string
 	Dimension        int32
@@ -473,14 +456,14 @@ func (req CreatePodIndexRequest) TotalCount() *int {
 //  ctx := context.Background()
 //
 //  clientParams := pinecone.NewClientParams{
-//    ApiKey:    getEnvVars("PINECONE_API_KEY"),
-//    SourceTag: "your_source_identifier", // optional
-//   }
+//	  ApiKey:    "YOUR_API_KEY",
+//	  SourceTag: "your_source_identifier", // optional
+//	}
 //
 //  pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//   }
+//  }
 //
 //  idx, err := pc.CreatePodIndex(ctx, &pinecone.CreatePodIndexRequest{
 //    Name:        "my-pod-index",
@@ -488,11 +471,14 @@ func (req CreatePodIndexRequest) TotalCount() *int {
 //    Metric:      pinecone.Cosine,
 //    Environment: "us-west1-gcp",
 //    PodType:     "s1",
-//   })
+//    }
+//  )
 //
-//  if err != nil {
-//    fmt.Println("Error:", err)
-//   }
+// 	if err != nil {
+//	  fmt.Println("Failed to create pod index:", err)
+//	} else {
+//	  fmt.Printf("Successfully created pod index: %s", idx.Name)
+//	}
 func (c *Client) CreatePodIndex(ctx context.Context, in *CreatePodIndexRequest) (*Index, error) {
 	metric := control.IndexMetric(in.Metric)
 	req := control.CreateIndexRequest{
@@ -559,14 +545,14 @@ func (c *Client) CreatePodIndex(ctx context.Context, in *CreatePodIndexRequest) 
 //  ctx := context.Background()
 //
 //  clientParams := pinecone.NewClientParams{
-//    ApiKey:    getEnvVars("PINECONE_API_KEY"),
-//    SourceTag: "your_source_identifier", // optional
-//   }
+//	  ApiKey:    "YOUR_API_KEY",
+//	  SourceTag: "your_source_identifier", // optional
+//	}
 //
 //  pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//   }
+//  }
 //
 //  idx, err := pc.CreateServerlessIndex(ctx, &pinecone.CreateServerlessIndexRequest{
 //    Name:    "my-serverless-index",
@@ -574,11 +560,12 @@ func (c *Client) CreatePodIndex(ctx context.Context, in *CreatePodIndexRequest) 
 //    Metric:  pinecone.Cosine,
 //    Cloud:   pinecone.Aws,
 //    Region:  "us-east-1",
-//   })
+//  }
+//)
 //
 //  if err != nil {
 //    fmt.Println("Error:", err)
-//   }
+//  }
 type CreateServerlessIndexRequest struct {
 	Name      string
 	Dimension int32
@@ -600,14 +587,14 @@ type CreateServerlessIndexRequest struct {
 //  ctx := context.Background()
 //
 //  clientParams := pinecone.NewClientParams{
-//    ApiKey:    getEnvVars("PINECONE_API_KEY"),
-//    SourceTag: "your_source_identifier", // optional
-//   }
+//	  ApiKey:    "YOUR_API_KEY",
+//	  SourceTag: "your_source_identifier", // optional
+//	}
 //
 //  pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//   }
+//  }
 //
 //  idx, err := pc.CreateServerlessIndex(ctx, &pinecone.CreateServerlessIndexRequest{
 //    Name:    "my-serverless-index",
@@ -615,11 +602,12 @@ type CreateServerlessIndexRequest struct {
 //    Metric:  pinecone.Cosine,
 //    Cloud:   pinecone.Aws,
 //    Region:  "us-east-1",
-//   })
+//  }
+//)
 //
 //  if err != nil {
 //    fmt.Println("Error:", err)
-//   }
+//  }
 func (c *Client) CreateServerlessIndex(ctx context.Context, in *CreateServerlessIndexRequest) (*Index, error) {
 	metric := control.IndexMetric(in.Metric)
 	req := control.CreateIndexRequest{
@@ -668,19 +656,19 @@ func (c *Client) CreateServerlessIndex(ctx context.Context, in *CreateServerless
 //  ctx := context.Background()
 //
 //  clientParams := pinecone.NewClientParams{
-//    ApiKey:    getEnvVars("PINECONE_API_KEY"),
-//    SourceTag: "your_source_identifier", // optional
-//   }
+//	  ApiKey:    "YOUR_API_KEY",
+//	  SourceTag: "your_source_identifier", // optional
+//	}
 //
 //  pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//   }
+//  }
 //
 //  idx, err := pc.DescribeIndex(ctx, "the-name-of-my-index")
 //  if err != nil {
 //    fmt.Println("Error:", err)
-//   }
+//  }
 func (c *Client) DescribeIndex(ctx context.Context, idxName string) (*Index, error) {
 	res, err := c.restClient.DescribeIndex(ctx, idxName)
 	if err != nil {
@@ -708,19 +696,19 @@ func (c *Client) DescribeIndex(ctx context.Context, idxName string) (*Index, err
 //  ctx := context.Background()
 //
 //  clientParams := pinecone.NewClientParams{
-//    ApiKey:    getEnvVars("PINECONE_API_KEY"),
-//    SourceTag: "your_source_identifier", // optional
-//   }
+//	  ApiKey:    "YOUR_API_KEY",
+//	  SourceTag: "your_source_identifier", // optional
+//	}
 //
 //  pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//   }
+//  }
 //
 //  err := pc.DeleteIndex(ctx, "the-name-of-my-index")
 //  if err != nil {
 //    fmt.Println("Error:", err)
-//   }
+//  }
 func (c *Client) DeleteIndex(ctx context.Context, idxName string) error {
 	res, err := c.restClient.DeleteIndex(ctx, idxName)
 	if err != nil {
@@ -750,13 +738,14 @@ func (c *Client) DeleteIndex(ctx context.Context, idxName string) error {
 //  ctx := context.Background()
 //
 //  clientParams := pinecone.NewClientParams{
-//    ApiKey:    getEnvVars("PINECONE_API_KEY"),
-//    SourceTag: "your_source_identifier", // optional
-//   }
+//	  ApiKey:    "YOUR_API_KEY",
+//	  SourceTag: "your_source_identifier", // optional
+//	}
+//
 // pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//   }
+//  }
 //
 //  collections, err := pc.ListCollections(ctx)
 //	if err != nil {
@@ -809,19 +798,19 @@ func (c *Client) ListCollections(ctx context.Context) ([]*Collection, error) {
 //  ctx := context.Background()
 //
 //  clientParams := pinecone.NewClientParams{
-//    ApiKey:    getEnvVars("PINECONE_API_KEY"),
-//    SourceTag: "your_source_identifier", // optional
-//   }
+//	  ApiKey:    "YOUR_API_KEY",
+//	  SourceTag: "your_source_identifier", // optional
+//	}
 //
 // pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//   }
+//  }
 //
 //  collection, err := pc.DescribeCollection(ctx, "my-collection")
 //  if err != nil {
 //    fmt.Println("Error:", err)
-//   }
+//  }
 func (c *Client) DescribeCollection(ctx context.Context, collectionName string) (*Collection, error) {
 	res, err := c.restClient.DescribeCollection(ctx, collectionName)
 	if err != nil {
@@ -848,23 +837,24 @@ func (c *Client) DescribeCollection(ctx context.Context, collectionName string) 
 //  ctx := context.Background()
 //
 //  clientParams := pinecone.NewClientParams{
-//    ApiKey:    getEnvVars("PINECONE_API_KEY"),
-//    SourceTag: "your_source_identifier", // optional
-//   }
+//	  ApiKey:    "YOUR_API_KEY",
+//	  SourceTag: "your_source_identifier", // optional
+//	}
 //
 // pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//   }
+//  }
 //
 //  collection, err := pc.CreateCollection(ctx, &pinecone.CreateCollectionRequest{
 //    Name:   "my-collection",
 //    Source: "my-source-pods-based-index",
-//   })
+//  }
+//)
 //
 //  if err != nil {
 //    fmt.Println("Error:", err)
-//   }
+//  }
 type CreateCollectionRequest struct {
 	Name   string
 	Source string
@@ -885,23 +875,24 @@ type CreateCollectionRequest struct {
 //  ctx := context.Background()
 //
 //  clientParams := pinecone.NewClientParams{
-//    ApiKey:    getEnvVars("PINECONE_API_KEY"),
-//    SourceTag: "your_source_identifier", // optional
-//   }
+//	  ApiKey:    "YOUR_API_KEY",
+//	  SourceTag: "your_source_identifier", // optional
+//	}
 //
 // pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//   }
+//  }
 //
 //  collection, err := pc.CreateCollection(ctx, &pinecone.CreateCollectionRequest{
 //    Name:   "my-collection",
 //    Source: "my-source-pods-based-index",
-//   })
+//  }
+//)
 //
 //  if err != nil {
 //    fmt.Println("Error:", err)
-//   }
+//  }
 func (c *Client) CreateCollection(ctx context.Context, in *CreateCollectionRequest) (*Collection, error) {
 	req := control.CreateCollectionRequest{
 		Name:   in.Name,
@@ -936,19 +927,19 @@ func (c *Client) CreateCollection(ctx context.Context, in *CreateCollectionReque
 //  ctx := context.Background()
 //
 //  clientParams := pinecone.NewClientParams{
-//    ApiKey:    getEnvVars("PINECONE_API_KEY"),
-//    SourceTag: "your_source_identifier", // optional
-//   }
+//	  ApiKey:    "YOUR_API_KEY",
+//	  SourceTag: "your_source_identifier", // optional
+//	}
 //
 // pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
-//   }
+//  }
 //
 //  err = pc.DeleteCollection(ctx, "my-collection")
 //  if err != nil {
 //    fmt.Println("Error:", err)
-//   }
+//  }
 func (c *Client) DeleteCollection(ctx context.Context, collectionName string) error {
 	res, err := c.restClient.DeleteCollection(ctx, collectionName)
 	if err != nil {

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -101,24 +101,17 @@ type NewClientBaseParams struct {
 }
 
 // NewClient creates and initializes a new instance of Client.
-// This function sets up the control plane client with the necessary configuration for authentication and communication
-// with the control plane API.
+// This function sets up the control plane client with the necessary configuration for authentication and communication.
 //
-// This function requires an input parameter of type NewClientParams, which includes:
-//   - ApiKey: The API key used to authenticate with the Pinecone control plane API.
-//   - Headers: An optional map of additional HTTP headers to include in each API request to the control plane.
-//   Provided through NewClientParams.Headers or NewClientBaseParams.Headers.
-//   - Host: The host URL of the Pinecone control plane API. If not provided,
-//     the default value is "https://api.pinecone.io".
-//   - RestClient: An optional custom HTTP client to use for communication with the control plane API.
-//   - SourceTag: An optional string used to help Pinecone attribute API activity to our partners.
+// Parameters:
+//   - in: A NewClientParams object that includes the API key used to authenticate with the Pinecone control plane
+//  API. See NewClientParams for more information.
 //
 // Note: It is important to handle the error returned by this function to ensure that the
 // control plane client has been created successfully before attempting to make API calls.
 //
-// Returns a pointer to an initialized Client instance on success. In case of
-// failure, it returns nil and an error describing the issue encountered. Possible errors
-// include issues with setting up the API key provider or problems initializing the
+// Returns a pointer to an initialized Client instance on success or an error describing the issue encountered.
+// Possible errors include issues with setting up the API key provider or problems initializing the
 // underlying REST client.
 //
 // Example:
@@ -155,24 +148,17 @@ func NewClient(in NewClientParams) (*Client, error) {
 	return NewClientBase(NewClientBaseParams{Headers: clientHeaders, Host: in.Host, RestClient: in.RestClient, SourceTag: in.SourceTag})
 }
 
-// NewClientBase creates and initializes a new instance of Client with custom authentication headers,
-// allowing users to authenticate in ways other than passing an API key.
+// NewClientBase creates and initializes a new instance of Client with custom authentication headers.
 //
-// This function requires an input parameter of type NewClientBaseParams, which includes:
-//   - Headers: An optional map of additional HTTP headers to include in each API request to the control plane.
-//    Provided through NewClientParams.Headers or NewClientBaseParams.Headers.
-//    "Authorization" and "X-Project-Id" headers are required.
-//   - Host: The host URL of the Pinecone control plane API. If not provided,
-//     the default value is "https://api.pinecone.io".
-//   - RestClient: An optional custom HTTP client to use for communication with the control plane API.
-//   - SourceTag: An optional string used to help Pinecone attribute API activity to our partners.
+// Parameters:
+//   - in: A NewClientBaseParams object that includes the necessary configuration for the control plane client. See
+//   NewClientBaseParams for more information.
 //
 // Note: It is important to handle the error returned by this function to ensure that the
 // control plane client has been created successfully before attempting to make API calls.
 //
-// Returns a pointer to an initialized Client instance on success. In case of
-// failure, it returns nil and an error describing the issue encountered. Possible errors
-// include issues with setting up the headers or problems initializing the
+// Returns a pointer to an initialized Client instance on success or an error describing the issue encountered.
+// Possible errors include issues with setting up the headers or problems initializing the
 // underlying REST client.
 //
 // Example:
@@ -211,12 +197,12 @@ func NewClientBase(in NewClientBaseParams) (*Client, error) {
 	return &c, nil
 }
 
-// Index creates an IndexConnection to the specified host.
+// Index creates an IndexConnection to a specified host.
 //
 // Parameters:
-//   - host: The host URL of your Pinecone index.
+//   - host: The host URL of a Pinecone index.
 //
-// Returns a pointer to an IndexConnection instance on success. In case of failure, it returns nil and an error.
+// Returns a pointer to an IndexConnection instance or an error.
 //
 // Example:
 //  ctx := context.Background()
@@ -244,13 +230,13 @@ func NewClientBase(in NewClientBaseParams) (*Client, error) {
 	return c.IndexWithAdditionalMetadata(host, "", nil)
 }
 
-// IndexWithNamespace creates an IndexConnection to the specified host within the specified namespace.
+// IndexWithNamespace creates an IndexConnection to a specified host and a specified namespace.
 //
 // Parameters:
-//   - host: The host URL of your Pinecone index.
-//   - namespace: The target namespace.
+//   - host: The host URL of a Pinecone index.
+//   - namespace: The namespace where index operations will be performed.
 //
-// Returns a pointer to an IndexConnection instance on success. In case of failure, it returns nil and an error.
+// Returns a pointer to an IndexConnection or an error.
 //
 // Example:
 //  ctx := context.Background()
@@ -279,15 +265,14 @@ func (c *Client) IndexWithNamespace(host string, namespace string) (*IndexConnec
 }
 
 // IndexWithAdditionalMetadata creates an IndexConnection to the specified host within the specified namespace,
-// with the addition of custom metadata.
+// with the addition of custom metadata. Read more about how gRPC handles metadata at [grpc.io/docs].
 //
 // Parameters:
 //   - host: The host URL of your Pinecone index.
-//   - namespace: The target namespace.
-//   - additionalMetadata: A map of additional metadata fields to include in the API request.
+//   - namespace: The namespace where index operations will be performed.
+//   - additionalMetadata: Additional metadata to be sent with each RPC request.
 //
-// Returns a pointer to an IndexConnection instance on success. In case of failure,
-// it returns nil and the error encountered.
+// Returns a pointer to an IndexConnection or error.
 //
 // Example:
 //  ctx := context.Background()
@@ -318,6 +303,8 @@ func (c *Client) IndexWithNamespace(host string, namespace string) (*IndexConnec
 //    fmt.Printf("IndexConnection created successfully for index: %s , with namespace \"%s\"\n", idx.Name,
 //    idxConnection.Namespace)
 //	}
+//
+// [grpc.io/docs]: https://grpc.io/docs/guides/metadata/
 func (c *Client) IndexWithAdditionalMetadata(host string, namespace string, additionalMetadata map[string]string) (*IndexConnection, error) {
 	authHeader := c.extractAuthHeader()
 
@@ -337,14 +324,13 @@ func (c *Client) IndexWithAdditionalMetadata(host string, namespace string, addi
 	return idx, nil
 }
 
-// ListIndexes retrieves a list of all indexes in a Pinecone project.
+// ListIndexes retrieves a list of all indexes in a Pinecone [project].
 //
 // Parameters:
 //   - ctx: A context.Context object controls the request's lifetime, allowing for the request
 //   to be canceled or to timeout according to the context's deadline.
 //
-// Returns a slice of pointers to Index objects on success. In case of failure,
-// it returns nil and the error encountered.
+// Returns a slice of pointers to Index objects or an error.
 //
 // Example:
 //  clientParams := pinecone.NewClientParams{
@@ -366,6 +352,8 @@ func (c *Client) IndexWithAdditionalMetadata(host string, namespace string, addi
 //	    fmt.Printf("- \"%s\"\n", idx.Name)
 //	  }
 //  }
+//
+// [project]: https://docs.pinecone.io/guides/projects/understanding-projects
 func (c *Client) ListIndexes(ctx context.Context) ([]*Index, error) {
 	res, err := c.restClient.ListIndexes(ctx)
 	if err != nil {
@@ -391,18 +379,18 @@ func (c *Client) ListIndexes(ctx context.Context) ([]*Index, error) {
 	return indexes, nil
 }
 
-// CreatePodIndexRequest holds the parameters for creating a new Pods-based index.
+// CreatePodIndexRequest holds the parameters for creating a new pods-based index.
 //
 // Fields:
-//   - Name: The name of the index.
-//   - Dimension: The dimension of the index.
-//   - Metric: The metric used to measure the similarity between vectors ("Cosine", "Euclidean", or "Dotproduct").
-//   - Environment: The cloud environment in which the index will be created.
-//   - PodType: The type of pod to use for the index ("p1", "p2", or "s2").
+//   - Name: The name of the pods-based index to be created.
+//   - Dimension: The dimension of the index (must match [dimensionality] of upserted vectors).
+//   - Metric: The metric used to measure the [similarity] between vectors.
+//   - Environment: The [cloud environment] in which the index will be created.
+//   - PodType: The [type of pod] to use for the index.
 //   - Shards: The number of shards to use for the index (defaults to 1).
-//   - Replicas: The number of replicas to use for the index (defaults to 1).
+//   - Replicas: The number of [replicas] to use for the index (defaults to 1).
 //   - SourceCollection: The Collection from which to create the index.
-//   - MetadataConfig: The metadata configuration for the index.
+//   - MetadataConfig: The [metadata configuration] for the index.
 //
 // To create a new pods-based index, use the CreatePodIndex method on the Client object.
 //
@@ -433,6 +421,13 @@ func (c *Client) ListIndexes(ctx context.Context) ([]*Index, error) {
 //	} else {
 //	  fmt.Printf("Successfully created pod index: %s", idx.Name)
 //  }
+//
+// [dimensionality]: https://docs.pinecone.io/guides/indexes/choose-a-pod-type-and-size#dimensionality-of-vectors
+// [similarity]: https://docs.pinecone.io/guides/indexes/understanding-indexes#distance-metrics
+// [type of pods]: https://docs.pinecone.io/guides/indexes/choose-a-pod-type-and-size
+// [metadata configuration]: https://docs.pinecone.io/guides/indexes/configure-pod-based-indexes#selective-metadata-indexing
+// [cloud environment]: https://docs.pinecone.io/guides/indexes/understanding-indexes#pod-environments
+// [replicas]: https://docs.pinecone.io/guides/indexes/configure-pod-based-indexes#add-replicas
 type CreatePodIndexRequest struct {
 	Name             string
 	Dimension        int32
@@ -445,21 +440,21 @@ type CreatePodIndexRequest struct {
 	MetadataConfig   *PodSpecMetadataConfig
 }
 
-// ReplicaCount ensures the replica count is >1 and returns a pointer to the number of replicas on the
-// CreatePodIndexRequest object.
+// ReplicaCount ensures the replica count of a pods-based index is >1.
+// It returns a pointer to the number of replicas on a CreatePodIndexRequest object.
 func (req CreatePodIndexRequest) ReplicaCount() *int32 {
 	x := minOne(req.Replicas)
 	return &x
 }
 
-// ShardCount ensures the number of shards is >1 and returns a pointer to the number of shards on the
-// CreatePodIndexRequest object.
+// ShardCount ensures the number of shards on a pods-based index is >1. It returns a pointer to the number of shards on
+// a CreatePodIndexRequest object.
 func (req CreatePodIndexRequest) ShardCount() *int32 {
 	x := minOne(req.Shards)
 	return &x
 }
 
-// TotalCount calculates and returns the total number of pods (replicas*shards) on the CreatePodIndexRequest object.
+// TotalCount calculates and returns the total number of pods (replicas*shards) on a CreatePodIndexRequest object.
 func (req CreatePodIndexRequest) TotalCount() *int {
 	x := int(*req.ReplicaCount() * *req.ShardCount())
 	return &x
@@ -470,9 +465,9 @@ func (req CreatePodIndexRequest) TotalCount() *int {
 // Parameters:
 // 	- ctx: A context.Context object controls the request's lifetime, allowing for the request
 //  to be canceled or to timeout according to the context's deadline.
-//  - in: A pointer to a CreatePodIndexRequest object.
+//  - in: A pointer to a CreatePodIndexRequest object. See CreatePodIndexRequest for more information.
 //
-// Returns a pointer to an Index object. In case of failure, it returns nil and the error encountered.
+// Returns a pointer to an Index object or an error.
 //
 // Example:
 //  ctx := context.Background()
@@ -552,14 +547,14 @@ func (c *Client) CreatePodIndex(ctx context.Context, in *CreatePodIndexRequest) 
 	return decodeIndex(res.Body)
 }
 
-// CreateServerlessIndexRequest holds the parameters for creating a new Serverless index.
+// CreateServerlessIndexRequest holds the parameters for creating a new [Serverless] index.
 //
 // Fields:
-//   - Name: The name of the index.
-//   - Dimension: The dimension of the index.
-//   - Metric: The metric used to measure the similarity between vectors ("Cosine", "Euclidean", or "Dotproduct").
-//   - Cloud: The cloud provider in which the index will be created.
-//   - Region: The region in which the index will be created.
+//   - Name: The name of the Serverless index.
+//   - Dimension: The dimension of the index (must match dimensionality of upserted vectors).
+//   - Metric: The metric used to measure the [similarity] between vectors.
+//   - Cloud: The [cloud provider] in which the index will be created.
+//   - Region: The [region] in which the index will be created.
 //
 // To create a new Serverless index, use the CreateServerlessIndex method on the Client object.
 //
@@ -590,6 +585,11 @@ func (c *Client) CreatePodIndex(ctx context.Context, in *CreatePodIndexRequest) 
 //  } else {
 //    fmt.Printf("Successfully created serverless index: %s", idx.Name)
 // }
+//
+// [Serverless]: https://docs.pinecone.io/guides/indexes/understanding-indexes#serverless-indexes
+// [similarity]: https://docs.pinecone.io/guides/indexes/understanding-indexes#distance-metrics
+// [region]: https://docs.pinecone.io/troubleshooting/available-cloud-regions
+// [cloud provider]: https://docs.pinecone.io/troubleshooting/available-cloud-regions#regions-available-for-serverless-indexes
 type CreateServerlessIndexRequest struct {
 	Name      string
 	Dimension int32

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -20,15 +20,17 @@ import (
 // Client holds the parameters for connecting to the Pinecone service. It is returned by the NewClient and NewClientBase
 // functions. To use Client, first build the parameters of the request using NewClientParams (or NewClientBaseParams).
 // Then, pass those parameters into the NewClient (or NewClientBase) function to create a new Client object.
-// Once instantiated, you can use Client to execute control plane API requests (e.g. create an index, list indexes,
-// etc.). Read more about different control plane API routes at [pinecone.io/docs].
+// Once instantiated, you can use Client to execute control plane API requests (e.g. create an Index, list Indexes,
+// etc.). Read more about different control plane API routes at [docs.pinecone.io/reference/api].
 //
 // Note: Client methods are safe for concurrent use.
 //
 // Fields:
 //   - headers: An optional map of additional HTTP headers to include in each API request to the control plane,
 //   provided through NewClientParams.Headers or NewClientBaseParams.Headers.
-//   - restClient: The underlying REST client used to communicate with the Pinecone control plane API.
+//   - restClient: Optional underlying *http.Client object used to communicate with the Pinecone control plane API,
+//   provided through NewClientParams.RestClient or NewClientBaseParams.RestClient. If not provided,
+//   a default client is created for you.
 //   - sourceTag: An optional string used to help Pinecone attribute API activity, provided through NewClientParams.SourceTag
 //  or NewClientBaseParams.SourceTag.
 //
@@ -59,7 +61,7 @@ import (
 //	  log.Println("IndexConnection created successfully!")
 //  }
 //
-// [pinecone.io/docs]: https://docs.pinecone.io/reference/api/control-plane/list_indexes
+// [docs.pinecone.io/reference/api]: https://docs.pinecone.io/reference/api/control-plane/list_indexes
 type Client struct {
 	headers    map[string]string
 	restClient *control.Client
@@ -94,7 +96,7 @@ type NewClientParams struct {
 //   "Authorization" and "X-Project-Id" headers are required if authenticating using a JWT.
 //   - Host: The host URL of the Pinecone control plane API. If not provided,
 //   the default value is "https://api.pinecone.io".
-//   - RestClient: An optional HTTP client to use for communication with the control plane API.
+//   - RestClient: An optional *http.Client object to use for communication with the control plane API.
 //   - SourceTag: An optional string used to help Pinecone attribute API activity.
 //
 // See Client for code example.
@@ -206,7 +208,7 @@ func NewClientBase(in NewClientBaseParams) (*Client, error) {
 // Index creates an IndexConnection to a specified host.
 //
 // Parameters:
-//   - host: The host URL of a Pinecone index.
+//   - host: The URL address where the Index is hosted.
 //
 // Returns a pointer to an IndexConnection instance or an error.
 //
@@ -245,8 +247,8 @@ func NewClientBase(in NewClientBaseParams) (*Client, error) {
 // IndexWithNamespace creates an IndexConnection to a specified host and a specified namespace.
 //
 // Parameters:
-//   - host: The host URL of a Pinecone index.
-//   - namespace: The namespace where index operations will be performed.
+//   - host: The URL address where the Index is hosted.
+//   - namespace: The namespace where Index operations will be performed.
 //
 // Returns a pointer to an IndexConnection instance or an error.
 //
@@ -286,8 +288,8 @@ func (c *Client) IndexWithNamespace(host string, namespace string) (*IndexConnec
 // with the addition of custom metadata. Read more about how gRPC handles metadata in the [gRPC documentation].
 //
 // Parameters:
-//   - host: The host URL of your Pinecone index.
-//   - namespace: The namespace where index operations will be performed.
+//   - host: The URL address where the Index is hosted.
+//   - namespace: The namespace where Index operations will be performed.
 //   - additionalMetadata: Additional metadata to be sent with each RPC request.
 //
 // Returns a pointer to an IndexConnection instance or error.
@@ -346,7 +348,7 @@ func (c *Client) IndexWithAdditionalMetadata(host string, namespace string, addi
 	return idx, nil
 }
 
-// ListIndexes retrieves a list of all indexes in a Pinecone [project].
+// ListIndexes retrieves a list of all Indexes in a Pinecone [project].
 //
 // Parameters:
 //   - ctx: A context.Context object controls the request's lifetime, allowing for the request
@@ -403,29 +405,29 @@ func (c *Client) ListIndexes(ctx context.Context) ([]*Index, error) {
 	return indexes, nil
 }
 
-// CreatePodIndexRequest holds the parameters for creating a new pods-based index.
+// CreatePodIndexRequest holds the parameters for creating a new pods-based Index.
 //
 // Fields:
 //   - Name: The name of the Index. Resource name must be 1-45 characters long,
 //   start and end with an alphanumeric character,
 //   and consist only of lower case alphanumeric characters or '-'.
-//   - Dimension: The [dimensionality] of the vectors to be inserted in the index.
+//   - Dimension: The [dimensionality] of the vectors to be inserted in the Index.
 //   - Metric: The distance metric to be used for [similarity] search. You can use
 //   'euclidean', 'cosine', or 'dotproduct'.
-//   - Environment: The [cloud environment] where the index will be hosted.
-//   - PodType: The [type of pod] to use for the index. One of `s1`, `p1`, or `p2` appended with `.` and
+//   - Environment: The [cloud environment] where the Index will be hosted.
+//   - PodType: The [type of pod] to use for the Index. One of `s1`, `p1`, or `p2` appended with `.` and
 //    one of `x1`, `x2`, `x4`, or `x8`.
-//   - Shards: The number of shards to use for the index (defaults to 1).
-//    Shards split your data across multiple pods, so you can fit more data into an index.
-//   - Replicas: The number of [replicas] to use for the index (defaults to 1). Replicas duplicate your index.
+//   - Shards: The number of shards to use for the Index (defaults to 1).
+//    Shards split your data across multiple pods, so you can fit more data into an Index.
+//   - Replicas: The number of [replicas] to use for the Index (defaults to 1). Replicas duplicate your Index.
 //    They provide higher availability and throughput. Replicas can be scaled up or down as your needs change.
-//   - SourceCollection: The name of the Collection to be used as the source for the index.
-//   - MetadataConfig: The [metadata configuration] for the behavior of Pinecone's internal metadata index. By
+//   - SourceCollection: The name of the Collection to be used as the source for the Index.
+//   - MetadataConfig: The [metadata configuration] for the behavior of Pinecone's internal metadata Index. By
 //   default, all metadata is indexed; when `metadata_config` is present,
 //   only specified metadata fields are indexed. These configurations are
-//   only valid for use with pod-based indexes.
+//   only valid for use with pod-based Indexes.
 //
-// To create a new pods-based index, use the CreatePodIndex method on the Client object.
+// To create a new pods-based Index, use the CreatePodIndex method on the Client object.
 //
 // Example:
 //  ctx := context.Background()
@@ -480,14 +482,14 @@ type CreatePodIndexRequest struct {
 	MetadataConfig   *PodSpecMetadataConfig
 }
 
-// ReplicaCount ensures the replica count of a pods-based index is >1.
+// ReplicaCount ensures the replica count of a pods-based Index is >1.
 // It returns a pointer to the number of replicas on a CreatePodIndexRequest object.
 func (req CreatePodIndexRequest) ReplicaCount() *int32 {
 	x := minOne(req.Replicas)
 	return &x
 }
 
-// ShardCount ensures the number of shards on a pods-based index is >1. It returns a pointer to the number of shards on
+// ShardCount ensures the number of shards on a pods-based Index is >1. It returns a pointer to the number of shards on
 // a CreatePodIndexRequest object.
 func (req CreatePodIndexRequest) ShardCount() *int32 {
 	x := minOne(req.Shards)
@@ -500,7 +502,7 @@ func (req CreatePodIndexRequest) TotalCount() *int {
 	return &x
 }
 
-// CreatePodIndex creates and initializes a new pods-based index via the specified Client.
+// CreatePodIndex creates and initializes a new pods-based Index via the specified Client.
 //
 // Parameters:
 // 	- ctx: A context.Context object controls the request's lifetime, allowing for the request
@@ -594,19 +596,19 @@ func (c *Client) CreatePodIndex(ctx context.Context, in *CreatePodIndexRequest) 
 	return decodeIndex(res.Body)
 }
 
-// CreateServerlessIndexRequest holds the parameters for creating a new [Serverless] index.
+// CreateServerlessIndexRequest holds the parameters for creating a new [Serverless] Index.
 //
 // Fields:
 //   - Name: The name of the Index. Resource name must be 1-45 characters long,
 //   start and end with an alphanumeric character,
 //   and consist only of lower case alphanumeric characters or '-'.
-//   - Dimension: The dimension of the index (must match dimensionality of upserted vectors).
+//   - Dimension: The [dimensionality] of the vectors to be inserted in the Index.
 //   - Metric: The metric used to measure the [similarity] between vectors ('euclidean', 'cosine', or 'dotproduct').
-//   - Cloud: The public [cloud provider] where you would like your index hosted.
-//   For serverless indexes, you define only the cloud and region where the index should be hosted.
-//   - Region: The [region] where you would like your index to be created.
+//   - Cloud: The public [cloud provider] where you would like your Index hosted.
+//   For serverless Indexes, you define only the cloud and region where the Index should be hosted.
+//   - Region: The [region] where you would like your Index to be created.
 //
-// To create a new Serverless index, use the CreateServerlessIndex method on the Client object.
+// To create a new Serverless Index, use the CreateServerlessIndex method on the Client object.
 //
 // Example:
 //  ctx := context.Background()
@@ -638,6 +640,7 @@ func (c *Client) CreatePodIndex(ctx context.Context, in *CreatePodIndexRequest) 
 //    fmt.Printf("Successfully created serverless index: %s", idx.Name)
 //  }
 //
+// [dimensionality]: https://docs.pinecone.io/guides/indexes/choose-a-pod-type-and-size#dimensionality-of-vectors
 // [Serverless]: https://docs.pinecone.io/guides/indexes/understanding-indexes#serverless-indexes
 // [similarity]: https://docs.pinecone.io/guides/indexes/understanding-indexes#distance-metrics
 // [region]: https://docs.pinecone.io/troubleshooting/available-cloud-regions
@@ -650,7 +653,7 @@ type CreateServerlessIndexRequest struct {
 	Region    string
 }
 
-// CreateServerlessIndex creates and initializes a new serverless index via the specified Client.
+// CreateServerlessIndex creates and initializes a new serverless Index via the specified Client.
 //
 // Parameters:
 // 	- ctx: A context.Context object controls the request's lifetime, allowing for the request
@@ -715,12 +718,12 @@ func (c *Client) CreateServerlessIndex(ctx context.Context, in *CreateServerless
 	return decodeIndex(res.Body)
 }
 
-// DescribeIndex retrieves information about a specific index. See Index for more information.
+// DescribeIndex retrieves information about a specific Index. See Index for more information.
 //
 // Parameters:
 // 	- ctx: A context.Context object controls the request's lifetime, allowing for the request
 //  to be canceled or to timeout according to the context's deadline.
-//  - idxName: The name of the index to describe.
+//  - idxName: The name of the Index to describe.
 //
 // Returns a pointer to an Index object or an error.
 //
@@ -759,12 +762,12 @@ func (c *Client) DescribeIndex(ctx context.Context, idxName string) (*Index, err
 	return decodeIndex(res.Body)
 }
 
-// DeleteIndex deletes a specific index.
+// DeleteIndex deletes a specific Index.
 //
 // Parameters:
 // 	- ctx: A context.Context object controls the request's lifetime, allowing for the request
 //  to be canceled or to timeout according to the context's deadline.
-//  - idxName: The name of the index to delete.
+//  - idxName: The name of the Index to delete.
 //
 // Returns an error if the deletion fails.
 //
@@ -805,7 +808,7 @@ func (c *Client) DeleteIndex(ctx context.Context, idxName string) error {
 	return nil
 }
 
-// ListCollections retrieves a list of all collections in a Pinecone [project]. See Collection for more information.
+// ListCollections retrieves a list of all Collections in a Pinecone [project]. See Collection for more information.
 //
 // Parameters:
 // 	- ctx: A context.Context object controls the request's lifetime, allowing for the request
@@ -813,7 +816,7 @@ func (c *Client) DeleteIndex(ctx context.Context, idxName string) error {
 //
 // Returns a slice of pointers to [Collection] objects or an error.
 //
-// Note: Collections are only available for pods-based indexes.
+// Note: Collections are only available for pods-based Indexes.
 //
 // Example:
 //  ctx := context.Background()
@@ -845,7 +848,7 @@ func (c *Client) DeleteIndex(ctx context.Context, idxName string) error {
 //	}
 //
 // [project]: https://docs.pinecone.io/guides/projects/understanding-projects
-// [collection]: https://docs.pinecone.io/guides/indexes/understanding-collections
+// [Collection]: https://docs.pinecone.io/guides/indexes/understanding-collections
 func (c *Client) ListCollections(ctx context.Context) ([]*Collection, error) {
 	res, err := c.restClient.ListCollections(ctx)
 	if err != nil {
@@ -870,22 +873,22 @@ func (c *Client) ListCollections(ctx context.Context) ([]*Collection, error) {
 	return collections, nil
 }
 
-// DescribeCollection retrieves information about a specific [collection].
+// DescribeCollection retrieves information about a specific [Collection].
 //
 // Parameters:
 // 	- ctx: A context.Context object controls the request's lifetime, allowing for the request
 //  to be canceled or to timeout according to the context's deadline.
-//  - collectionName: The name of the collection to describe.
+//  - collectionName: The name of the Collection to describe.
 //
 // Returns a pointer to a Collection object or an error.
 //
-// Note: Collections are only available for pods-based indexes.
+// Note: Collections are only available for pods-based Indexes.
 //
 // Since the returned value is a pointer to a Collection object, it will have the following fields:
 //   - Name: The name of the Collection.
 //   - Size: The size of the Collection in bytes.
 //   - Status: The status of the Collection.
-//   - Dimension: The dimension of the vectors stored in each record held in the Collection.
+//   - Dimension: The [dimensionality] of the vectors stored in each record held in the Collection.
 //   - VectorCount: The number of records stored in the Collection.
 //   - Environment: The cloud environment where the Collection is hosted.
 //
@@ -911,7 +914,8 @@ func (c *Client) ListCollections(ctx context.Context) ([]*Collection, error) {
 //	  fmt.Printf("Collection: %+v\n", *collection)
 //	}
 //
-// [collection]: https://docs.pinecone.io/guides/indexes/understanding-collections
+// [dimensionality]: https://docs.pinecone.io/guides/indexes/choose-a-pod-type-and-size#dimensionality-of-vectors
+// [Collection]: https://docs.pinecone.io/guides/indexes/understanding-collections
 func (c *Client) DescribeCollection(ctx context.Context, collectionName string) (*Collection, error) {
 	res, err := c.restClient.DescribeCollection(ctx, collectionName)
 	if err != nil {
@@ -926,15 +930,15 @@ func (c *Client) DescribeCollection(ctx context.Context, collectionName string) 
 	return decodeCollection(res.Body)
 }
 
-// CreateCollectionRequest holds the parameters for creating a new [collection].
+// CreateCollectionRequest holds the parameters for creating a new [Collection].
 //
 // Fields:
 //   - Name: The name of the Collection.
 //   - Source: The name of the Index to be used as the source for the Collection.
 //
-// To create a new collection, use the CreateCollection method on the Client object.
+// To create a new Collection, use the CreateCollection method on the Client object.
 //
-// Note: Collections are only available for pods-based indexes.
+// Note: Collections are only available for pods-based Indexes.
 //
 // Example:
 //  ctx := context.Background()
@@ -962,20 +966,20 @@ func (c *Client) DescribeCollection(ctx context.Context, collectionName string) 
 //	  fmt.Printf("Successfully created collection \"%s\".", collection.Name)
 //	}
 //
-// [collection]: https://docs.pinecone.io/guides/indexes/understanding-collections
+// [Collection]: https://docs.pinecone.io/guides/indexes/understanding-collections
 type CreateCollectionRequest struct {
 	Name   string
 	Source string
 }
 
-// CreateCollection creates and initializes a new [collection] via the specified Client.
+// CreateCollection creates and initializes a new [Collection] via the specified Client.
 //
 // Parameters:
 // 	- ctx: A context.Context object controls the request's lifetime, allowing for the request
 //  to be canceled or to timeout according to the context's deadline.
 //  - in: A pointer to a CreateCollectionRequest object.
 //
-// Note: Collections are only available for pods-based indexes.
+// Note: Collections are only available for pods-based Indexes.
 //
 // Returns a pointer to a Collection object or an error.
 //
@@ -1005,7 +1009,7 @@ type CreateCollectionRequest struct {
 //	  fmt.Printf("Successfully created collection \"%s\".", collection.Name)
 //	}
 //
-// [collection]: https://docs.pinecone.io/guides/indexes/understanding-collections
+// [Collection]: https://docs.pinecone.io/guides/indexes/understanding-collections
 func (c *Client) CreateCollection(ctx context.Context, in *CreateCollectionRequest) (*Collection, error) {
 	req := control.CreateCollectionRequest{
 		Name:   in.Name,
@@ -1025,14 +1029,14 @@ func (c *Client) CreateCollection(ctx context.Context, in *CreateCollectionReque
 	return decodeCollection(res.Body)
 }
 
-// DeleteCollection deletes a specific [collection].
+// DeleteCollection deletes a specific [Collection].
 //
 // Parameters:
 // 	- ctx: A context.Context object controls the request's lifetime, allowing for the request
 //  to be canceled or to timeout according to the context's deadline.
-//  - collectionName: The name of the collection to delete.
+//  - collectionName: The name of the Collection to delete.
 //
-// Note: Collections are only available for pods-based indexes.
+// Note: Collections are only available for pods-based Indexes.
 //
 // Returns an error if the deletion fails.
 //
@@ -1060,7 +1064,7 @@ func (c *Client) CreateCollection(ctx context.Context, in *CreateCollectionReque
 //	  log.Printf("Successfully deleted collection \"%s\"\n", collectionName)
 //	}
 //
-// [collection]: https://docs.pinecone.io/guides/indexes/understanding-collections
+// [Collection]: https://docs.pinecone.io/guides/indexes/understanding-collections
 func (c *Client) DeleteCollection(ctx context.Context, collectionName string) error {
 	res, err := c.restClient.DeleteCollection(ctx, collectionName)
 	if err != nil {

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -1070,8 +1070,6 @@ func (c *Client) extractAuthHeader() map[string]string {
 	for key, value := range c.headers {
 		for _, checkKey := range possibleAuthKeys {
 			if strings.ToLower(key) == checkKey {
-				//fmt.Println("!! key in extractAuthHeader here", key)
-				//fmt.Println("!! Return value from extractAuthHeader looks like this: ", map[string]string{key: value})
 				return map[string]string{key: value}
 			}
 		}

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -16,21 +16,21 @@ import (
 	"github.com/pinecone-io/go-pinecone/internal/useragent"
 )
 
-// Client provides a high-level interface for interacting with the Pinecone control plane API.
-// It encapsulates the necessary authentication, request creation, and response handling for the API's operations.
+
+// Client holds the parameters for connecting to the Pinecone service. It is returned by the NewClient and NewClientBase
+// functions. To use Client, first build the parameters of the request using NewClientParams (or NewClientBaseParams).
+// Then, pass those parameters into the NewClient (or NewBaseClient) function to create a new Client object.
+// Once instantiated, you can use Client to execute control plane API requests (e.g. create an index, list indexes,
+// etc.). Read more about different control plane API routes at [pinecone.io/docs].
 //
-// The Client is designed to be long-lived and reused across multiple operations.
+// Note: Client methods are safe for concurrent use.
 //
 // Fields:
-//   - headers: A map of additional HTTP headers to include in the API request.
-//   - restClient: The underlying REST client used to communicate with the Pinecone control plane API.
-//     This field is internal and managed by Client.
-//   - sourceTag: An optional string used to help Pinecone attribute API activity to our partners.
-//
-// To use Client, first build the parameters of your request using NewClientParams,
-// providing your API key. Then pass those parameters into the NewClient function to create a new Client.
-// Once instantiated, you can call Client's methods to perform actions such as creating, deleting,
-// and describing indexes and collections.
+//   - headers: An optional map of additional HTTP headers to include in each API request to the control plane,
+//    Provided through NewClientParams.Headers or NewClientBaseParams.Headers.
+//   - restClient: The underlying REST client (managed internally) used to communicate with the Pinecone control plane API.
+//   - sourceTag: An optional string used to help Pinecone attribute API activity, provided through NewClientParams.SourceTag
+//  or NewClientBaseParams.SourceTag.
 //
 // Example:
 //  ctx := context.Background()
@@ -40,7 +40,7 @@ import (
 //	  SourceTag: "your_source_identifier", // optional
 //	}
 //
-//  pc, err := pinecone.NewClient(clientParams)
+//  pc, err := pinecone.NewClient(clientParams) // --> This creates a new Client object.
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
 //  }
@@ -55,16 +55,24 @@ import (
 //	  log.Fatalf("Failed to create IndexConnection for Host: %v. Error: %v", idx.Host, err)
 //	}
 //
-// Note that Client methods are designed to be safe for concurrent use by multiple
-// goroutines, assuming that its configuration (e.g., the API key) is not modified after
-// initialization.
+// [pinecone.io/docs]: https://docs.pinecone.io/reference/api/control-plane/list_indexes
 type Client struct {
 	headers    map[string]string
 	restClient *control.Client
 	sourceTag  string
 }
 
-// NewClientParams holds the parameters for creating a new Client.
+// NewClientParams holds the parameters for creating a new Client while authenticating with an API key.
+//
+// Fields:
+//   - ApiKey: The API key used to authenticate with the Pinecone control plane API.
+//   - Headers: An optional map of additional HTTP headers to include in each API request to the control plane.
+//   - Host: The host URL of the Pinecone control plane API. If not provided,
+//   the default value is "https://api.pinecone.io".
+//   - RestClient: An optional HTTP client to use for communication with the control plane API.
+//   - SourceTag: An optional string used to help Pinecone attribute API activity.
+//
+// See Client for code example.
 type NewClientParams struct {
 	ApiKey     string            // required - provide through NewClientParams or environment variable PINECONE_API_KEY
 	Headers    map[string]string // optional
@@ -73,7 +81,18 @@ type NewClientParams struct {
 	SourceTag  string            // optional
 }
 
-// NewClientBaseParams holds the parameters for creating a new Client with custom authentication headers.
+// NewClientBaseParams holds the parameters for creating a new Client while passing custom authentication headers.
+//
+// Fields:
+//   - Headers: An optional map of additional HTTP headers to include in each API request to the control plane,
+//   provided through NewClientParams.Headers or NewClientBaseParams.Headers.
+//   "Authorization" and "X-Project-Id" headers are required if authenticating using a JWT.
+//   - Host: The host URL of the Pinecone control plane API. If not provided,
+//   the default value is "https://api.pinecone.io".
+//   - RestClient: An optional HTTP client to use for communication with the control plane API.
+//   - SourceTag: An optional string used to help Pinecone attribute API activity.
+//
+// See Client for code example.
 type NewClientBaseParams struct {
 	Headers    map[string]string
 	Host       string
@@ -87,7 +106,8 @@ type NewClientBaseParams struct {
 //
 // This function requires an input parameter of type NewClientParams, which includes:
 //   - ApiKey: The API key used to authenticate with the Pinecone control plane API.
-//   - Headers: A map of additional HTTP headers to include in the API request.
+//   - Headers: An optional map of additional HTTP headers to include in each API request to the control plane.
+//   Provided through NewClientParams.Headers or NewClientBaseParams.Headers.
 //   - Host: The host URL of the Pinecone control plane API. If not provided,
 //     the default value is "https://api.pinecone.io".
 //   - RestClient: An optional custom HTTP client to use for communication with the control plane API.
@@ -139,8 +159,9 @@ func NewClient(in NewClientParams) (*Client, error) {
 // allowing users to authenticate in ways other than passing an API key.
 //
 // This function requires an input parameter of type NewClientBaseParams, which includes:
-//   - Headers: A map of additional HTTP headers to include in the API request.
-//     "Authorization" and "X-Project-Id" headers are required.
+//   - Headers: An optional map of additional HTTP headers to include in each API request to the control plane.
+//    Provided through NewClientParams.Headers or NewClientBaseParams.Headers.
+//    "Authorization" and "X-Project-Id" headers are required.
 //   - Host: The host URL of the Pinecone control plane API. If not provided,
 //     the default value is "https://api.pinecone.io".
 //   - RestClient: An optional custom HTTP client to use for communication with the control plane API.

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -48,7 +48,6 @@ import (
 //  idxs, err := pc.ListIndexes(ctx)
 //	if err != nil {
 //	  fmt.Println("Error:", err)
-//    return
 //	 }
 //
 //	for _, idx := range idxs {
@@ -114,7 +113,6 @@ type NewClientBaseParams struct {
 //  idxs, err := pc.ListIndexes(ctx)
 //	if err != nil {
 //	  fmt.Println("Error:", err)
-//    return
 //	 }
 //
 //	for _, idx := range idxs {
@@ -180,7 +178,6 @@ func NewClient(in NewClientParams) (*Client, error) {
 //  idxs, err := pc.ListIndexes(ctx)
 //	if err != nil {
 //	  fmt.Println("Error:", err)
-//    return
 //	 }
 //
 //	for _, idx := range idxs {
@@ -195,7 +192,7 @@ func NewClientBase(in NewClientBaseParams) (*Client, error) {
 
 	controlHostOverride := valueOrFallback(in.Host, os.Getenv("PINECONE_CONTROLLER_HOST"))
 	if controlHostOverride != "" {
-		controlHostOverride, err = ensureURLScheme(controlHostOverride)
+		controlHostOverride, err = ensureURLSchema(controlHostOverride)
 		if err != nil {
 			return nil, err
 		}
@@ -232,7 +229,6 @@ func NewClientBase(in NewClientBaseParams) (*Client, error) {
 //  idxs, err := pc.ListIndexes(ctx)
 //	if err != nil {
 //	  fmt.Println("Error:", err)
-//    return
 //	 }
 //
 //  idx, err := pc.Index(idxs[0].Host) // You can now use idx to interact with your index.
@@ -240,7 +236,6 @@ func NewClientBase(in NewClientBaseParams) (*Client, error) {
 //
 //  if err != nil {
 //    fmt.Println("Error:", err)
-//    return
 //   }
  func (c *Client) Index(host string) (*IndexConnection, error) {
 	return c.IndexWithAdditionalMetadata(host, "", nil)
@@ -269,7 +264,6 @@ func NewClientBase(in NewClientBaseParams) (*Client, error) {
 //  idxs, err := pc.ListIndexes(ctx)
 //	if err != nil {
 //	  fmt.Println("Error:", err)
-//    return
 //	 }
 //
 //  idx, err := pc.IndexWithNamespace(idxs[0].Host, <"sample-namespace">) // You can now use idx to interact with your index.
@@ -277,7 +271,6 @@ func NewClientBase(in NewClientBaseParams) (*Client, error) {
 //
 //  if err != nil {
 //    fmt.Println("Error:", err)
-//    return
 //   }
 func (c *Client) IndexWithNamespace(host string, namespace string) (*IndexConnection, error) {
 	return c.IndexWithAdditionalMetadata(host, namespace, nil)
@@ -310,7 +303,6 @@ func (c *Client) IndexWithNamespace(host string, namespace string) (*IndexConnec
 //  idxs, err := pc.ListIndexes(ctx)
 //	if err != nil {
 //	  fmt.Println("Error:", err)
-//    return
 //	 }
 //
 //  idx, err := pc.IndexWithAdditionalMetadata(
@@ -322,7 +314,6 @@ func (c *Client) IndexWithNamespace(host string, namespace string) (*IndexConnec
 //
 //  if err != nil {
 //    fmt.Println("Error:", err)
-//    return
 //   }
 func (c *Client) IndexWithAdditionalMetadata(host string, namespace string, additionalMetadata map[string]string) (*IndexConnection, error) {
 	authHeader := c.extractAuthHeader()
@@ -366,7 +357,6 @@ func (c *Client) IndexWithAdditionalMetadata(host string, namespace string, addi
 //  idxs, err := pc.ListIndexes(ctx)
 //	if err != nil {
 //	  fmt.Println("Error:", err)
-//    return
 //	 }
 //
 //	for _, idx := range idxs {
@@ -435,10 +425,7 @@ func (c *Client) ListIndexes(ctx context.Context) ([]*Index, error) {
 //
 //  if err != nil {
 //    fmt.Println("Error:", err)
-//    return
 //   }
-//
-//  fmt.Println(idx)
 type CreatePodIndexRequest struct {
 	Name             string
 	Dimension        int32
@@ -503,7 +490,6 @@ func (req CreatePodIndexRequest) TotalCount() *int {
 //
 //  if err != nil {
 //    fmt.Println("Error:", err)
-//    return
 //   }
 func (c *Client) CreatePodIndex(ctx context.Context, in *CreatePodIndexRequest) (*Index, error) {
 	metric := control.IndexMetric(in.Metric)
@@ -590,7 +576,6 @@ func (c *Client) CreatePodIndex(ctx context.Context, in *CreatePodIndexRequest) 
 //
 //  if err != nil {
 //    fmt.Println("Error:", err)
-//    return
 //   }
 type CreateServerlessIndexRequest struct {
 	Name      string
@@ -632,7 +617,6 @@ type CreateServerlessIndexRequest struct {
 //
 //  if err != nil {
 //    fmt.Println("Error:", err)
-//    return
 //   }
 func (c *Client) CreateServerlessIndex(ctx context.Context, in *CreateServerlessIndexRequest) (*Index, error) {
 	metric := control.IndexMetric(in.Metric)
@@ -661,7 +645,7 @@ func (c *Client) CreateServerlessIndex(ctx context.Context, in *CreateServerless
 	return decodeIndex(res.Body)
 }
 
-// DescribeIndex retrieves information about a specific index in a Pinecone project via a specified Client.
+// DescribeIndex retrieves information about a specific index.
 //
 // Parameters:
 // 	- ctx: A context.Context object controls the request's lifetime, allowing for the request
@@ -670,7 +654,31 @@ func (c *Client) CreateServerlessIndex(ctx context.Context, in *CreateServerless
 //
 // Returns a pointer to an Index object. In case of failure, it returns nil and the error encountered.
 //
+// Since the returned value is a pointer to an Index object, it will have the following fields:
+//   - Name: The name of the index.
+//   - Dimension: The dimension of the index.
+//   - Host: The host URL of the index.
+//   - Metric: The metric used to measure the similarity between vectors.
+//   - Spec: The specification of the index.
+//   - Status: The status of the index.
+//
 // Example:
+//  ctx := context.Background()
+//
+//  clientParams := pinecone.NewClientParams{
+//    ApiKey:    getEnvVars("PINECONE_API_KEY"),
+//    SourceTag: "your_source_identifier", // optional
+//   }
+//
+//  pc, err := pinecone.NewClient(clientParams)
+//  if err != nil {
+//    log.Fatalf("Failed to create Client: %v", err)
+//   }
+//
+//  idx, err := pc.DescribeIndex(ctx, "the-name-of-my-index")
+//  if err != nil {
+//    fmt.Println("Error:", err)
+//   }
 func (c *Client) DescribeIndex(ctx context.Context, idxName string) (*Index, error) {
 	res, err := c.restClient.DescribeIndex(ctx, idxName)
 	if err != nil {
@@ -685,6 +693,32 @@ func (c *Client) DescribeIndex(ctx context.Context, idxName string) (*Index, err
 	return decodeIndex(res.Body)
 }
 
+// DeleteIndex deletes a specific index.
+//
+// Parameters:
+// 	- ctx: A context.Context object controls the request's lifetime, allowing for the request
+//  to be canceled or to timeout according to the context's deadline.
+//  - idxName: The name of the index to delete.
+//
+// Returns an error if the deletion fails.
+//
+// Example:
+//  ctx := context.Background()
+//
+//  clientParams := pinecone.NewClientParams{
+//    ApiKey:    getEnvVars("PINECONE_API_KEY"),
+//    SourceTag: "your_source_identifier", // optional
+//   }
+//
+//  pc, err := pinecone.NewClient(clientParams)
+//  if err != nil {
+//    log.Fatalf("Failed to create Client: %v", err)
+//   }
+//
+//  err := pc.DeleteIndex(ctx, "the-name-of-my-index")
+//  if err != nil {
+//    fmt.Println("Error:", err)
+//   }
 func (c *Client) DeleteIndex(ctx context.Context, idxName string) error {
 	res, err := c.restClient.DeleteIndex(ctx, idxName)
 	if err != nil {
@@ -699,6 +733,33 @@ func (c *Client) DeleteIndex(ctx context.Context, idxName string) error {
 	return nil
 }
 
+// ListCollections retrieves a list of all collections in a Pinecone project.
+//
+// Parameters:
+// 	- ctx: A context.Context object controls the request's lifetime, allowing for the request
+//  to be canceled or to timeout according to the context's deadline.
+//
+// Returns a slice of pointers to Collection objects on success. In case of failure,
+// it returns nil and the error encountered.
+//
+// Note: Collections are only available for pods-based indexes.
+//
+// Example:
+//  ctx := context.Background()
+//
+//  clientParams := pinecone.NewClientParams{
+//    ApiKey:    getEnvVars("PINECONE_API_KEY"),
+//    SourceTag: "your_source_identifier", // optional
+//   }
+// pc, err := pinecone.NewClient(clientParams)
+//  if err != nil {
+//    log.Fatalf("Failed to create Client: %v", err)
+//   }
+//
+//  collections, err := pc.ListCollections(ctx)
+//	if err != nil {
+//	  fmt.Println("Error:", err)
+//	 }
 func (c *Client) ListCollections(ctx context.Context) ([]*Collection, error) {
 	res, err := c.restClient.ListCollections(ctx)
 	if err != nil {
@@ -723,6 +784,42 @@ func (c *Client) ListCollections(ctx context.Context) ([]*Collection, error) {
 	return collections, nil
 }
 
+// DescribeCollection retrieves information about a specific collection.
+//
+// Parameters:
+// 	- ctx: A context.Context object controls the request's lifetime, allowing for the request
+//  to be canceled or to timeout according to the context's deadline.
+//  - collectionName: The name of the collection to describe.
+//
+// Returns a pointer to a Collection object. In case of failure, it returns nil and the error encountered.
+//
+// Since the returned value is a pointer to a Collection object, it will have the following fields:
+//   - Name: The name of the collection.
+//   - Size: The size of the collection.
+//   - Status: The status of the collection.
+//   - Dimension: The dimension of the collection.
+//   - VectorCount: The number of vectors in the collection.
+//   - Environment: The cloud environment in which the collection resides.
+//
+// Note: Collections are only available for pods-based indexes.
+//
+// Example:
+//  ctx := context.Background()
+//
+//  clientParams := pinecone.NewClientParams{
+//    ApiKey:    getEnvVars("PINECONE_API_KEY"),
+//    SourceTag: "your_source_identifier", // optional
+//   }
+//
+// pc, err := pinecone.NewClient(clientParams)
+//  if err != nil {
+//    log.Fatalf("Failed to create Client: %v", err)
+//   }
+//
+//  collection, err := pc.DescribeCollection(ctx, "my-collection")
+//  if err != nil {
+//    fmt.Println("Error:", err)
+//   }
 func (c *Client) DescribeCollection(ctx context.Context, collectionName string) (*Collection, error) {
 	res, err := c.restClient.DescribeCollection(ctx, collectionName)
 	if err != nil {
@@ -737,11 +834,72 @@ func (c *Client) DescribeCollection(ctx context.Context, collectionName string) 
 	return decodeCollection(res.Body)
 }
 
+// CreateCollectionRequest holds the parameters for creating a new collection.
+//
+// Fields:
+//   - Name: The name of the collection.
+//   - Source: The source index from which the collection will be made.
+//
+// To create a new collection, use the CreateCollection method on the Client object.
+//
+// Example:
+//  ctx := context.Background()
+//
+//  clientParams := pinecone.NewClientParams{
+//    ApiKey:    getEnvVars("PINECONE_API_KEY"),
+//    SourceTag: "your_source_identifier", // optional
+//   }
+//
+// pc, err := pinecone.NewClient(clientParams)
+//  if err != nil {
+//    log.Fatalf("Failed to create Client: %v", err)
+//   }
+//
+//  collection, err := pc.CreateCollection(ctx, &pinecone.CreateCollectionRequest{
+//    Name:   "my-collection",
+//    Source: "my-source-pods-based-index",
+//   })
+//
+//  if err != nil {
+//    fmt.Println("Error:", err)
+//   }
 type CreateCollectionRequest struct {
 	Name   string
 	Source string
 }
 
+// CreateCollection creates and initializes a new collection via the specified Client.
+//
+// Parameters:
+// 	- ctx: A context.Context object controls the request's lifetime, allowing for the request
+//  to be canceled or to timeout according to the context's deadline.
+//  - in: A pointer to a CreateCollectionRequest object.
+//
+// Returns a pointer to a Collection object. In case of failure, it returns nil and the error encountered.
+//
+// Note: Collections are only available for pods-based indexes.
+//
+// Example:
+//  ctx := context.Background()
+//
+//  clientParams := pinecone.NewClientParams{
+//    ApiKey:    getEnvVars("PINECONE_API_KEY"),
+//    SourceTag: "your_source_identifier", // optional
+//   }
+//
+// pc, err := pinecone.NewClient(clientParams)
+//  if err != nil {
+//    log.Fatalf("Failed to create Client: %v", err)
+//   }
+//
+//  collection, err := pc.CreateCollection(ctx, &pinecone.CreateCollectionRequest{
+//    Name:   "my-collection",
+//    Source: "my-source-pods-based-index",
+//   })
+//
+//  if err != nil {
+//    fmt.Println("Error:", err)
+//   }
 func (c *Client) CreateCollection(ctx context.Context, in *CreateCollectionRequest) (*Collection, error) {
 	req := control.CreateCollectionRequest{
 		Name:   in.Name,
@@ -761,6 +919,34 @@ func (c *Client) CreateCollection(ctx context.Context, in *CreateCollectionReque
 	return decodeCollection(res.Body)
 }
 
+// DeleteCollection deletes a specific collection.
+//
+// Parameters:
+// 	- ctx: A context.Context object controls the request's lifetime, allowing for the request
+//  to be canceled or to timeout according to the context's deadline.
+//  - collectionName: The name of the collection to delete.
+//
+// Returns an error if the deletion fails.
+//
+// Note: Collections are only available for pods-based indexes.
+//
+// Example:
+//  ctx := context.Background()
+//
+//  clientParams := pinecone.NewClientParams{
+//    ApiKey:    getEnvVars("PINECONE_API_KEY"),
+//    SourceTag: "your_source_identifier", // optional
+//   }
+//
+// pc, err := pinecone.NewClient(clientParams)
+//  if err != nil {
+//    log.Fatalf("Failed to create Client: %v", err)
+//   }
+//
+//  err = pc.DeleteCollection(ctx, "my-collection")
+//  if err != nil {
+//    fmt.Println("Error:", err)
+//   }
 func (c *Client) DeleteCollection(ctx context.Context, collectionName string) error {
 	res, err := c.restClient.DeleteCollection(ctx, collectionName)
 	if err != nil {
@@ -971,7 +1157,7 @@ func buildClientBaseOptions(in NewClientBaseParams) []control.ClientOption {
 	return clientOptions
 }
 
-func ensureURLScheme(inputURL string) (string, error) {
+func ensureURLSchema(inputURL string) (string, error) {
 	parsedURL, err := url.Parse(inputURL)
 	if err != nil {
 		return "", fmt.Errorf("invalid URL: %v", err)
@@ -984,7 +1170,7 @@ func ensureURLScheme(inputURL string) (string, error) {
 }
 
 func valueOrFallback[T comparable](value, fallback T) T {
-	var zero T
+	var zero T // set to zero-value of generic type T
 	if value != zero {
 		return value
 	} else {
@@ -999,15 +1185,9 @@ func derefOrDefault[T any](ptr *T, defaultValue T) T {
 	return *ptr
 }
 
-// Ensure the value is at least 1
 func minOne(x int32) int32 {
-	if x < 1 {
+	if x < 1 { // ensure x is at least 1
 		return 1
 	}
 	return x
-}
-
-func PrettifyStruct(obj interface{}) string {
-	bytes, _ := json.MarshalIndent(obj, "", "  ")
-	return string(bytes)
 }

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -45,14 +45,15 @@ import (
 //    log.Fatalf("Failed to create Client: %v", err)
 //  }
 //
-//  idxs, err := pc.ListIndexes(ctx)
-//	if err != nil {
-//	  fmt.Println("Error:", err)
-//	 }
+//  idx, err := pc.DescribeIndex(ctx, "your-index-name")
+//  if err != nil {
+//	  log.Fatalf("Failed to describe index \"%s\". Error:%s", idx.Name, err)
+//  }
 //
-//	for _, idx := range idxs {
-//	  fmt.Println(idx)
-//	 }
+// 	idxConnection, err := pc.Index(idx.Host)
+//	if err != nil {
+//	  log.Fatalf("Failed to create IndexConnection for Host: %v. Error: %v", idx.Host, err)
+//	}
 //
 // Note that Client methods are designed to be safe for concurrent use by multiple
 // goroutines, assuming that its configuration (e.g., the API key) is not modified after
@@ -245,12 +246,12 @@ func NewClientBase(in NewClientBaseParams) (*Client, error) {
 //
 //  idx, err := pc.DescribeIndex(ctx, "your-index-name")
 //  if err != nil {
-//	  fmt.Printf("Failed to describe index \"%s\". Error:%s", idx.Name, err)
+//	  log.Fatalf("Failed to describe index \"%s\". Error:%s", idx.Name, err)
 //  }
 //
 // 	idxConnection, err := pc.IndexWithNamespace(idx.Host, "custom-namespace")
 //	if err != nil {
-//	  fmt.Println("Failed to create IndexConnection for Host: %v. Error: %v", idx.Host, err)
+//	  log.Fatalf("Failed to create IndexConnection for Host: %v. Error: %v", idx.Host, err)
 //	}
 func (c *Client) IndexWithNamespace(host string, namespace string) (*IndexConnection, error) {
 	return c.IndexWithAdditionalMetadata(host, namespace, nil)
@@ -282,7 +283,7 @@ func (c *Client) IndexWithNamespace(host string, namespace string) (*IndexConnec
 //
 //  idx, err := pc.DescribeIndex(ctx, "your-index-name")
 //  if err != nil {
-//	  fmt.Printf("Failed to describe index \"%s\". Error:%s", idx.Name, err)
+//	  log.Fatalf("Failed to describe index \"%s\". Error:%s", idx.Name, err)
 //  }
 //
 //  indexMetadata := map[string]string{
@@ -291,7 +292,7 @@ func (c *Client) IndexWithNamespace(host string, namespace string) (*IndexConnec
 //
 //  idxConnection, err := pc.IndexWithAdditionalMetadata(idx.Host, "custom-namespace", indexMetadata)
 //	if err != nil {
-//	  fmt.Printf("Failed to create IndexConnection: %v", err)
+//	  log.Fatalf("Failed to create IndexConnection: %v", err)
 //	} else {
 //    fmt.Printf("IndexConnection created successfully for index: %s , with namespace \"%s\"\n", idx.Name,
 //    idxConnection.Namespace)
@@ -337,7 +338,7 @@ func (c *Client) IndexWithAdditionalMetadata(host string, namespace string, addi
 //
 //  idxs, err := pc.ListIndexes(ctx)
 //	if err != nil {
-//	  fmt.Println("Failed to list indexes:", err)
+//	  log.Fatalf("Failed to list indexes:", err)
 //  } else {
 //	  fmt.Println("Your project has the following indexes:")
 //	  for _, idx := range idxs {
@@ -407,7 +408,7 @@ func (c *Client) ListIndexes(ctx context.Context) ([]*Index, error) {
 //  )
 //
 //  if err != nil {
-//	  fmt.Println("Failed to create pod index:", err)
+//	  log.Fatalf("Failed to create pod index:", err)
 //	} else {
 //	  fmt.Printf("Successfully created pod index: %s", idx.Name)
 //  }
@@ -475,7 +476,7 @@ func (req CreatePodIndexRequest) TotalCount() *int {
 //  )
 //
 // 	if err != nil {
-//	  fmt.Println("Failed to create pod index:", err)
+//	  log.Fatalf("Failed to create pod index:", err)
 //	} else {
 //	  fmt.Printf("Successfully created pod index: %s", idx.Name)
 //	}
@@ -560,12 +561,14 @@ func (c *Client) CreatePodIndex(ctx context.Context, in *CreatePodIndexRequest) 
 //    Metric:  pinecone.Cosine,
 //    Cloud:   pinecone.Aws,
 //    Region:  "us-east-1",
-//  }
-//)
+//    }
+//  )
 //
 //  if err != nil {
-//    fmt.Println("Error:", err)
-//  }
+//    log.Fatalf("Failed to create serverless index: %s", idx.Name)
+//  } else {
+//    fmt.Printf("Successfully created serverless index: %s", idx.Name)
+// }
 type CreateServerlessIndexRequest struct {
 	Name      string
 	Dimension int32
@@ -606,8 +609,10 @@ type CreateServerlessIndexRequest struct {
 //)
 //
 //  if err != nil {
-//    fmt.Println("Error:", err)
-//  }
+//    log.Fatalf("Failed to create serverless index: %s", idx.Name)
+//  } else {
+//    fmt.Printf("Successfully created serverless index: %s", idx.Name)
+// }
 func (c *Client) CreateServerlessIndex(ctx context.Context, in *CreateServerlessIndexRequest) (*Index, error) {
 	metric := control.IndexMetric(in.Metric)
 	req := control.CreateIndexRequest{
@@ -667,8 +672,10 @@ func (c *Client) CreateServerlessIndex(ctx context.Context, in *CreateServerless
 //
 //  idx, err := pc.DescribeIndex(ctx, "the-name-of-my-index")
 //  if err != nil {
-//    fmt.Println("Error:", err)
-//  }
+//    log.Fatalf("Failed to describe index: %s", err)
+//  } else {
+//    fmt.Printf("%+v", *idx)
+// }
 func (c *Client) DescribeIndex(ctx context.Context, idxName string) (*Index, error) {
 	res, err := c.restClient.DescribeIndex(ctx, idxName)
 	if err != nil {
@@ -705,10 +712,12 @@ func (c *Client) DescribeIndex(ctx context.Context, idxName string) (*Index, err
 //    log.Fatalf("Failed to create Client: %v", err)
 //  }
 //
-//  err := pc.DeleteIndex(ctx, "the-name-of-my-index")
-//  if err != nil {
-//    fmt.Println("Error:", err)
-//  }
+// 	err = pc.DeleteIndex(ctx, "the-name-of-my-index")
+//	if err != nil {
+//	  fmt.Println("Error:", err)
+//	} else {
+//	  fmt.Printf("Index \"%s\" deleted successfully", idx.Name)
+//	}
 func (c *Client) DeleteIndex(ctx context.Context, idxName string) error {
 	res, err := c.restClient.DeleteIndex(ctx, idxName)
 	if err != nil {
@@ -749,8 +758,17 @@ func (c *Client) DeleteIndex(ctx context.Context, idxName string) error {
 //
 //  collections, err := pc.ListCollections(ctx)
 //	if err != nil {
-//	  fmt.Println("Error:", err)
-//	 }
+//	  fmt.Println("Failed to list collections:", err)
+//	} else {
+//	  if len(collections) == 0 {
+//	    fmt.Printf("No collections found in project")
+//	  } else {
+//	    fmt.Println("Collections in project:")
+//		for _, collection := range collections {
+//		  fmt.Printf("Collection: %s\n", collection.Name)
+//		}
+//	  }
+//	}
 func (c *Client) ListCollections(ctx context.Context) ([]*Collection, error) {
 	res, err := c.restClient.ListCollections(ctx)
 	if err != nil {
@@ -784,6 +802,8 @@ func (c *Client) ListCollections(ctx context.Context) ([]*Collection, error) {
 //
 // Returns a pointer to a Collection object. In case of failure, it returns nil and the error encountered.
 //
+// Note: Collections are only available for pods-based indexes.
+//
 // Since the returned value is a pointer to a Collection object, it will have the following fields:
 //   - Name: The name of the collection.
 //   - Size: The size of the collection.
@@ -791,8 +811,6 @@ func (c *Client) ListCollections(ctx context.Context) ([]*Collection, error) {
 //   - Dimension: The dimension of the collection.
 //   - VectorCount: The number of vectors in the collection.
 //   - Environment: The cloud environment in which the collection resides.
-//
-// Note: Collections are only available for pods-based indexes.
 //
 // Example:
 //  ctx := context.Background()
@@ -802,15 +820,17 @@ func (c *Client) ListCollections(ctx context.Context) ([]*Collection, error) {
 //	  SourceTag: "your_source_identifier", // optional
 //	}
 //
-// pc, err := pinecone.NewClient(clientParams)
+//  pc, err := pinecone.NewClient(clientParams)
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
 //  }
 //
 //  collection, err := pc.DescribeCollection(ctx, "my-collection")
 //  if err != nil {
-//    fmt.Println("Error:", err)
-//  }
+//	  fmt.Println("Error describing collection:", err)
+//	} else {
+//	  fmt.Printf("Collection: %+v\n", *collection)
+//	}
 func (c *Client) DescribeCollection(ctx context.Context, collectionName string) (*Collection, error) {
 	res, err := c.restClient.DescribeCollection(ctx, collectionName)
 	if err != nil {
@@ -849,12 +869,13 @@ func (c *Client) DescribeCollection(ctx context.Context, collectionName string) 
 //  collection, err := pc.CreateCollection(ctx, &pinecone.CreateCollectionRequest{
 //    Name:   "my-collection",
 //    Source: "my-source-pods-based-index",
-//  }
-//)
-//
+//    },
+//  )
 //  if err != nil {
-//    fmt.Println("Error:", err)
-//  }
+//	  log.Fatalf("Failed to create collection: %s", err)
+//	} else {
+//	  fmt.Printf("Successfully created collection \"%s\".", collection.Name)
+//	}
 type CreateCollectionRequest struct {
 	Name   string
 	Source string
@@ -887,12 +908,13 @@ type CreateCollectionRequest struct {
 //  collection, err := pc.CreateCollection(ctx, &pinecone.CreateCollectionRequest{
 //    Name:   "my-collection",
 //    Source: "my-source-pods-based-index",
-//  }
-//)
-//
-//  if err != nil {
-//    fmt.Println("Error:", err)
-//  }
+//    }
+//  )
+// 	if err != nil {
+//	  log.Fatalf("Failed to create collection: %s", err)
+//	} else {
+//	  fmt.Printf("Successfully created collection \"%s\".", collection.Name)
+//	}
 func (c *Client) CreateCollection(ctx context.Context, in *CreateCollectionRequest) (*Collection, error) {
 	req := control.CreateCollectionRequest{
 		Name:   in.Name,
@@ -936,10 +958,14 @@ func (c *Client) CreateCollection(ctx context.Context, in *CreateCollectionReque
 //    log.Fatalf("Failed to create Client: %v", err)
 //  }
 //
-//  err = pc.DeleteCollection(ctx, "my-collection")
-//  if err != nil {
-//    fmt.Println("Error:", err)
-//  }
+//  collectionName := "my-collection"
+//
+//  err = pc.DeleteCollection(ctx, collectionName)
+//	if err != nil {
+//	  log.Fatalf("Failed to create collection: %s\n", err)
+//	} else {
+//	  log.Printf("Successfully deleted collection \"%s\"\n", collectionName)
+//	}
 func (c *Client) DeleteCollection(ctx context.Context, collectionName string) error {
 	res, err := c.restClient.DeleteCollection(ctx, collectionName)
 	if err != nil {

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -577,7 +577,7 @@ func (c *Client) CreatePodIndex(ctx context.Context, in *CreatePodIndexRequest) 
 //    Metric:  pinecone.Cosine,
 //    Cloud:   pinecone.Aws,
 //    Region:  "us-east-1",
-//    }
+//    },
 //  )
 //
 //  if err != nil {
@@ -603,9 +603,9 @@ type CreateServerlessIndexRequest struct {
 // Parameters:
 // 	- ctx: A context.Context object controls the request's lifetime, allowing for the request
 //  to be canceled or to timeout according to the context's deadline.
-//  - in: A pointer to a CreateServerlessIndexRequest object.
+//  - in: A pointer to a CreateServerlessIndexRequest object. See CreateServerlessIndexRequest for more information.
 //
-// Returns a pointer to an Index object. In case of failure, it returns nil and the error encountered.
+// Returns a pointer to an Index object or an error.
 //
 // Example:
 //  ctx := context.Background()
@@ -626,8 +626,8 @@ type CreateServerlessIndexRequest struct {
 //    Metric:  pinecone.Cosine,
 //    Cloud:   pinecone.Aws,
 //    Region:  "us-east-1",
-//  }
-//)
+//   },
+//  )
 //
 //  if err != nil {
 //    log.Fatalf("Failed to create serverless index: %s", idx.Name)
@@ -661,22 +661,14 @@ func (c *Client) CreateServerlessIndex(ctx context.Context, in *CreateServerless
 	return decodeIndex(res.Body)
 }
 
-// DescribeIndex retrieves information about a specific index.
+// DescribeIndex retrieves information about a specific index. See Index for more information.
 //
 // Parameters:
 // 	- ctx: A context.Context object controls the request's lifetime, allowing for the request
 //  to be canceled or to timeout according to the context's deadline.
 //  - idxName: The name of the index to describe.
 //
-// Returns a pointer to an Index object. In case of failure, it returns nil and the error encountered.
-//
-// Since the returned value is a pointer to an Index object, it will have the following fields:
-//   - Name: The name of the index.
-//   - Dimension: The dimension of the index.
-//   - Host: The host URL of the index.
-//   - Metric: The metric used to measure the similarity between vectors.
-//   - Spec: The specification of the index.
-//   - Status: The status of the index.
+// Returns a pointer to an Index object or an error.
 //
 // Example:
 //  ctx := context.Background()
@@ -696,7 +688,7 @@ func (c *Client) CreateServerlessIndex(ctx context.Context, in *CreateServerless
 //    log.Fatalf("Failed to describe index: %s", err)
 //  } else {
 //    fmt.Printf("%+v", *idx)
-// }
+//  }
 func (c *Client) DescribeIndex(ctx context.Context, idxName string) (*Index, error) {
 	res, err := c.restClient.DescribeIndex(ctx, idxName)
 	if err != nil {
@@ -733,11 +725,13 @@ func (c *Client) DescribeIndex(ctx context.Context, idxName string) (*Index, err
 //    log.Fatalf("Failed to create Client: %v", err)
 //  }
 //
-// 	err = pc.DeleteIndex(ctx, "the-name-of-my-index")
+// 	indexName := "the-name-of-my-index"
+//
+//	err = pc.DeleteIndex(ctx, indexName)
 //	if err != nil {
 //	  fmt.Println("Error:", err)
 //	} else {
-//	  fmt.Printf("Index \"%s\" deleted successfully", idx.Name)
+//    fmt.Printf("Index \"%s\" deleted successfully", indexName)
 //	}
 func (c *Client) DeleteIndex(ctx context.Context, idxName string) error {
 	res, err := c.restClient.DeleteIndex(ctx, idxName)
@@ -753,14 +747,13 @@ func (c *Client) DeleteIndex(ctx context.Context, idxName string) error {
 	return nil
 }
 
-// ListCollections retrieves a list of all collections in a Pinecone project.
+// ListCollections retrieves a list of all collections in a Pinecone [project]. See Collection for more information.
 //
 // Parameters:
 // 	- ctx: A context.Context object controls the request's lifetime, allowing for the request
 //  to be canceled or to timeout according to the context's deadline.
 //
-// Returns a slice of pointers to Collection objects on success. In case of failure,
-// it returns nil and the error encountered.
+// Returns a slice of pointers to [Collection] objects or an error.
 //
 // Note: Collections are only available for pods-based indexes.
 //
@@ -786,10 +779,13 @@ func (c *Client) DeleteIndex(ctx context.Context, idxName string) error {
 //	  } else {
 //	    fmt.Println("Collections in project:")
 //		for _, collection := range collections {
-//		  fmt.Printf("Collection: %s\n", collection.Name)
+//		  fmt.Printf("- %s\n", collection.Name)
 //		}
 //	  }
 //	}
+//
+// [project]: https://docs.pinecone.io/guides/projects/understanding-projects
+// [collection]: https://docs.pinecone.io/guides/indexes/understanding-collections
 func (c *Client) ListCollections(ctx context.Context) ([]*Collection, error) {
 	res, err := c.restClient.ListCollections(ctx)
 	if err != nil {
@@ -814,14 +810,14 @@ func (c *Client) ListCollections(ctx context.Context) ([]*Collection, error) {
 	return collections, nil
 }
 
-// DescribeCollection retrieves information about a specific collection.
+// DescribeCollection retrieves information about a specific [collection].
 //
 // Parameters:
 // 	- ctx: A context.Context object controls the request's lifetime, allowing for the request
 //  to be canceled or to timeout according to the context's deadline.
 //  - collectionName: The name of the collection to describe.
 //
-// Returns a pointer to a Collection object. In case of failure, it returns nil and the error encountered.
+// Returns a pointer to a Collection object or an error.
 //
 // Note: Collections are only available for pods-based indexes.
 //
@@ -852,6 +848,8 @@ func (c *Client) ListCollections(ctx context.Context) ([]*Collection, error) {
 //	} else {
 //	  fmt.Printf("Collection: %+v\n", *collection)
 //	}
+//
+// [collection]: https://docs.pinecone.io/guides/indexes/understanding-collections
 func (c *Client) DescribeCollection(ctx context.Context, collectionName string) (*Collection, error) {
 	res, err := c.restClient.DescribeCollection(ctx, collectionName)
 	if err != nil {
@@ -866,50 +864,13 @@ func (c *Client) DescribeCollection(ctx context.Context, collectionName string) 
 	return decodeCollection(res.Body)
 }
 
-// CreateCollectionRequest holds the parameters for creating a new collection.
+// CreateCollectionRequest holds the parameters for creating a new [collection].
 //
 // Fields:
-//   - Name: The name of the collection.
+//   - Name: The name of the collection to create.
 //   - Source: The source index from which the collection will be made.
 //
 // To create a new collection, use the CreateCollection method on the Client object.
-//
-// Example:
-//  ctx := context.Background()
-//
-//  clientParams := pinecone.NewClientParams{
-//	  ApiKey:    "YOUR_API_KEY",
-//	  SourceTag: "your_source_identifier", // optional
-//	}
-//
-// pc, err := pinecone.NewClient(clientParams)
-//  if err != nil {
-//    log.Fatalf("Failed to create Client: %v", err)
-//  }
-//
-//  collection, err := pc.CreateCollection(ctx, &pinecone.CreateCollectionRequest{
-//    Name:   "my-collection",
-//    Source: "my-source-pods-based-index",
-//    },
-//  )
-//  if err != nil {
-//	  log.Fatalf("Failed to create collection: %s", err)
-//	} else {
-//	  fmt.Printf("Successfully created collection \"%s\".", collection.Name)
-//	}
-type CreateCollectionRequest struct {
-	Name   string
-	Source string
-}
-
-// CreateCollection creates and initializes a new collection via the specified Client.
-//
-// Parameters:
-// 	- ctx: A context.Context object controls the request's lifetime, allowing for the request
-//  to be canceled or to timeout according to the context's deadline.
-//  - in: A pointer to a CreateCollectionRequest object.
-//
-// Returns a pointer to a Collection object. In case of failure, it returns nil and the error encountered.
 //
 // Note: Collections are only available for pods-based indexes.
 //
@@ -928,7 +889,48 @@ type CreateCollectionRequest struct {
 //
 //  collection, err := pc.CreateCollection(ctx, &pinecone.CreateCollectionRequest{
 //    Name:   "my-collection",
-//    Source: "my-source-pods-based-index",
+//    Source: "my-source-index",
+//    },
+//  )
+//  if err != nil {
+//	  log.Fatalf("Failed to create collection: %s", err)
+//	} else {
+//	  fmt.Printf("Successfully created collection \"%s\".", collection.Name)
+//	}
+//
+// [collection]: https://docs.pinecone.io/guides/indexes/understanding-collections
+type CreateCollectionRequest struct {
+	Name   string
+	Source string
+}
+
+// CreateCollection creates and initializes a new [collection] via the specified Client.
+//
+// Parameters:
+// 	- ctx: A context.Context object controls the request's lifetime, allowing for the request
+//  to be canceled or to timeout according to the context's deadline.
+//  - in: A pointer to a CreateCollectionRequest object.
+//
+// Note: Collections are only available for pods-based indexes.
+//
+// Returns a pointer to a Collection object or an error.
+//
+// Example:
+//  ctx := context.Background()
+//
+//  clientParams := pinecone.NewClientParams{
+//	  ApiKey:    "YOUR_API_KEY",
+//	  SourceTag: "your_source_identifier", // optional
+//	}
+//
+// pc, err := pinecone.NewClient(clientParams)
+//  if err != nil {
+//    log.Fatalf("Failed to create Client: %v", err)
+//  }
+//
+//  collection, err := pc.CreateCollection(ctx, &pinecone.CreateCollectionRequest{
+//    Name:   "my-collection",
+//    Source: "my-source-index",
 //    }
 //  )
 // 	if err != nil {
@@ -936,6 +938,8 @@ type CreateCollectionRequest struct {
 //	} else {
 //	  fmt.Printf("Successfully created collection \"%s\".", collection.Name)
 //	}
+//
+// [collection]: https://docs.pinecone.io/guides/indexes/understanding-collections
 func (c *Client) CreateCollection(ctx context.Context, in *CreateCollectionRequest) (*Collection, error) {
 	req := control.CreateCollectionRequest{
 		Name:   in.Name,
@@ -955,16 +959,16 @@ func (c *Client) CreateCollection(ctx context.Context, in *CreateCollectionReque
 	return decodeCollection(res.Body)
 }
 
-// DeleteCollection deletes a specific collection.
+// DeleteCollection deletes a specific [collection].
 //
 // Parameters:
 // 	- ctx: A context.Context object controls the request's lifetime, allowing for the request
 //  to be canceled or to timeout according to the context's deadline.
 //  - collectionName: The name of the collection to delete.
 //
-// Returns an error if the deletion fails.
-//
 // Note: Collections are only available for pods-based indexes.
+//
+// Returns an error if the deletion fails.
 //
 // Example:
 //  ctx := context.Background()
@@ -987,6 +991,8 @@ func (c *Client) CreateCollection(ctx context.Context, in *CreateCollectionReque
 //	} else {
 //	  log.Printf("Successfully deleted collection \"%s\"\n", collectionName)
 //	}
+//
+// [collection]: https://docs.pinecone.io/guides/indexes/understanding-collections
 func (c *Client) DeleteCollection(ctx context.Context, collectionName string) error {
 	res, err := c.restClient.DeleteCollection(ctx, collectionName)
 	if err != nil {

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -605,7 +605,6 @@ func (c *Client) CreatePodIndex(ctx context.Context, in *CreatePodIndexRequest) 
 //   - Cloud: The public [cloud provider] where you would like your index hosted.
 //   For serverless indexes, you define only the cloud and region where the index should be hosted.
 //   - Region: The [region] where you would like your index to be created.
-//   Serverless indexes can be created only in the us-east-1, us-west-2, and eu-west-1 regions of AWS at this time.
 //
 // To create a new Serverless index, use the CreateServerlessIndex method on the Client object.
 //

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -176,7 +176,7 @@ func NewClient(in NewClientParams) (*Client, error) {
 //  if err != nil {
 //    log.Fatalf("Failed to create Client: %v", err)
 //  }
-func NewClientBase(in NewClientBaseParams) (*Client, error) {
+	func NewClientBase(in NewClientBaseParams) (*Client, error) {
 	clientOptions := buildClientBaseOptions(in)
 	var err error
 

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -430,12 +430,17 @@ func (c *Client) ListIndexes(ctx context.Context) ([]*Index, error) {
 //	  fmt.Println("Successfully created a new Client object!")
 //	}
 //
+// 	podIndexMetadata := &pinecone.PodSpecMetadataConfig{
+//	  Indexed: &[]string{"title", "description"},
+//	}
+//
 //  idx, err := pc.CreatePodIndex(ctx, &pinecone.CreatePodIndexRequest{
 //    Name:        "my-pod-index",
 //    Dimension:   3,
 //    Metric:      pinecone.Cosine,
 //    Environment: "us-west1-gcp",
 //    PodType:     "s1",
+//    MetadataConfig: podIndexMetadata,
 //    },
 //  )
 //
@@ -507,12 +512,17 @@ func (req CreatePodIndexRequest) TotalCount() *int {
 //	  fmt.Println("Successfully created a new Client object!")
 //	}
 //
+// 	podIndexMetadata := &pinecone.PodSpecMetadataConfig{
+//	  Indexed: &[]string{"title", "description"},
+//	}
+//
 //  idx, err := pc.CreatePodIndex(ctx, &pinecone.CreatePodIndexRequest{
 //    Name:        "my-pod-index",
 //    Dimension:   3,
 //    Metric:      pinecone.Cosine,
 //    Environment: "us-west1-gcp",
 //    PodType:     "s1",
+//    MetadataConfig: podIndexMetadata,
 //    }
 //  )
 //

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -209,9 +209,10 @@ func NewClientBase(in NewClientBaseParams) (*Client, error) {
 
 // Index creates an IndexConnection to the specified host.
 //
-// This function requires an input parameter of type string, which is the host URL of your Pinecone index.
+// Parameters:
+//   - host: The host URL of your Pinecone index.
 //
-// It returns a pointer to an IndexConnection instance on success. In case of failure, it returns nil and an error.
+// Returns a pointer to an IndexConnection instance on success. In case of failure, it returns nil and an error.
 //
 // Example:
 //  ctx := context.Background()
@@ -243,10 +244,11 @@ func NewClientBase(in NewClientBaseParams) (*Client, error) {
 
 // IndexWithNamespace creates an IndexConnection to the specified host within the specified namespace.
 //
-// This function requires input parameters of type string.
-// They are the host URL of your Pinecone index and the target namespace.
+// Parameters:
+//   - host: The host URL of your Pinecone index.
+//   - namespace: The target namespace.
 //
-// It returns a pointer to an IndexConnection instance on success. In case of failure, it returns nil and an error.
+// Returns a pointer to an IndexConnection instance on success. In case of failure, it returns nil and an error.
 //
 // Example:
 //  ctx := context.Background()
@@ -285,7 +287,7 @@ func (c *Client) IndexWithNamespace(host string, namespace string) (*IndexConnec
 //   - additionalMetadata: A map of additional metadata fields to include in the API request.
 //
 // Returns a pointer to an IndexConnection instance on success. In case of failure,
-//it returns nil and the error encountered.
+// it returns nil and the error encountered.
 //
 // Example:
 //  ctx := context.Background()


### PR DESCRIPTION
## Problem

We do not have docstrings in the public types, functions, and methods in `client.go`. 

Asana ticket: https://app.asana.com/0/1203260648987893/1207208972408364/f

## Solution

Add docstrings!

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [x] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

CI passes.