### PR TITLE
Update docstring for NewManagementClient

### DIFF
--- a/pinecone/management_client.go
+++ b/pinecone/management_client.go
@@ -65,10 +65,10 @@ type NewManagementClientParams struct {
 }
 
 // NewManagementClient creates and initializes a new instance of ManagementClient.
-// This method sets up the management plane client with the necessary configuration for
+// This function sets up the management plane client with the necessary configuration for
 // authentication and communication with the management API.
 //
-// The method requires an input parameter of type NewManagementClientParams, which includes:
+// The function requires an input parameter of type NewManagementClientParams, which includes:
 //   - ApiKey: The API key used for authenticating requests to the management API.
 //     This key should have the necessary organization-level permissions for the operations
 //     you intend to perform.
@@ -93,7 +93,7 @@ type NewManagementClientParams struct {
 //	}
 //	// Use managementClient to interact with the management API
 //
-// It is important to handle the error returned by this method to ensure that the
+// It is important to handle the error returned by this function to ensure that the
 // management client has been created successfully before attempting to make API calls.
 func NewManagementClient(in NewManagementClientParams) (*ManagementClient, error) {
 	apiKeyProvider, err := securityprovider.NewSecurityProviderApiKey("header", "Api-Key", in.ApiKey)


### PR DESCRIPTION
## Problem

Super nit: `NewManagementClient` is a function not a method, so just reword docstring :)

## Solution

Change wording from "method" to "function".

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [x] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

CI passes.