### PR TITLE
Implement support for `DeletionProtection`

### DIFF
--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -821,7 +821,7 @@ type ConfigureIndexParams struct {
 //
 // Example:
 //
-//		// To scale the size of your pods from "x2" to "x4":
+//		// To scale the size of your pods-based index from "x2" to "x4":
 //		 _, err := pc.ConfigureIndex(ctx, "my-pod-index", &ConfigureIndexParams{PodType: "p1.x4"})
 //		 if err != nil {
 //		     fmt.Printf("Failed to configure index: %v\n", err)
@@ -1209,14 +1209,14 @@ func toIndex(idx *control.IndexModel) *Index {
 		Ready: idx.Status.Ready,
 		State: IndexStatusState(idx.Status.State),
 	}
-	deletionProtecetion := derefOrDefault(idx.DeletionProtection, control.Disabled)
+	deletionProtection := derefOrDefault(idx.DeletionProtection, "")
 
 	return &Index{
 		Name:               idx.Name,
 		Dimension:          idx.Dimension,
 		Host:               idx.Host,
 		Metric:             IndexMetric(idx.Metric),
-		DeletionProtection: deletionProtecetion,
+		DeletionProtection: DeletionProtection(deletionProtection),
 		Spec:               spec,
 		Status:             status,
 	}

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -642,10 +642,6 @@ type CreateServerlessIndexRequest struct {
 //	    }
 func (c *Client) CreateServerlessIndex(ctx context.Context, in *CreateServerlessIndexRequest) (*Index, error) {
 	deletionProtection := toDeletionProtection(in.DeletionProtection)
-
-	fmt.Printf("in.Metric: %v\n", in.Metric)
-	fmt.Printf("control.CreateIndexRequestMetric(in.Metric): %v\n", control.CreateIndexRequestMetric(in.Metric))
-
 	metric := control.CreateIndexRequestMetric(in.Metric)
 
 	req := control.CreateIndexRequest{
@@ -814,9 +810,9 @@ type ConfigureIndexParams struct {
 // [app.pinecone.io]: https://app.pinecone.io
 func (c *Client) ConfigureIndex(ctx context.Context, name string, configParams ConfigureIndexParams) (*Index, error) {
 
-	// if configParams.PodType == "" && configParams.Replicas == 0 && configParams.DeletionProtection == "" {
-	// 	return nil, fmt.Errorf("must specify either PodType, Replicas, or DeletionProtection")
-	// }
+	if configParams.PodType == "" && configParams.Replicas == 0 && configParams.DeletionProtection == "" {
+		return nil, fmt.Errorf("must specify either PodType, Replicas, or DeletionProtection")
+	}
 
 	podType := pointerOrNil(configParams.PodType)
 	replicas := pointerOrNil(configParams.Replicas)

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -1224,12 +1224,7 @@ func TestBuildClientBaseOptionsUnit(t *testing.T) {
 	}
 }
 
-// Helper functions
-
-func stringPtr(s string) *string {
-	return &s
-}
-
+// Helper functions:
 func isValidUUID(u string) bool {
 	_, err := uuid.Parse(u)
 	return err == nil

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -48,7 +48,7 @@ func (ts *ClientTestsIntegration) SetupSuite() {
 	require.NotEmpty(ts.T(), ts.podIndex, "STATIC_TEST_PODS_INDEX_NAME env variable not set")
 
 	ts.serverlessIndex = os.Getenv("STATIC_TEST_SERVERLESS_INDEX_NAME")
-	require.NotEmpty(ts.T(), ts.serverlessIndex, "TEST_SERVERLESS_INDEX_NAME env variable not set")
+	require.NotEmpty(ts.T(), ts.serverlessIndex, "STATIC_TEST_SERVERLESS_INDEX_NAME env variable not set")
 
 	client, err := NewClient(NewClientParams{})
 	require.NoError(ts.T(), err)
@@ -471,7 +471,6 @@ func (ts *IntegrationTests) TestCreateCollection() {
 		Name:   name,
 		Source: sourceIndex,
 	})
-	fmt.Printf("TestCreateCollection err: %+v\n", err)
 
 	require.NoError(ts.T(), err)
 	require.Equal(ts.T(), name, collection.Name, "Collection name does not match")
@@ -486,7 +485,6 @@ func (ts *IntegrationTests) TestDeleteCollection() {
 		Name:   collectionName,
 		Source: ts.idxName,
 	})
-	fmt.Printf("TestDeleteCollection err: %+v\n", err)
 
 	require.NoError(ts.T(), err)
 
@@ -513,7 +511,7 @@ func (ts *IntegrationTests) TestConfigureIndexIllegalScaleDown() {
 		log.Fatalf("Error creating index %s: %v", name, err)
 	}
 
-	_, err = ts.client.ConfigureIndex(context.Background(), name, ConfigureIndexParams{PodType: "p1.x1", Replicas: 1})
+	_, err = ts.client.ConfigureIndex(context.Background(), name, &ConfigureIndexParams{PodType: "p1.x1", Replicas: 1})
 	require.ErrorContainsf(ts.T(), err, "Cannot scale down", err.Error())
 }
 
@@ -536,7 +534,7 @@ func (ts *IntegrationTests) TestConfigureIndexScaleUpNoPods() {
 		log.Fatalf("Error creating index %s: %v", name, err)
 	}
 
-	_, err = ts.client.ConfigureIndex(context.Background(), name, ConfigureIndexParams{Replicas: 2})
+	_, err = ts.client.ConfigureIndex(context.Background(), name, &ConfigureIndexParams{Replicas: 2})
 	require.NoError(ts.T(), err)
 }
 
@@ -559,7 +557,7 @@ func (ts *IntegrationTests) TestConfigureIndexScaleUpNoReplicas() {
 		log.Fatalf("Error creating index %s: %v", name, err)
 	}
 
-	_, err = ts.client.ConfigureIndex(context.Background(), name, ConfigureIndexParams{PodType: "p1.x4"})
+	_, err = ts.client.ConfigureIndex(context.Background(), name, &ConfigureIndexParams{PodType: "p1.x4"})
 	require.NoError(ts.T(), err)
 }
 
@@ -582,7 +580,7 @@ func (ts *IntegrationTests) TestConfigureIndexIllegalNoPodsOrReplicasOrDeletionP
 		log.Fatalf("Error creating index %s: %v", name, err)
 	}
 
-	_, err = ts.client.ConfigureIndex(context.Background(), name, ConfigureIndexParams{})
+	_, err = ts.client.ConfigureIndex(context.Background(), name, &ConfigureIndexParams{})
 	require.ErrorContainsf(ts.T(), err, "must specify either PodType, Replicas, or DeletionProtection", err.Error())
 }
 
