### PR TITLE
Auto-adding needs-triage label to all new issues

### DIFF
--- a/.github/workflows/add-labels
+++ b/.github/workflows/add-labels
@@ -1,0 +1,18 @@
+name: Label issues
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - run: gh issue edit "$NUMBER" --add-label "$LABELS"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          LABELS: status:needs-triage


### PR DESCRIPTION
## Problem

Describe the purpose of this change. What problem is being solved and why?
Adding a new needs-triage label to all new issues in the repo as a part of our new triage process

## Solution

Describe the approach you took. Link to any relevant bugs, issues, docs, or other resources.
Created a new workflow

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.
Gonna create a test issue and see
