### PR TITLE
Remove `.env.example`, update `CONTRIBUTING.md`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,0 @@
-PINECONE_API_KEY="<Project API Key>"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,11 +8,11 @@
 
 Then, execute `just bootstrap` to install the necessary Go packages
 
-## .env Setup
+## Environment Setup
 
-An easy way to keep track of necessary environment variables is to create a `.env` file in the root of the project.
-This project comes with a sample `.env` file (`.env.sample`) that you can copy and modify. At the very least, you
-will need to include the `PINECONE_API_KEY` variable in your `.env` file for the tests to run locally.
+At a minimum, you will need to declare a `PINECONE_API_KEY` variable in your environment in order to interact with Pinecone services, and
+run the integration tests locally. If `PINECONE_API_KEY` is available in you environment, the `Client` struct can be created with `NewClient`
+without any additional configuration parameters. Alternatively, you can pass `ApiKey` as a configuration directly through `NewClientParams`.
 
 ````shell
 ### API Definitions submodule

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,7 @@ Then, execute `just bootstrap` to install the necessary Go packages
 
 ## Environment Setup
 
-At a minimum, you will need to declare a `PINECONE_API_KEY` variable in your environment in order to interact with Pinecone services, and
-run the integration tests locally. If `PINECONE_API_KEY` is available in you environment, the `Client` struct can be created with `NewClient`
-without any additional configuration parameters. Alternatively, you can pass `ApiKey` as a configuration directly through `NewClientParams`.
+At a minimum, you will need to declare a `PINECONE_API_KEY` variable in your environment in order to interact with Pinecone services, and run integration tests locally. If `PINECONE_API_KEY` is available in your environment, the `Client` struct can be created with `NewClient` without any additional configuration parameters. Alternatively, you can pass `ApiKey` as a configuration directly through `NewClientParams`.
 
 ````shell
 ### API Definitions submodule


### PR DESCRIPTION
## Problem
Within the SDK itself we're not reading anything from an `.env` file, but the repo still has an example file that's referenced in the `CONTRIBUTING.md` file.

## Solution
Remove `.env.example` and update the section about setting up your environment in the `CONTRIBUTING.md` file.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [X] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
N/A