@@ -605,7 +603,7 @@ func (ts *IntegrationTests) TestConfigureIndexHitPodLimit() {
 		log.Fatalf("Error creating index %s: %v", name, err)
 	}
 
-	_, err = ts.client.ConfigureIndex(context.Background(), name, ConfigureIndexParams{Replicas: 30000})
+	_, err = ts.client.ConfigureIndex(context.Background(), name, &ConfigureIndexParams{Replicas: 30000})
 	require.ErrorContainsf(ts.T(), err, "You've reached the max pods allowed", err.Error())
 }
 

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -428,6 +428,8 @@ func (ts *IntegrationTests) TestCreateCollection() {
 		Name:   name,
 		Source: sourceIndex,
 	})
+	fmt.Printf("TestCreateCollection err: %+v\n", err)
+
 	require.NoError(ts.T(), err)
 	require.Equal(ts.T(), name, collection.Name, "Collection name does not match")
 }
@@ -441,6 +443,8 @@ func (ts *IntegrationTests) TestDeleteCollection() {
 		Name:   collectionName,
 		Source: ts.idxName,
 	})
+	fmt.Printf("TestDeleteCollection err: %+v\n", err)
+
 	require.NoError(ts.T(), err)
 
 	err = ts.client.DeleteCollection(context.Background(), collectionName)

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -24,7 +24,50 @@ import (
 )
 
 // Integration tests:
