### PR TITLE
Rename Filter to MetadataFilter for clarity

### DIFF
--- a/pinecone/index_connection.go
+++ b/pinecone/index_connection.go
@@ -387,14 +387,14 @@ func (idx *IndexConnection) ListVectors(ctx context.Context, in *ListVectorsRequ
 // Fields:
 //   - Vector: The query vector used to find similar vectors.
 //   - TopK: The number of vectors to return.
-//   - Filter: The filter to apply to your query.
+//   - MetadataFilter: The filter to apply to your query.
 //   - IncludeValues: Whether to include the values of the vectors in the response.
 //   - IncludeMetadata: Whether to include the metadata associated with the vectors in the response.
 //   - SparseValues: The sparse values of the query vector, if applicable.
 type QueryByVectorValuesRequest struct {
 	Vector          []float32
 	TopK            uint32
-	Filter          *Filter
+	Filter          *MetadataFilter
 	IncludeValues   bool
 	IncludeMetadata bool
 	SparseValues    *SparseValues
@@ -471,7 +471,7 @@ type QueryVectorsResponse struct {
 //	    res, err := idxConnection.QueryByVectorValues(ctx, &pinecone.QueryByVectorValuesRequest{
 //		       Vector:          queryVector,
 //		       TopK:            topK, // number of vectors to be returned
-//		       Filter:          metadataFilter,
+//		       MetadataFilter:          metadataFilter,
 //		       SparseValues:    &sparseValues,
 //		       IncludeValues:   true,
 //		       IncludeMetadata: true,
@@ -504,14 +504,14 @@ func (idx *IndexConnection) QueryByVectorValues(ctx context.Context, in *QueryBy
 // Fields:
 //   - VectorId: The unique ID of the vector used to find similar vectors.
 //   - TopK: The number of vectors to return.
-//   - Filter: The filter to apply to your query.
+//   - MetadataFilter: The filter to apply to your query.
 //   - IncludeValues: Whether to include the values of the vectors in the response.
 //   - IncludeMetadata: Whether to include the metadata associated with the vectors in the response.
 //   - SparseValues: The sparse values of the query vector, if applicable.
 type QueryByVectorIdRequest struct {
 	VectorId        string
 	TopK            uint32
-	Filter          *Filter
+	Filter          *MetadataFilter
 	IncludeValues   bool
 	IncludeMetadata bool
 	SparseValues    *SparseValues
@@ -700,7 +700,7 @@ func (idx *IndexConnection) DeleteVectorsById(ctx context.Context, ids []string)
 //	    if err != nil {
 //		       log.Fatalf("Failed to delete vector(s) with filter: %+v. Error: %s\n", filter, err)
 //	    }
-func (idx *IndexConnection) DeleteVectorsByFilter(ctx context.Context, filter *Filter) error {
+func (idx *IndexConnection) DeleteVectorsByFilter(ctx context.Context, filter *MetadataFilter) error {
 	req := data.DeleteRequest{
 		Filter:    filter,
 		Namespace: idx.Namespace,
@@ -953,7 +953,7 @@ func (idx *IndexConnection) DescribeIndexStats(ctx context.Context) (*DescribeIn
 //			       fmt.Printf("Namespace: \"%s\", has %d vector(s) that match the given filter\n", name, summary.VectorCount)
 //		       }
 //	    }
-func (idx *IndexConnection) DescribeIndexStatsFiltered(ctx context.Context, filter *Filter) (*DescribeIndexStatsResponse, error) {
+func (idx *IndexConnection) DescribeIndexStatsFiltered(ctx context.Context, filter *MetadataFilter) (*DescribeIndexStatsResponse, error) {
 	req := &data.DescribeIndexStatsRequest{
 		Filter: filter,
 	}

--- a/pinecone/index_connection_test.go
+++ b/pinecone/index_connection_test.go
@@ -267,7 +267,7 @@ func (ts *IndexConnectionTests) TestDescribeIndexStats() {
 
 func (ts *IndexConnectionTests) TestDescribeIndexStatsFiltered() {
 	ctx := context.Background()
-	res, err := ts.idxConn.DescribeIndexStatsFiltered(ctx, &Filter{})
+	res, err := ts.idxConn.DescribeIndexStatsFiltered(ctx, &MetadataFilter{})
 	assert.NoError(ts.T(), err)
 	assert.NotNil(ts.T(), res)
 }

--- a/pinecone/models.go
+++ b/pinecone/models.go
@@ -142,11 +142,11 @@ type Usage struct {
 	ReadUnits uint32 `json:"read_units"`
 }
 
-// Filter represents the [metadata filters] attached to a Pinecone request.
+// MetadataFilter represents the [metadata filters] attached to a Pinecone request.
 // These optional metadata filters are applied to query and deletion requests.
 //
 // [metadata filters]: https://docs.pinecone.io/guides/data/filter-with-metadata#querying-an-index-with-metadata-filters
-type Filter = structpb.Struct
+type MetadataFilter = structpb.Struct
 
 // Metadata represents optional,
 // additional information that can be [attached to, or updated for, a vector] in a Pinecone Index.


### PR DESCRIPTION
## Problem

Currently, `Filter`'s function is confusing as it relates to `Metadata` (see [this comment](https://github.com/pinecone-io/go-pinecone/pull/37#discussion_r1678421985) for more info). 

## Solution

Rename `Filter` to `MetadataFilter` to convey that it holds metadata that is used to constrain query-related requests.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [x] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

CI passes.