### PR TITLE
update Go documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See [Pinecone API Docs](https://docs.pinecone.io/reference/) for more info.
 
 ## Installation
 
-go-pinecone requires a Go version with [modules](https://github.com/golang/go/wiki/Modules) support.
+go-pinecone requires a Go version with [modules](https://go.dev/wiki/Modules) support.
 
 To add a dependency on go-pinecone:
 


### PR DESCRIPTION
## Problem

Existing link was moved https://github.com/golang/go/wiki/Modules
<img width="520" alt="Screenshot 2024-06-21 at 4 00 43 PM" src="https://github.com/pinecone-io/go-pinecone/assets/19216250/7469b0e7-d67c-4d16-b01b-00b6ddca0db7">

## Solution

Changed to current link

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [X] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

N/A