### PR TITLE
Change dir in documentation GH action to contain multiple HTML pages

### DIFF
--- a/.github/workflows/build-and-publish-docs.yml
+++ b/.github/workflows/build-and-publish-docs.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
         with:
-          source-directory: dist/pkg/github.com/pinecone-io/go-pinecone/pinecone
+          source-directory: dist
           destination-github-username: pinecone-io
           destination-repository-name: sdk-docs
           user-email: clients@pinecone.io


### PR DESCRIPTION
## Problem

In the original `gopages` [PR](https://github.com/pinecone-io/go-pinecone/pull/45), I was under the impression that we could only push a single `index.html` file to the `sdk-docs` repo. Upon inspecting the other clients' dirs in `sdk-docs`, though, I realized we could push a dir containing many different html pages in it.

## Solution

Point action to entire dir (`dist`) that contains multiple html files.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Merge to main, trigger build documentation workflow in this repo, trigger publish documentation workflow in `sdk-docs` repo, see if rendering is better.
