### PR TITLE
Try new strategy for better rendering of documentation with gopages

### DIFF
--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -7,15 +7,7 @@ runs:
     - name: Check out the repository
       uses: actions/checkout@v4
 
-    - name: Write html file to docs directory
+    - name: Run gopages to generate documentation
       shell: bash
       run: |
-        # Check if the ./docs directory exists
-        if [ -d "./docs" ]; then
-          echo "Directory ./docs exists."
-        else
-          echo "Directory ./docs does not exist. Creating it now..."
-          mkdir ./docs
-        fi
-        godoc -url pkg/github.com/pinecone-io/go-pinecone/pinecone/ > ./docs/index.html
-        echo "godoc command has been executed and the output has been saved to ./docs/index.html"
+        gopages

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -18,6 +18,6 @@ runs:
       shell: bash
       run: go mod download
 
-    - name: Install godoc
+    - name: Install gopages
       shell: bash
-      run: go install golang.org/x/tools/cmd/godoc@latest
+      run: go install github.com/johnstarich/go/gopages@latest

--- a/.github/workflows/build-and-publish-docs.yml
+++ b/.github/workflows/build-and-publish-docs.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
         with:
-          source-directory: docs
+          source-directory: dist/pkg/github.com/pinecone-io/go-pinecone/pinecone
           destination-github-username: pinecone-io
           destination-repository-name: sdk-docs
           user-email: clients@pinecone.io


### PR DESCRIPTION
## Problem

Our current documentation is quite ugly (https://sdk.pinecone.io/go/). We generated it by running `godoc -url`, which basically prints standard html to a file. We then pushed this static file to `sdk-docs` via that repo's README instructions. 

## Solution

There is a Go module called `gopages`: https://johnstarich.com/go/gopages/pkg/github.com/johnstarich/go/gopages/ that seemingly renders things better. We should try that to see if it looks nicer.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Need to merge to main, then trigger the documentation workflow in the `sdk-docs` repo to see the rendering.