### PR TITLE
Add GH action + workflow for setting up Go env in CI

### DIFF
--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -1,8 +1,12 @@
-name: 'Build client documentation'
+name: 'Generate client documentation'
 description: 'Generates client documentation using godoc'
+
 runs:
   using: 'composite'
   steps:
+    - name: Check out the repository
+      uses: actions/checkout@v4
+
     - name: Write html file to docs directory
       shell: bash
       run: |
@@ -13,7 +17,5 @@ runs:
           echo "Directory ./docs does not exist. Creating it now..."
           mkdir ./docs
         fi
-          
-        # Run the godoc command
         godoc -url pkg/github.com/pinecone-io/go-pinecone/pinecone/ > ./docs/index.html
         echo "godoc command has been executed and the output has been saved to ./docs/index.html"

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,15 @@
+name: 'Setup Go'
+description: 'Sets up Go using actions/setup-go@v5'
+inputs:
+  go-version:
+    description: 'The version of Go to use'
+    required: true
+    default: '1.21'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ inputs.go-version }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,3 +13,7 @@ runs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ inputs.go-version }}
+
+    - name: Install Go dependencies
+      shell: bash
+      run: go mod download

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -17,3 +17,7 @@ runs:
     - name: Install Go dependencies
       shell: bash
       run: go mod download
+
+    - name: Install godoc
+      shell: bash
+      run: go install golang.org/x/tools/cmd/godoc@latest

--- a/.github/workflows/build-and-publish-docs.yml
+++ b/.github/workflows/build-and-publish-docs.yml
@@ -14,6 +14,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Go
+        uses: ./.github/actions/setup/action.yml
+
       - name: Generate Go documentation
         uses: ./.github/actions/build-docs
 


### PR DESCRIPTION
## Problem

CI currently won't run for generating `godoc` documentation because we have no "setup" steps that installs go and our project's dependencies.

## Solution

Add 'em.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

CI passes.