### PR TITLE
Address bug bash feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,7 +722,7 @@ func main() {
 	}
 
 	vectorId := "vector-id"
-	res, err := idxConnection.QueryByVectorId(ctx, &pinecone. & pinecone.QueryByVectorIdRequest{
+	res, err := idxConnection.QueryByVectorId(ctx, &pinecone.QueryByVectorIdRequest{
 		VectorId:      vectorId,
 		TopK:          3,
 		IncludeValues: true,
@@ -730,7 +730,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error encountered when querying by vector ID `%v`: %v", vectorId, err)
 	} else {
-		fmt.Printf(prettifyStruct(res))
+		fmt.Printf(prettifyStruct(res.Matches))
 	}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -430,7 +430,13 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to describe index \"%s\". Error:%s", idx.Name, err)
 	} else {
-		fmt.Printf("Successfully found the \"%s\" index!\n", idx.Name)
+		desc := fmt.Sprintf("Description: \n  Name: %s\n  Dimension: %d\n  Host: %s\n  Metric: %s\n"+
+			"  DeletionProtection"+
+			": %s\n"+
+			"  Spec: %+v"+
+			"\n  Status: %+v\n",
+			idx.Name, idx.Dimension, idx.Host, idx.Metric, idx.DeletionProtection, idx.Spec, idx.Status)
+		fmt.Println(desc)
 	}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -150,20 +150,8 @@ func main() {
 
 	indexName := "my-serverless-index"
 
-	indexes, err := pc.ListIndexes(ctx)
-	if err != nil {
-		log.Fatalf("Failed to list indexes: %v", err)
-	}
-
-	for _, idx := range indexes {
-		if idx.Name == indexName {
-			fmt.Printf("Index \"%s\" already exists\n", indexName)
-			return
-		}
-	}
-
 	idx, err := pc.CreateServerlessIndex(ctx, &pinecone.CreateServerlessIndexRequest{
-		Name:      &indexName,
+		Name:      indexName,
 		Dimension: 3,
 		Metric:    pinecone.Cosine,
 		Cloud:     pinecone.Aws,
@@ -171,7 +159,7 @@ func main() {
 	})
 
 	if err != nil {
-		log.Fatalf("Failed to create serverless index: %s", idx.Name)
+		log.Fatalf("Failed to create serverless index: %s", indexName)
 	} else {
 		fmt.Printf("Successfully created serverless index: %s", idx.Name)
 	}
@@ -214,20 +202,8 @@ func main() {
 		Indexed: &[]string{"title", "description"},
 	}
 
-	indexes, err := pc.ListIndexes(ctx)
-	if err != nil {
-		log.Fatalf("Failed to list indexes: %v", err)
-	}
-
-	for _, idx := range indexes {
-		if idx.Name == indexName {
-			fmt.Printf("Index \"%s\" already exists\n", indexName)
-			return
-		}
-	}
-
 	idx, err := pc.CreatePodIndex(ctx, &pinecone.CreatePodIndexRequest{
-		Name:           &indexName,
+		Name:           indexName,
 		Dimension:      3,
 		Metric:         pinecone.Cosine,
 		Environment:    "us-west1-gcp",

--- a/README.md
+++ b/README.md
@@ -370,25 +370,25 @@ func main() {
 	}
 
 	// To scale the size of your pods-based index from "x2" to "x4":
-	_, err := pc.ConfigureIndex(ctx, "my-pod-index", &ConfigureIndexParams{PodType: "p1.x4"})
+	_, err := pc.ConfigureIndex(ctx, "my-pod-index", pinecone.ConfigureIndexParams{PodType: "p1.x4"})
 	if err != nil {
 		fmt.Printf("Failed to configure index: %v\n", err)
 	}
 
 	// To scale the number of replicas to 4:
-	_, err := pc.ConfigureIndex(ctx, "my-pod-index", &ConfigureIndexParams{Replicas: 4})
+	_, err := pc.ConfigureIndex(ctx, "my-pod-index", pinecone.ConfigureIndexParams{Replicas: 4})
 	if err != nil {
 		fmt.Printf("Failed to configure index: %v\n", err)
 	}
 
 	// To scale both the size of your pods and the number of replicas:
-	_, err := pc.ConfigureIndex(ctx, "my-pod-index", &ConfigureIndexParams{PodType: "p1.x4", Replicas: 4})
+	_, err := pc.ConfigureIndex(ctx, "my-pod-index", pinecone.ConfigureIndexParams{PodType: "p1.x4", Replicas: 4})
 	if err != nil {
 		fmt.Printf("Failed to configure index: %v\n", err)
 	}
 
 	// To enable deletion protection:
-	_, err := pc.ConfigureIndex(ctx, "my-index", &ConfigureIndexParams{DeletionProtection: "enabled"})
+	_, err := pc.ConfigureIndex(ctx, "my-index", pinecone.ConfigureIndexParams{DeletionProtection: "enabled"})
 	if err != nil {
 		fmt.Printf("Failed to configure index: %v\n", err)
 	}

--- a/README.md
+++ b/README.md
@@ -606,10 +606,10 @@ func main() {
 	}
 
 	res, err := idxConnection.QueryByVectorValues(ctx, &pinecone.QueryByVectorValuesRequest{
-		Vector:        queryVector,
-		TopK:          3,
-		Filter:        metadataFilter,
-		IncludeValues: true,
+		Vector:         queryVector,
+		TopK:           3,
+		MetadataFilter: metadataFilter,
+		IncludeValues:  true,
 	})
 	if err != nil {
 		log.Fatalf("Error encountered when querying by vector: %v", err)

--- a/README.md
+++ b/README.md
@@ -483,7 +483,9 @@ func main() {
 
 ### Upsert vectors
 
-The following example upserts vectors to `example-index`.
+The following example upserts
+vectors ([both dense and sparse](https://docs.pinecone.io/guides/data/upsert-sparse-dense-vectors)) and metadata
+to `example-index`.
 
 ```go
 package main
@@ -492,6 +494,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/pinecone-io/go-pinecone/pinecone"
+	"google.golang.org/protobuf/types/known/structpb"
 	"log"
 	"os"
 )
@@ -520,22 +523,41 @@ func main() {
 		log.Fatalf("Failed to create IndexConnection for Host: %v: %v", idx.Host, err)
 	}
 
+	metadataMap := map[string]interface{}{
+		"genre": "classical",
+	}
+
+	metadata, err := structpb.NewStruct(metadataMap)
+
+	sparseValues := pinecone.SparseValues{
+		Indices: []uint32{0, 1, 2, 3, 4, 5, 6, 7},
+		Values:  []float32{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0},
+	}
+
 	vectors := []*pinecone.Vector{
 		{
-			Id:     "A",
-			Values: []float32{0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1},
+			Id:           "A",
+			Values:       []float32{0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1},
+			Metadata:     metadata,
+			SparseValues: &sparseValues,
 		},
 		{
-			Id:     "B",
-			Values: []float32{0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2},
+			Id:           "B",
+			Values:       []float32{0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2},
+			Metadata:     metadata,
+			SparseValues: &sparseValues,
 		},
 		{
-			Id:     "C",
-			Values: []float32{0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3},
+			Id:           "C",
+			Values:       []float32{0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3},
+			Metadata:     metadata,
+			SparseValues: &sparseValues,
 		},
 		{
-			Id:     "D",
-			Values: []float32{0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4},
+			Id:           "D",
+			Values:       []float32{0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4},
+			Metadata:     metadata,
+			SparseValues: &sparseValues,
 		},
 	}
 
@@ -552,7 +574,10 @@ func main() {
 
 #### Query by vector values
 
-The following example queries the index `example-index` with vector values and metadata filtering.
+The following example queries the index `example-index` with vector values and metadata filtering. Note: you can
+also query by sparse values;
+see [sparse-dense documentation](https://docs.pinecone.io/guides/data/query-sparse-dense-vectors)
+for examples.
 
 ```go
 package main
@@ -562,6 +587,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/pinecone-io/go-pinecone/pinecone"
+	"google.golang.org/protobuf/types/known/structpb"
 	"log"
 	"os"
 )
@@ -797,6 +823,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/pinecone-io/go-pinecone/pinecone"
+	"google.golang.org/protobuf/types/known/structpb"
 	"log"
 	"os"
 )

--- a/README.md
+++ b/README.md
@@ -148,8 +148,22 @@ func main() {
 		fmt.Println("Successfully created a new Client object!")
 	}
 
+	indexName := "my-serverless-index"
+
+	indexes, err := pc.ListIndexes(ctx)
+	if err != nil {
+		log.Fatalf("Failed to list indexes: %v", err)
+	}
+
+	for _, idx := range indexes {
+		if idx.Name == indexName {
+			fmt.Printf("Index \"%s\" already exists\n", indexName)
+			return
+		}
+	}
+
 	idx, err := pc.CreateServerlessIndex(ctx, &pinecone.CreateServerlessIndexRequest{
-		Name:      "my-serverless-index",
+		Name:      &indexName,
 		Dimension: 3,
 		Metric:    pinecone.Cosine,
 		Cloud:     pinecone.Aws,
@@ -194,12 +208,26 @@ func main() {
 		fmt.Println("Successfully created a new Client object!")
 	}
 
+	indexName := "my-pod-index"
+
 	podIndexMetadata := &pinecone.PodSpecMetadataConfig{
 		Indexed: &[]string{"title", "description"},
 	}
 
+	indexes, err := pc.ListIndexes(ctx)
+	if err != nil {
+		log.Fatalf("Failed to list indexes: %v", err)
+	}
+
+	for _, idx := range indexes {
+		if idx.Name == indexName {
+			fmt.Printf("Index \"%s\" already exists\n", indexName)
+			return
+		}
+	}
+
 	idx, err := pc.CreatePodIndex(ctx, &pinecone.CreatePodIndexRequest{
-		Name:           "my-pod-index",
+		Name:           &indexName,
 		Dimension:      3,
 		Metric:         pinecone.Cosine,
 		Environment:    "us-west1-gcp",

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -704,7 +704,14 @@ func (c *Client) CreateServerlessIndex(ctx context.Context, in *CreateServerless
 //	    if err != nil {
 //	        log.Fatalf("Failed to describe index: %s", err)
 //	    } else {
-//	        fmt.Printf("%+v", *idx)
+//	        desc := fmt.Sprintf("Description: \n  Name: %s\n  Dimension: %d\n  Host: %s\n  Metric: %s\n"+
+//			"  DeletionProtection"+
+//			": %s\n"+
+//			"  Spec: %+v"+
+//			"\n  Status: %+v\n",
+//			idx.Name, idx.Dimension, idx.Host, idx.Metric, idx.DeletionProtection, idx.Spec, idx.Status)
+//
+//		    fmt.Println(desc)
 //	    }
 func (c *Client) DescribeIndex(ctx context.Context, idxName string) (*Index, error) {
 	res, err := c.restClient.DescribeIndex(ctx, idxName)

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -799,7 +799,7 @@ func (c *Client) DeleteIndex(ctx context.Context, idxName string) error {
 //		       fmt.Println("Successfully created a new Client object!")
 //	    }
 //
-//	    idx, err := pc.ConfigureIndex(ctx, "my-index", &ConfigureIndexParams{ DeletionProtection: "enabled", Replicas: 4 })
+//	    idx, err := pc.ConfigureIndex(ctx, "my-index", ConfigureIndexParams{ DeletionProtection: "enabled", Replicas: 4 })
 //
 // [app.pinecone.io]: https://app.pinecone.io
 // [scale a pods-based index]: https://docs.pinecone.io/guides/indexes/configure-pod-based-indexes
@@ -827,25 +827,25 @@ type ConfigureIndexParams struct {
 // Example:
 //
 //		// To scale the size of your pods-based index from "x2" to "x4":
-//		 _, err := pc.ConfigureIndex(ctx, "my-pod-index", &ConfigureIndexParams{PodType: "p1.x4"})
+//		 _, err := pc.ConfigureIndex(ctx, "my-pod-index", ConfigureIndexParams{PodType: "p1.x4"})
 //		 if err != nil {
 //		     fmt.Printf("Failed to configure index: %v\n", err)
 //		 }
 //
 //		// To scale the number of replicas:
-//		 _, err := pc.ConfigureIndex(ctx, "my-pod-index", &ConfigureIndexParams{Replicas: 4})
+//		 _, err := pc.ConfigureIndex(ctx, "my-pod-index", ConfigureIndexParams{Replicas: 4})
 //		 if err != nil {
 //		     fmt.Printf("Failed to configure index: %v\n", err)
 //		 }
 //
 //		// To scale both the size of your pods and the number of replicas to 4:
-//		 _, err := pc.ConfigureIndex(ctx, "my-pod-index", &ConfigureIndexParams{PodType: "p1.x4", Replicas: 4})
+//		 _, err := pc.ConfigureIndex(ctx, "my-pod-index", ConfigureIndexParams{PodType: "p1.x4", Replicas: 4})
 //		 if err != nil {
 //		     fmt.Printf("Failed to configure index: %v\n", err)
 //		 }
 //
 //	    // To enable deletion protection:
-//		 _, err := pc.ConfigureIndex(ctx, "my-index", &ConfigureIndexParams{DeletionProtection: "enabled"})
+//		 _, err := pc.ConfigureIndex(ctx, "my-index", ConfigureIndexParams{DeletionProtection: "enabled"})
 //		 if err != nil {
 //		     fmt.Printf("Failed to configure index: %v\n", err)
 //		 }

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -576,21 +576,21 @@ func (c *Client) CreatePodIndex(ctx context.Context, in *CreatePodIndexRequest) 
 //
 // Example:
 //
-//	    ctx := context.Background()
+//		    ctx := context.Background()
 //
-//	    clientParams := pinecone.NewClientParams{
-//		       ApiKey:    "YOUR_API_KEY",
-//			   SourceTag: "your_source_identifier", // optional
-//	    }
+//		    clientParams := pinecone.NewClientParams{
+//			       ApiKey:    "YOUR_API_KEY",
+//				   SourceTag: "your_source_identifier", // optional
+//		    }
 //
-//		   pc, err := pinecone.NewClient(clientParams)
-//		   if err != nil {
+//	    pc, err := pinecone.NewClient(clientParams)
+//	    if err != nil {
 //		       log.Fatalf("Failed to create Client: %v", err)
 //		   } else {
 //		       fmt.Println("Successfully created a new Client object!")
 //		   }
 //
-//		   indexName := "my-serverless-index"
+//	    indexName := "my-serverless-index"
 //
 //		   idx, err := pc.CreateServerlessIndex(ctx, &pinecone.CreateServerlessIndexRequest{
 //		       Name:      indexName,
@@ -598,9 +598,9 @@ func (c *Client) CreatePodIndex(ctx context.Context, in *CreatePodIndexRequest) 
 //			   Metric:  pinecone.Cosine,
 //			   Cloud:   pinecone.Aws,
 //			   Region:  "us-east-1",
-//		   })
+//	    })
 //
-//		   if err != nil {
+//	    if err != nil {
 //		       log.Fatalf("Failed to create serverless index: %s", indexName)
 //		   } else {
 //		       fmt.Printf("Successfully created serverless index: %s", idx.Name)

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -414,20 +414,8 @@ func (c *Client) ListIndexes(ctx context.Context) ([]*Index, error) {
 //
 //	    indexName := "my-pod-index"
 //
-//		indexes, err := pc.ListIndexes(ctx)
-//			if err != nil {
-//				log.Fatalf("Failed to list indexes: %v", err)
-//		}
-//
-//		for _, idx := range indexes {
-//			if idx.Name == indexName {
-//				fmt.Printf("Index \"%s\" already exists\n", indexName)
-//				return
-//			}
-//		}
-//
 //	    idx, err := pc.CreatePodIndex(ctx, &pinecone.CreatePodIndexRequest{
-//	        Name:        &indexName,
+//	        Name:        indexName,
 //	        Dimension:   3,
 //	        Metric:      pinecone.Cosine,
 //	        Environment: "us-west1-gcp",
@@ -509,20 +497,8 @@ func (req CreatePodIndexRequest) TotalCount() int {
 //
 //	    indexName := "my-pod-index"
 //
-//		indexes, err := pc.ListIndexes(ctx)
-//			if err != nil {
-//				log.Fatalf("Failed to list indexes: %v", err)
-//		}
-//
-//		for _, idx := range indexes {
-//			if idx.Name == indexName {
-//				fmt.Printf("Index \"%s\" already exists\n", indexName)
-//				return
-//			}
-//		}
-//
 //		idx, err := pc.CreatePodIndex(ctx, &pinecone.CreatePodIndexRequest{
-//		    Name:        &indexName,
+//		    Name:        indexName,
 //		    Dimension:   3,
 //		    Metric:      pinecone.Cosine,
 //		    Environment: "us-west1-gcp",
@@ -600,47 +576,36 @@ func (c *Client) CreatePodIndex(ctx context.Context, in *CreatePodIndexRequest) 
 //
 // Example:
 //
-//		    ctx := context.Background()
+//			ctx := context.Background()
 //
-//		    clientParams := pinecone.NewClientParams{
-//			       ApiKey:    "YOUR_API_KEY",
-//			       SourceTag: "your_source_identifier", // optional
-//		    }
+//
+//			clientParams := pinecone.NewClientParams{
+//				   ApiKey:    "YOUR_API_KEY",
+//				   SourceTag: "your_source_identifier", // optional
+//			}
 //
 //		    pc, err := pinecone.NewClient(clientParams)
-//		    if err != nil {
-//		        log.Fatalf("Failed to create Client: %v", err)
-//		    } else {
-//			       fmt.Println("Successfully created a new Client object!")
-//		    }
-//
-//	     indexName := "my-serverless-index"
-//
-//			indexes, err := pc.ListIndexes(ctx)
 //			if err != nil {
-//				log.Fatalf("Failed to list indexes: %v", err)
+//			    log.Fatalf("Failed to create Client: %v", err)
+//			} else {
+//				   fmt.Println("Successfully created a new Client object!")
 //			}
 //
-//			for _, idx := range indexes {
-//				if idx.Name == indexName {
-//					fmt.Printf("Index \"%s\" already exists\n", indexName)
-//					return
-//				}
+//	    indexName := "my-serverless-index"
+//
+//	    idx, err := pc.CreateServerlessIndex(ctx, &pinecone.CreateServerlessIndexRequest{
+//		       Name:      indexName,
+//			   Dimension: 3,
+//			   Metric:  pinecone.Cosine,
+//			   Cloud:   pinecone.Aws,
+//			   Region:  "us-east-1",
+//			})
+//
+//			if err != nil {
+//			    log.Fatalf("Failed to create serverless index: %s", indexName)
+//			} else {
+//			    fmt.Printf("Successfully created serverless index: %s", idx.Name)
 //			}
-//
-//		    idx, err := pc.CreateServerlessIndex(ctx, &pinecone.CreateServerlessIndexRequest{
-//		        Name:      &indexName,
-//		        Dimension: 3,
-//		        Metric:  pinecone.Cosine,
-//		        Cloud:   pinecone.Aws,
-//		        Region:  "us-east-1",
-//		    })
-//
-//		    if err != nil {
-//		        log.Fatalf("Failed to create serverless index: %s", idx.Name)
-//		    } else {
-//		        fmt.Printf("Successfully created serverless index: %s", idx.Name)
-//		    }
 //
 // [dimensionality]: https://docs.pinecone.io/guides/indexes/choose-a-pod-type-and-size#dimensionality-of-vectors
 // [Serverless]: https://docs.pinecone.io/guides/indexes/understanding-indexes#serverless-indexes
@@ -684,20 +649,8 @@ type CreateServerlessIndexRequest struct {
 //
 //	    indexName := "my-serverless-index"
 //
-//		indexes, err := pc.ListIndexes(ctx)
-//		if err != nil {
-//			log.Fatalf("Failed to list indexes: %v", err)
-//		}
-//
-//		for _, idx := range indexes {
-//			if idx.Name == indexName {
-//				fmt.Printf("Index \"%s\" already exists\n", indexName)
-//				return
-//			}
-//		}
-//
 //	    idx, err := pc.CreateServerlessIndex(ctx, &pinecone.CreateServerlessIndexRequest{
-//		    Name:    &indexName,
+//		    Name:    indexName,
 //		    Dimension: 3,
 //		    Metric:  pinecone.Cosine,
 //		    Cloud:   pinecone.Aws,
@@ -705,7 +658,7 @@ type CreateServerlessIndexRequest struct {
 //		})
 //
 //		if err != nil {
-//		    log.Fatalf("Failed to create serverless index: %s", idx.Name)
+//		    log.Fatalf("Failed to create serverless index: %s", indexName)
 //		} else {
 //		    fmt.Printf("Successfully created serverless index: %s", idx.Name)
 //		}

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -408,8 +408,22 @@ func (c *Client) ListIndexes(ctx context.Context) ([]*Index, error) {
 //		       Indexed: &[]string{"title", "description"},
 //	    }
 //
+//	    indexName := "my-pod-index"
+//
+//		indexes, err := pc.ListIndexes(ctx)
+//			if err != nil {
+//				log.Fatalf("Failed to list indexes: %v", err)
+//		}
+//
+//		for _, idx := range indexes {
+//			if idx.Name == indexName {
+//				fmt.Printf("Index \"%s\" already exists\n", indexName)
+//				return
+//			}
+//		}
+//
 //	    idx, err := pc.CreatePodIndex(ctx, &pinecone.CreatePodIndexRequest{
-//	        Name:        "my-pod-index",
+//	        Name:        &indexName,
 //	        Dimension:   3,
 //	        Metric:      pinecone.Cosine,
 //	        Environment: "us-west1-gcp",
@@ -489,20 +503,34 @@ func (req CreatePodIndexRequest) TotalCount() int {
 //		       Indexed: &[]string{"title", "description"},
 //	    }
 //
-//	    idx, err := pc.CreatePodIndex(ctx, &pinecone.CreatePodIndexRequest{
-//	        Name:        "my-pod-index",
-//	        Dimension:   3,
-//	        Metric:      pinecone.Cosine,
-//	        Environment: "us-west1-gcp",
-//	        PodType:     "s1",
-//	        MetadataConfig: podIndexMetadata,
-//	    })
+//	    indexName := "my-pod-index"
 //
-//	    if err != nil {
-//		       log.Fatalf("Failed to create pod index:", err)
-//	    } else {
-//		       fmt.Printf("Successfully created pod index: %s", idx.Name)
-//	    }
+//		indexes, err := pc.ListIndexes(ctx)
+//			if err != nil {
+//				log.Fatalf("Failed to list indexes: %v", err)
+//		}
+//
+//		for _, idx := range indexes {
+//			if idx.Name == indexName {
+//				fmt.Printf("Index \"%s\" already exists\n", indexName)
+//				return
+//			}
+//		}
+//
+//		idx, err := pc.CreatePodIndex(ctx, &pinecone.CreatePodIndexRequest{
+//		    Name:        &indexName,
+//		    Dimension:   3,
+//		    Metric:      pinecone.Cosine,
+//		    Environment: "us-west1-gcp",
+//		    PodType:     "s1",
+//		    MetadataConfig: podIndexMetadata,
+//		})
+//
+//		if err != nil {
+//	    	log.Fatalf("Failed to create pod index:", err)
+//		} else {
+//			   fmt.Printf("Successfully created pod index: %s", idx.Name)
+//		}
 func (c *Client) CreatePodIndex(ctx context.Context, in *CreatePodIndexRequest) (*Index, error) {
 	deletionProtection := pointerOrNil(control.DeletionProtection(in.DeletionProtection))
 	metric := pointerOrNil(control.CreateIndexRequestMetric(in.Metric))
@@ -564,33 +592,47 @@ func (c *Client) CreatePodIndex(ctx context.Context, in *CreatePodIndexRequest) 
 //
 // Example:
 //
-//	    ctx := context.Background()
+//		    ctx := context.Background()
 //
-//	    clientParams := pinecone.NewClientParams{
-//		       ApiKey:    "YOUR_API_KEY",
-//		       SourceTag: "your_source_identifier", // optional
-//	    }
+//		    clientParams := pinecone.NewClientParams{
+//			       ApiKey:    "YOUR_API_KEY",
+//			       SourceTag: "your_source_identifier", // optional
+//		    }
 //
-//	    pc, err := pinecone.NewClient(clientParams)
-//	    if err != nil {
-//	        log.Fatalf("Failed to create Client: %v", err)
-//	    } else {
-//		       fmt.Println("Successfully created a new Client object!")
-//	    }
+//		    pc, err := pinecone.NewClient(clientParams)
+//		    if err != nil {
+//		        log.Fatalf("Failed to create Client: %v", err)
+//		    } else {
+//			       fmt.Println("Successfully created a new Client object!")
+//		    }
 //
-//	    idx, err := pc.CreateServerlessIndex(ctx, &pinecone.CreateServerlessIndexRequest{
-//	        Name:    "my-serverless-index",
-//	        Dimension: 3,
-//	        Metric:  pinecone.Cosine,
-//	        Cloud:   pinecone.Aws,
-//	        Region:  "us-east-1",
-//	    })
+//	     indexName := "my-serverless-index"
 //
-//	    if err != nil {
-//	        log.Fatalf("Failed to create serverless index: %s", idx.Name)
-//	    } else {
-//	        fmt.Printf("Successfully created serverless index: %s", idx.Name)
-//	    }
+//			indexes, err := pc.ListIndexes(ctx)
+//			if err != nil {
+//				log.Fatalf("Failed to list indexes: %v", err)
+//			}
+//
+//			for _, idx := range indexes {
+//				if idx.Name == indexName {
+//					fmt.Printf("Index \"%s\" already exists\n", indexName)
+//					return
+//				}
+//			}
+//
+//		    idx, err := pc.CreateServerlessIndex(ctx, &pinecone.CreateServerlessIndexRequest{
+//		        Name:      &indexName,
+//		        Dimension: 3,
+//		        Metric:  pinecone.Cosine,
+//		        Cloud:   pinecone.Aws,
+//		        Region:  "us-east-1",
+//		    })
+//
+//		    if err != nil {
+//		        log.Fatalf("Failed to create serverless index: %s", idx.Name)
+//		    } else {
+//		        fmt.Printf("Successfully created serverless index: %s", idx.Name)
+//		    }
 //
 // [dimensionality]: https://docs.pinecone.io/guides/indexes/choose-a-pod-type-and-size#dimensionality-of-vectors
 // [Serverless]: https://docs.pinecone.io/guides/indexes/understanding-indexes#serverless-indexes
@@ -632,19 +674,33 @@ type CreateServerlessIndexRequest struct {
 //		       fmt.Println("Successfully created a new Client object!")
 //	    }
 //
-//	    idx, err := pc.CreateServerlessIndex(ctx, &pinecone.CreateServerlessIndexRequest{
-//	        Name:    "my-serverless-index",
-//	        Dimension: 3,
-//	        Metric:  pinecone.Cosine,
-//	        Cloud:   pinecone.Aws,
-//	        Region:  "us-east-1",
-//	    })
+//	    indexName := "my-serverless-index"
 //
-//	    if err != nil {
-//	        log.Fatalf("Failed to create serverless index: %s", idx.Name)
-//	    } else {
-//	        fmt.Printf("Successfully created serverless index: %s", idx.Name)
-//	    }
+//		indexes, err := pc.ListIndexes(ctx)
+//		if err != nil {
+//			log.Fatalf("Failed to list indexes: %v", err)
+//		}
+//
+//		for _, idx := range indexes {
+//			if idx.Name == indexName {
+//				fmt.Printf("Index \"%s\" already exists\n", indexName)
+//				return
+//			}
+//		}
+//
+//	    idx, err := pc.CreateServerlessIndex(ctx, &pinecone.CreateServerlessIndexRequest{
+//		    Name:    &indexName,
+//		    Dimension: 3,
+//		    Metric:  pinecone.Cosine,
+//		    Cloud:   pinecone.Aws,
+//		    Region:  "us-east-1",
+//		})
+//
+//		if err != nil {
+//		    log.Fatalf("Failed to create serverless index: %s", idx.Name)
+//		} else {
+//		    fmt.Printf("Successfully created serverless index: %s", idx.Name)
+//		}
 func (c *Client) CreateServerlessIndex(ctx context.Context, in *CreateServerlessIndexRequest) (*Index, error) {
 	deletionProtection := pointerOrNil(control.DeletionProtection(in.DeletionProtection))
 	metric := pointerOrNil(control.CreateIndexRequestMetric(in.Metric))

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -576,36 +576,35 @@ func (c *Client) CreatePodIndex(ctx context.Context, in *CreatePodIndexRequest) 
 //
 // Example:
 //
-//			ctx := context.Background()
+//	    ctx := context.Background()
 //
+//	    clientParams := pinecone.NewClientParams{
+//		       ApiKey:    "YOUR_API_KEY",
+//			   SourceTag: "your_source_identifier", // optional
+//	    }
 //
-//			clientParams := pinecone.NewClientParams{
-//				   ApiKey:    "YOUR_API_KEY",
-//				   SourceTag: "your_source_identifier", // optional
-//			}
+//		   pc, err := pinecone.NewClient(clientParams)
+//		   if err != nil {
+//		       log.Fatalf("Failed to create Client: %v", err)
+//		   } else {
+//		       fmt.Println("Successfully created a new Client object!")
+//		   }
 //
-//		    pc, err := pinecone.NewClient(clientParams)
-//			if err != nil {
-//			    log.Fatalf("Failed to create Client: %v", err)
-//			} else {
-//				   fmt.Println("Successfully created a new Client object!")
-//			}
+//		   indexName := "my-serverless-index"
 //
-//	    indexName := "my-serverless-index"
-//
-//	    idx, err := pc.CreateServerlessIndex(ctx, &pinecone.CreateServerlessIndexRequest{
+//		   idx, err := pc.CreateServerlessIndex(ctx, &pinecone.CreateServerlessIndexRequest{
 //		       Name:      indexName,
 //			   Dimension: 3,
 //			   Metric:  pinecone.Cosine,
 //			   Cloud:   pinecone.Aws,
 //			   Region:  "us-east-1",
-//			})
+//		   })
 //
-//			if err != nil {
-//			    log.Fatalf("Failed to create serverless index: %s", indexName)
-//			} else {
-//			    fmt.Printf("Successfully created serverless index: %s", idx.Name)
-//			}
+//		   if err != nil {
+//		       log.Fatalf("Failed to create serverless index: %s", indexName)
+//		   } else {
+//		       fmt.Printf("Successfully created serverless index: %s", idx.Name)
+//		   }
 //
 // [dimensionality]: https://docs.pinecone.io/guides/indexes/choose-a-pod-type-and-size#dimensionality-of-vectors
 // [Serverless]: https://docs.pinecone.io/guides/indexes/understanding-indexes#serverless-indexes

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -576,21 +576,21 @@ func (c *Client) CreatePodIndex(ctx context.Context, in *CreatePodIndexRequest) 
 //
 // Example:
 //
-//		    ctx := context.Background()
+//	    ctx := context.Background()
 //
-//		    clientParams := pinecone.NewClientParams{
-//			       ApiKey:    "YOUR_API_KEY",
-//				   SourceTag: "your_source_identifier", // optional
-//		    }
+//		   clientParams := pinecone.NewClientParams{
+//		       ApiKey:    "YOUR_API_KEY",
+//			   SourceTag: "your_source_identifier", // optional
+//	    }
 //
-//	    pc, err := pinecone.NewClient(clientParams)
-//	    if err != nil {
+//		   pc, err := pinecone.NewClient(clientParams)
+//		   if err != nil {
 //		       log.Fatalf("Failed to create Client: %v", err)
 //		   } else {
 //		       fmt.Println("Successfully created a new Client object!")
 //		   }
 //
-//	    indexName := "my-serverless-index"
+//		   indexName := "my-serverless-index"
 //
 //		   idx, err := pc.CreateServerlessIndex(ctx, &pinecone.CreateServerlessIndexRequest{
 //		       Name:      indexName,
@@ -600,7 +600,7 @@ func (c *Client) CreatePodIndex(ctx context.Context, in *CreatePodIndexRequest) 
 //			   Region:  "us-east-1",
 //	    })
 //
-//	    if err != nil {
+//		   if err != nil {
 //		       log.Fatalf("Failed to create serverless index: %s", indexName)
 //		   } else {
 //		       fmt.Printf("Successfully created serverless index: %s", idx.Name)

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -578,33 +578,33 @@ func (c *Client) CreatePodIndex(ctx context.Context, in *CreatePodIndexRequest) 
 //
 //	    ctx := context.Background()
 //
-//		   clientParams := pinecone.NewClientParams{
-//		       ApiKey:    "YOUR_API_KEY",
-//			   SourceTag: "your_source_identifier", // optional
+//		clientParams := pinecone.NewClientParams{
+//		    ApiKey:    "YOUR_API_KEY",
+//			SourceTag: "your_source_identifier", // optional
 //	    }
 //
-//		   pc, err := pinecone.NewClient(clientParams)
-//		   if err != nil {
-//		       log.Fatalf("Failed to create Client: %v", err)
-//		   } else {
-//		       fmt.Println("Successfully created a new Client object!")
-//		   }
+//		pc, err := pinecone.NewClient(clientParams)
+//		if err != nil {
+//		    log.Fatalf("Failed to create Client: %v", err)
+//		} else {
+//		    fmt.Println("Successfully created a new Client object!")
+//		}
 //
-//		   indexName := "my-serverless-index"
+//		indexName := "my-serverless-index"
 //
-//		   idx, err := pc.CreateServerlessIndex(ctx, &pinecone.CreateServerlessIndexRequest{
-//		       Name:      indexName,
-//			   Dimension: 3,
-//			   Metric:  pinecone.Cosine,
-//			   Cloud:   pinecone.Aws,
-//			   Region:  "us-east-1",
+//		idx, err := pc.CreateServerlessIndex(ctx, &pinecone.CreateServerlessIndexRequest{
+//		    Name:      indexName,
+//			Dimension: 3,
+//			Metric:  pinecone.Cosine,
+//			Cloud:   pinecone.Aws,
+//			Region:  "us-east-1",
 //	    })
 //
-//		   if err != nil {
-//		       log.Fatalf("Failed to create serverless index: %s", indexName)
-//		   } else {
-//		       fmt.Printf("Successfully created serverless index: %s", idx.Name)
-//		   }
+//		if err != nil {
+//		    log.Fatalf("Failed to create serverless index: %s", indexName)
+//		} else {
+//		    fmt.Printf("Successfully created serverless index: %s", idx.Name)
+//		}
 //
 // [dimensionality]: https://docs.pinecone.io/guides/indexes/choose-a-pod-type-and-size#dimensionality-of-vectors
 // [Serverless]: https://docs.pinecone.io/guides/indexes/understanding-indexes#serverless-indexes


### PR DESCRIPTION
During a recent [Go Bug Bash](https://www.notion.so/GO-340b612c52e14891b56f30c44e7b4fd1?pvs=4), we received feedback that some code snippets in the README as well as in the doc comments were either incorrect or not as user-friendly as they could be. This PR addresses that feedback (outlined below for clarity): 

1. [Check to see if index exists before creating it](https://app.asana.com/0/1203260648987893/1207937493683809/f) 
--> done for both Serverless and Pods examples in `README` and `client.go`

2. [Make calls to DescribeIndex print out in a more user-friendly way](https://app.asana.com/0/1203260648987893/1207937493683812/f)
-- > Done in both `README` and  `client.go`


3. [ Remove dereference of ConfigureIndex obj from README](https://app.asana.com/0/1203260648987893/1207937493683816/f)


4. [Add sparse values and metadata example(s) to README](https://app.asana.com/0/1203260648987893/1207937493683820/f)
--> Updated Upsert example in README + linked out to sparse-dense documentation for users to see examples of querying by sparse-dense vectors.

5. [Update `Filter` to be `MetadataFilter` in README](https://app.asana.com/0/1203260648987893/1207937493683824/f)

6. [Remove typo in `QueryByVectorId` in README](https://app.asana.com/0/1203260648987893/1207937493683828/f)


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [x] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

CI passes

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207937493683828
  - https://app.asana.com/0/0/1207937493683820
  - https://app.asana.com/0/0/1207937493683824
  - https://app.asana.com/0/0/1207937493683816
  - https://app.asana.com/0/0/1207937493683812
  - https://app.asana.com/0/0/1207937493683809