### PR TITLE
Add Reference documentation status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 # go-pinecone
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/pinecone-io/go-pinecone.svg)](https://pkg.go.dev/github.com/pinecone-io/go-pinecone)
+
 Official Pinecone Go Client
 
 ## Features


### PR DESCRIPTION
## Problem

Hard to get to reference documentation.

## Solution

I tried to look on the offical pinecone website but the docs are quite sparse. Getting to the godoc took too many clicks.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [x] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Clicked the link.
