### PR TITLE
Add `Host` normalization when building `IndexConnection`

### DIFF
--- a/pinecone/index_connection.go
+++ b/pinecone/index_connection.go
@@ -1098,12 +1098,18 @@ func sparseValToGrpc(sv *SparseValues) *data.SparseValues {
 }
 
 func normalizeHost(host string) string {
-	// remove http:// or https:// from the host
-	host = strings.TrimPrefix(host, "http://")
+	hasPort := strings.Contains(host, ":")
+
+	// remove https:// from the host
 	host = strings.TrimPrefix(host, "https://")
 
+	// if plaintext without a port, strip http:// as well
+	if !hasPort {
+		host = strings.TrimPrefix(host, "http://")
+	}
+
 	// if a port was provided leave it, otherwise we append :443
-	if !strings.Contains(host, ":") {
+	if !hasPort {
 		host = host + ":443"
 	}
 

--- a/pinecone/index_connection.go
+++ b/pinecone/index_connection.go
@@ -3,6 +3,7 @@ package pinecone
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"log"
 	"net/url"
 	"strings"

--- a/pinecone/index_connection.go
+++ b/pinecone/index_connection.go
@@ -45,7 +45,8 @@ func newIndexConnection(in newIndexParameters, dialOpts ...grpc.DialOption) (*In
 	}
 
 	// if the target includes an http:// address, don't include TLS
-	if strings.HasPrefix(target, "http://") {
+	// otherwise we need to add transport credentials
+	if !strings.HasPrefix(target, "http://") {
 		config := &tls.Config{}
 		grpcOptions = append(grpcOptions, grpc.WithTransportCredentials(credentials.NewTLS(config)))
 	}

--- a/pinecone/index_connection_test.go
+++ b/pinecone/index_connection_test.go
@@ -1006,13 +1006,13 @@ func TestNormalizeHostUnit(t *testing.T) {
 		expectedHost string
 	}{
 		{
-			name:         "http:// scheme should be removed",
-			host:         "http://this-is-my-host.io",
-			expectedHost: "this-is-my-host.io:443",
-		}, {
 			name:         "https:// scheme should be removed",
 			host:         "https://this-is-my-host.io",
 			expectedHost: "this-is-my-host.io:443",
+		}, {
+			name:         "https:// scheme with a port should be removed",
+			host:         "https://this-is-my-host.io:33445",
+			expectedHost: "this-is-my-host.io:33445",
 		}, {
 			name:         "http:// scheme without a port should be removed",
 			host:         "http://this-is-my-host.io",

--- a/pinecone/index_connection_test.go
+++ b/pinecone/index_connection_test.go
@@ -999,6 +999,35 @@ func TestToUsageUnit(t *testing.T) {
 	}
 }
 
+func TestNormalizeHost(t *testing.T) {
+	tests := []struct {
+		name         string
+		host         string
+		expectedHost string
+	}{
+		{
+			name:         "http:// scheme should be removed",
+			host:         "http://this-is-my-host.io",
+			expectedHost: "this-is-my-host.io:443",
+		}, {
+			name:         "https:// scheme should be removed",
+			host:         "https://this-is-my-host.io",
+			expectedHost: "this-is-my-host.io:443",
+		}, {
+			name:         "port should be maintained",
+			host:         "https://this-is-my-host.io:8080",
+			expectedHost: "this-is-my-host.io:8080",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeHost(tt.host)
+			assert.Equal(t, tt.expectedHost, result, "Expected result to be '%s', but got '%s'", tt.expectedHost, result)
+		})
+	}
+}
+
 func TestToPaginationToken(t *testing.T) {
 	tokenForNilCase := ""
 	tokenForPositiveCase := "next-token"

--- a/pinecone/index_connection_test.go
+++ b/pinecone/index_connection_test.go
@@ -999,7 +999,7 @@ func TestToUsageUnit(t *testing.T) {
 	}
 }
 
-func TestNormalizeHost(t *testing.T) {
+func TestNormalizeHostUnit(t *testing.T) {
 	tests := []struct {
 		name         string
 		host         string

--- a/pinecone/index_connection_test.go
+++ b/pinecone/index_connection_test.go
@@ -1014,9 +1014,13 @@ func TestNormalizeHost(t *testing.T) {
 			host:         "https://this-is-my-host.io",
 			expectedHost: "this-is-my-host.io:443",
 		}, {
-			name:         "port should be maintained",
-			host:         "https://this-is-my-host.io:8080",
-			expectedHost: "this-is-my-host.io:8080",
+			name:         "http:// scheme without a port should be removed",
+			host:         "http://this-is-my-host.io",
+			expectedHost: "this-is-my-host.io:443",
+		}, {
+			name:         "http:// scheme and port should be maintained",
+			host:         "http://this-is-my-host.io:8080",
+			expectedHost: "http://this-is-my-host.io:8080",
 		},
 	}
 


### PR DESCRIPTION
## Problem
We had an issue that was logged around trying to call `Client.Index()` with a `Host` value including an `http://` or `https://` schema. The control plane does not attach these schemes, but when building an `IndexConnection` a user needs to provide a host and they could make this mistake. `grpc-go` is not expecting a `target` in `NewClient` that includes a scheme.

We could do a bit of normalization to handle the `Host` more thoroughly.

## Solution
- Add `normalizeHost` helper function in `index_connection.go`. This strips out `http://` & `https://` prefixes, and attaches the port `:443` unless the user has provided one directly. We want to leave some flexibility for making RPCs in specific scenarios.
- Add unit tests for `normalizeHost`.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
CI unit & integration tests should pass as normal.

To test manually, you can try and prepend schemes to the Host when calling `client.Index()`

```Go
indexConn, err := client.Index(pinecone.NewIndexConnParams{Host: fmt.Sprintf("https://%s", index.Host)})
if err != nil {
    panic(err)
}

stats, err := indexConn.DescribeIndexStats(context.Background())
```