+<<<<<<< HEAD
 func (ts *IntegrationTests) TestNewClientParamsSet() {
+=======
+type ClientTestsIntegration struct {
+	suite.Suite
+	client          Client
+	clientSourceTag Client
+	sourceTag       string
+	podIndex        string
+	serverlessIndex string
+}
+
+func TestIntegrationClient(t *testing.T) {
+	suite.Run(t, new(ClientTestsIntegration))
+}
+
+func (ts *ClientTestsIntegration) SetupSuite() {
+	apiKey := os.Getenv("PINECONE_API_KEY")
+	require.NotEmpty(ts.T(), apiKey, "PINECONE_API_KEY env variable not set")
+
+	ts.podIndex = os.Getenv("STATIC_TEST_PODS_INDEX_NAME")
+	require.NotEmpty(ts.T(), ts.podIndex, "STATIC_TEST_PODS_INDEX_NAME env variable not set")
+
+	ts.serverlessIndex = os.Getenv("STATIC_TEST_SERVERLESS_INDEX_NAME")
+	require.NotEmpty(ts.T(), ts.serverlessIndex, "TEST_SERVERLESS_INDEX_NAME env variable not set")
+
+	client, err := NewClient(NewClientParams{})
+	require.NoError(ts.T(), err)
+
+	ts.client = *client
+
+	ts.sourceTag = "test_source_tag"
+	clientSourceTag, err := NewClient(NewClientParams{ApiKey: apiKey, SourceTag: ts.sourceTag})
+	require.NoError(ts.T(), err)
+	ts.clientSourceTag = *clientSourceTag
+
+	// this will clean up the project deleting all indexes and collections that are
+	// named a UUID. Generally not needed as all tests are cleaning up after themselves
+	// Left here as a convenience during active development.
+	//deleteUUIDNamedResources(context.Background(), &ts.client)
+}
+
+func (ts *ClientTestsIntegration) TestNewClientParamsSet() {
+>>>>>>> 2e391eb (update the other one this time)
 	apiKey := "test-api-key"
 	client, err := NewClient(NewClientParams{ApiKey: apiKey})
 

--- a/pinecone/models.go
+++ b/pinecone/models.go
@@ -1,7 +1,6 @@
 package pinecone
 
 import (
-	"github.com/pinecone-io/go-pinecone/internal/gen/control"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -66,13 +65,13 @@ type IndexSpec struct {
 
 // Index is a Pinecone Index object. Can be either a pod-based or a serverless Index, depending on the IndexSpec.
 type Index struct {
-	Name               string                     `json:"name"`
-	Dimension          int32                      `json:"dimension"`
-	Host               string                     `json:"host"`
-	Metric             IndexMetric                `json:"metric"`
-	DeletionProtection control.DeletionProtection `json:"deletion_protection,omitempty"`
-	Spec               *IndexSpec                 `json:"spec,omitempty"`
-	Status             *IndexStatus               `json:"status,omitempty"`
+	Name               string             `json:"name"`
+	Dimension          int32              `json:"dimension"`
+	Host               string             `json:"host"`
+	Metric             IndexMetric        `json:"metric"`
+	DeletionProtection DeletionProtection `json:"deletion_protection,omitempty"`
+	Spec               *IndexSpec         `json:"spec,omitempty"`
+	Status             *IndexStatus       `json:"status,omitempty"`
 }
 
 // Collection is a Pinecone [Collection object]. Only available for pod-based Indexes.

--- a/pinecone/models.go
+++ b/pinecone/models.go
@@ -30,6 +30,17 @@ const (
 	Terminating          IndexStatusState = "Terminating"
 )
 
+// DeletionProtection determines whether [deletion protection] is "enabled" or "disabled" for the index.
+// When "enabled", the index cannot be deleted. Defaults to "disabled".
+//
+// [deletion protection]: http://docs.pinecone.io/guides/indexes/prevent-index-deletion
+type DeletionProtection string
+
+const (
+	DeletionProtectionEnabled  DeletionProtection = "Enabled"
+	DeletionProtectionDisabled DeletionProtection = "Disabled"
+)
+
 // Cloud is the [cloud provider] to be used for a Pinecone serverless Index.
 //
 // [cloud provider]: https://docs.pinecone.io/troubleshooting/available-cloud-regions

--- a/pinecone/models.go
+++ b/pinecone/models.go
@@ -1,6 +1,9 @@
 package pinecone
 
-import "google.golang.org/protobuf/types/known/structpb"
+import (
+	"github.com/pinecone-io/go-pinecone/internal/gen/control"
+	"google.golang.org/protobuf/types/known/structpb"
+)
 
 // IndexMetric is the [distance metric] to be used by similarity search against a Pinecone Index.
 //
@@ -52,12 +55,13 @@ type IndexSpec struct {
 
 // Index is a Pinecone Index object. Can be either a pod-based or a serverless Index, depending on the IndexSpec.
 type Index struct {
-	Name      string       `json:"name"`
-	Dimension int32        `json:"dimension"`
-	Host      string       `json:"host"`
-	Metric    IndexMetric  `json:"metric"`
-	Spec      *IndexSpec   `json:"spec,omitempty"`
-	Status    *IndexStatus `json:"status,omitempty"`
+	Name               string                     `json:"name"`
+	Dimension          int32                      `json:"dimension"`
+	Host               string                     `json:"host"`
+	Metric             IndexMetric                `json:"metric"`
+	DeletionProtection control.DeletionProtection `json:"deletion_protection,omitempty"`
+	Spec               *IndexSpec                 `json:"spec,omitempty"`
+	Status             *IndexStatus               `json:"status,omitempty"`
 }
 
 // Collection is a Pinecone [Collection object]. Only available for pod-based Indexes.

--- a/pinecone/models.go
+++ b/pinecone/models.go
@@ -36,8 +36,8 @@ const (
 type DeletionProtection string
 
 const (
-	DeletionProtectionEnabled  DeletionProtection = "Enabled"
-	DeletionProtectionDisabled DeletionProtection = "Disabled"
+	DeletionProtectionEnabled  DeletionProtection = "enabled"
+	DeletionProtectionDisabled DeletionProtection = "disabled"
 )
 
 // Cloud is the [cloud provider] to be used for a Pinecone serverless Index.


### PR DESCRIPTION
## Problem
Our other SDKs support the deletion protection feature with the latest major releases tied to the `2024-07` API version. We need to implement deletion protection in the Go SDK.

## Solution
- Add new `DeletionProtection` enum type to `models.go`.
- Update `CreatePodIndexRequest`, `CreateServerlessIndexRequest`, and `Index` to include `DeletionProtection`.
- Update `ConfigureIndex` to support a `ConfigureIndexParams` struct argument. This aligns more closely with our other SDKs, and makes it easier to pass configurations of arguments without needing to explicitly pass `nil`.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
Test serverless and pod creation functions to make sure `DeletionProtection` defaults to `disabled`, and vice versa when provided. Test `ConfigureIndex` to make sure configuring an index without passing `DeletionProtection` doesn't override things.
