### PR TITLE
Refactor Integration Tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 2. The [just](https://github.com/casey/just?tab=readme-ov-file#installation) command runner
 3. The [protobuf-compiler](https://grpc.io/docs/protoc-installation/)
 
-Then, execute `just bootstrap` to install the necessary Go packages
+Then, execute `just bootstrap` to install the necessary Go packages. The packages installed when bootstrapping allow regenerating client code from spec files, and generating Go documentation.
 
 ## Environment Setup
 
@@ -22,7 +22,8 @@ git submodule update --init --recursive
 ````
 
 For working with submodules, see the [Git Submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules)
-documentation.
+documentation. Note that since the current submodule is private to `pinecone-io`, you will not be able to work directly
+with the submodule.
 
 ## Just commands
 
@@ -35,3 +36,79 @@ documentation.
 `just docs` : Generates Go docs and starts http server on localhost
 
 `just bootstrap` : Installs necessary go packages for gen and docs
+
+## Testing
+
+The `go-pinecone` codebase includes both unit and integration tests. These tests are kept within the same files, but are
+constructed differently. See `/pinecone/index_connection_test.go` and `/pinecone/client_test.go` for examples. They are divided into sections with `// Integration tests: ` near the top, and `// Unit tests:` near the bottom of the file.
+
+For running tests you can use `just test` to run all tests, and `just test-unit` to only run integration tests.
+
+### Unit tests
+
+Unit tests are generally written using Go's built-in support. You can find a [brief walkthrough](https://go.dev/doc/tutorial/add-a-test) detailing how to write a test. You can also refer to [go.dev/doc/code#Testing](https://go.dev/doc/code#Testing).
+
+When adding unit tests, make sure to postfix `"Unit"` to the test function name in order for the test to be picked up by the `just test-unit` command. For example:
+
+```Go
+func TestNewClientParamsSetUnit(t *testing.T) {
+	apiKey := "test-api-key"
+	client, err := NewClient(NewClientParams{ApiKey: apiKey})
+
+	require.NoError(t, err)
+	require.Empty(t, client.sourceTag, "Expected client to have empty sourceTag")
+	require.NotNil(t, client.headers, "Expected client headers to not be nil")
+	apiKeyHeader, ok := client.headers["Api-Key"]
+	require.True(t, ok, "Expected client to have an 'Api-Key' header")
+	require.Equal(t, apiKey, apiKeyHeader, "Expected 'Api-Key' header to match provided ApiKey")
+	require.Equal(t, 3, len(client.restClient.RequestEditors), "Expected client to have correct number of request editors")
+}
+```
+
+### Integration Tests
+
+For integration tests we use the `stretchr/testify` module, specifically for the `suite`, `assert`, and `require` packages. You can find the source code and documentation on GitHub: [https://github.com/stretchr/testify](https://github.com/stretchr/testify).
+
+There are two files that define the integration test suite, and include code that manages setup and teardown of external Index resources before the test files are executed:
+
+- `./pinecone/test_suite.go`
+- `./pinecone/suite_runner_test.go`
+
+`test_suite.go` includes the definition of the `IntegrationTests` struct which embeds `suite.Suite` from testify. This file also includes `SetupSuite` and `TearDownSuite` methods, along with utility functions for things like index creation and upserting vectors.
+
+`suite_runner_test.go` is the primary entrypoint for the integration tests being run:
+
+```Go
+// This is the entry point for all integration tests
+// This test function is picked up by go test and triggers the suite runs
+func TestRunSuites(t *testing.T) {
+	RunSuites(t)
+}
+```
+
+In `RunSuites` we create two different `IntegrationTests` for pod and serverless indexes.
+
+As mentioned above, integration tests are written in the same files as unit tests. However, integration tests must be defined as methods on the `IntegrationTests` struct:
+
+```Go
+type IntegrationTests struct {
+	suite.Suite
+	apiKey         string
+	client         *Client
+	host           string
+	dimension      int32
+	indexType      string
+	vectorIds      []string
+	idxName        string
+	idxConn        *IndexConnection
+	collectionName string
+	sourceTag      string
+}
+
+// Integration tests:
+func (ts *IntegrationTests) TestListIndexes() {
+	indexes, err := ts.client.ListIndexes(context.Background())
+	require.NoError(ts.T(), err)
+	require.Greater(ts.T(), len(indexes), 0, "Expected at least one index to exist")
+}
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ with the submodule.
 The `go-pinecone` codebase includes both unit and integration tests. These tests are kept within the same files, but are
 constructed differently. See `/pinecone/index_connection_test.go` and `/pinecone/client_test.go` for examples. They are divided into sections with `// Integration tests: ` near the top, and `// Unit tests:` near the bottom of the file.
 
-For running tests you can use `just test` to run all tests, and `just test-unit` to only run integration tests.
+For running tests you can use `just test` to run all tests, and `just test-unit` to only run unit tests.
 
 ### Unit tests
 
@@ -69,7 +69,7 @@ func TestNewClientParamsSetUnit(t *testing.T) {
 
 For integration tests we use the `stretchr/testify` module, specifically for the `suite`, `assert`, and `require` packages. You can find the source code and documentation on GitHub: [https://github.com/stretchr/testify](https://github.com/stretchr/testify).
 
-There are two files that define the integration test suite, and include code that manages setup and teardown of external Index resources before the test files are executed:
+There are two files that define the integration test suite, and include code that manages setup and teardown of external Index resources before and after the integration suites execute.
 
 - `./pinecone/test_suite.go`
 - `./pinecone/suite_runner_test.go`

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -466,7 +466,7 @@ func TestHeadersOverrideAdditionalHeadersUnit(t *testing.T) {
 	os.Unsetenv("PINECONE_ADDITIONAL_HEADERS")
 }
 
-func TestControllerHostOverride(t *testing.T) {
+func TestControllerHostOverrideUnit(t *testing.T) {
 	apiKey := "test-api-key"
 	httpClient := utils.CreateMockClient(`{"indexes": []}`)
 	client, err := NewClient(NewClientParams{ApiKey: apiKey, Host: "https://test-controller-host.io", RestClient: httpClient})

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -276,7 +276,7 @@ func (ts *IntegrationTests) TestConfigureIndexHitPodLimit() {
 }
 
 // Unit tests:
-func TestExtractAuthHeader(t *testing.T) {
+func TestExtractAuthHeaderUnit(t *testing.T) {
 	globalApiKey := os.Getenv("PINECONE_API_KEY")
 	os.Unsetenv("PINECONE_API_KEY")
 
@@ -320,7 +320,7 @@ func TestExtractAuthHeader(t *testing.T) {
 	os.Setenv("PINECONE_API_KEY", globalApiKey)
 }
 
-func TestApiKeyPassedToIndexConnection(t *testing.T) {
+func TestApiKeyPassedToIndexConnectionUnit(t *testing.T) {
 	apiKey := "test-api-key"
 
 	client, err := NewClient(NewClientParams{ApiKey: apiKey})
@@ -345,7 +345,7 @@ func TestApiKeyPassedToIndexConnection(t *testing.T) {
 	assert.True(t, metadataHasApiKey, "Expected IndexConnection metadata to contain 'Api-Key' with value '%s'", apiKey)
 }
 
-func TestNewClientParamsSet(t *testing.T) {
+func TestNewClientParamsSetUnit(t *testing.T) {
 	apiKey := "test-api-key"
 	client, err := NewClient(NewClientParams{ApiKey: apiKey})
 
@@ -358,7 +358,7 @@ func TestNewClientParamsSet(t *testing.T) {
 	require.Equal(t, 3, len(client.restClient.RequestEditors), "Expected client to have correct number of request editors")
 }
 
-func TestNewClientParamsSetSourceTag(t *testing.T) {
+func TestNewClientParamsSetSourceTagUnit(t *testing.T) {
 	apiKey := "test-api-key"
 	sourceTag := "test-source-tag"
 	client, err := NewClient(NewClientParams{
@@ -374,7 +374,7 @@ func TestNewClientParamsSetSourceTag(t *testing.T) {
 	require.Equal(t, 3, len(client.restClient.RequestEditors), "Expected client to have %s request editors, but got %s", 2, len(client.restClient.RequestEditors))
 }
 
-func TestNewClientParamsSetHeaders(t *testing.T) {
+func TestNewClientParamsSetHeadersUnit(t *testing.T) {
 	apiKey := "test-api-key"
 	headers := map[string]string{"test-header": "test-ptr"}
 	client, err := NewClient(NewClientParams{ApiKey: apiKey, Headers: headers})
@@ -387,7 +387,7 @@ func TestNewClientParamsSetHeaders(t *testing.T) {
 	require.Equal(t, 4, len(client.restClient.RequestEditors), "Expected client to have %s request editors, but got %s", 3, len(client.restClient.RequestEditors))
 }
 
-func TestNewClientParamsNoApiKeyNoAuthorizationHeader(t *testing.T) {
+func TestNewClientParamsNoApiKeyNoAuthorizationHeaderUnit(t *testing.T) {
 	apiKey := os.Getenv("PINECONE_API_KEY")
 	os.Unsetenv("PINECONE_API_KEY")
 
@@ -402,7 +402,7 @@ func TestNewClientParamsNoApiKeyNoAuthorizationHeader(t *testing.T) {
 	os.Setenv("PINECONE_API_KEY", apiKey)
 }
 
-func TestHeadersAppliedToRequests(t *testing.T) {
+func TestHeadersAppliedToRequestsUnit(t *testing.T) {
 	apiKey := "test-api-key"
 	headers := map[string]string{"test-header": "123456"}
 
@@ -421,7 +421,7 @@ func TestHeadersAppliedToRequests(t *testing.T) {
 	assert.Equal(t, "123456", testHeaderValue, "Expected request to have header ptr '123456', but got '%s'", testHeaderValue)
 }
 
-func TestAdditionalHeadersAppliedToRequest(t *testing.T) {
+func TestAdditionalHeadersAppliedToRequestUnit(t *testing.T) {
 	os.Setenv("PINECONE_ADDITIONAL_HEADERS", `{"test-header": "environment-header"}`)
 
 	apiKey := "test-api-key"
@@ -443,7 +443,7 @@ func TestAdditionalHeadersAppliedToRequest(t *testing.T) {
 	os.Unsetenv("PINECONE_ADDITIONAL_HEADERS")
 }
 
-func TestHeadersOverrideAdditionalHeaders(t *testing.T) {
+func TestHeadersOverrideAdditionalHeadersUnit(t *testing.T) {
 	os.Setenv("PINECONE_ADDITIONAL_HEADERS", `{"test-header": "environment-header"}`)
 
 	apiKey := "test-api-key"
@@ -481,7 +481,7 @@ func TestControllerHostOverride(t *testing.T) {
 	assert.Equal(t, "test-controller-host.io", mockTransport.Req.Host, "Expected request to be made to 'test-controller-host.io', but got '%s'", mockTransport.Req.URL.Host)
 }
 
-func TestControllerHostOverrideFromEnv(t *testing.T) {
+func TestControllerHostOverrideFromEnvUnit(t *testing.T) {
 	os.Setenv("PINECONE_CONTROLLER_HOST", "https://env-controller-host.io")
 
 	apiKey := "test-api-key"
@@ -500,7 +500,7 @@ func TestControllerHostOverrideFromEnv(t *testing.T) {
 	os.Unsetenv("PINECONE_CONTROLLER_HOST")
 }
 
-func TestControllerHostNormalization(t *testing.T) {
+func TestControllerHostNormalizationUnit(t *testing.T) {
 	tests := []struct {
 		name       string
 		host       string
@@ -545,7 +545,6 @@ func TestControllerHostNormalization(t *testing.T) {
 	}
 }
 
-// Unit tests:
 func TestIndexConnectionMissingReqdFieldsUnit(t *testing.T) {
 	client := &Client{}
 	_, err := client.Index(NewIndexConnParams{})

--- a/pinecone/index_connection_test.go
+++ b/pinecone/index_connection_test.go
@@ -26,13 +26,6 @@ func (ts *IntegrationTests) TestFetchVectors() {
 	assert.NotNil(ts.T(), res)
 }
 
-func (ts *IntegrationTests) TestFetchVectorsSourceTag() {
-	ctx := context.Background()
-	res, err := ts.idxConnSourceTag.FetchVectors(ctx, ts.vectorIds)
-	assert.NoError(ts.T(), err)
-	assert.NotNil(ts.T(), res)
-}
-
 func (ts *IntegrationTests) TestQueryByVector() {
 	vec := make([]float32, ts.dimension)
 	for i := range vec {
@@ -50,23 +43,6 @@ func (ts *IntegrationTests) TestQueryByVector() {
 	assert.NotNil(ts.T(), res)
 }
 
-func (ts *IntegrationTests) TestQueryByVectorSourceTag() {
-	vec := make([]float32, ts.dimension)
-	for i := range vec {
-		vec[i] = 0.01
-	}
-
-	req := &QueryByVectorValuesRequest{
-		Vector: vec,
-		TopK:   5,
-	}
-
-	ctx := context.Background()
-	res, err := ts.idxConnSourceTag.QueryByVectorValues(ctx, req)
-	assert.NoError(ts.T(), err)
-	assert.NotNil(ts.T(), res)
-}
-
 func (ts *IntegrationTests) TestQueryById() {
 	req := &QueryByVectorIdRequest{
 		VectorId: ts.vectorIds[0],
@@ -75,18 +51,6 @@ func (ts *IntegrationTests) TestQueryById() {
 
 	ctx := context.Background()
 	res, err := ts.idxConn.QueryByVectorId(ctx, req)
-	assert.NoError(ts.T(), err)
-	assert.NotNil(ts.T(), res)
-}
-
-func (ts *IntegrationTests) TestQueryByIdSourceTag() {
-	req := &QueryByVectorIdRequest{
-		VectorId: ts.vectorIds[0],
-		TopK:     5,
-	}
-
-	ctx := context.Background()
-	res, err := ts.idxConnSourceTag.QueryByVectorId(ctx, req)
 	assert.NoError(ts.T(), err)
 	assert.NotNil(ts.T(), res)
 }

--- a/pinecone/suite_runner_test.go
+++ b/pinecone/suite_runner_test.go
@@ -2,7 +2,6 @@
 package pinecone
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -21,66 +20,34 @@ func RunSuites(t *testing.T) {
 	apiKey, present := os.LookupEnv("PINECONE_API_KEY")
 	assert.True(t, present, "PINECONE_API_KEY env variable not set")
 
-	client, err := NewClient(NewClientParams{ApiKey: apiKey})
+	sourceTag := "pinecone_test_go_sdk"
+	client, err := NewClient(NewClientParams{ApiKey: apiKey, SourceTag: sourceTag})
 	require.NotNil(t, client, "Client should not be nil after creation")
-	require.NoError(t, err)
-
-	sourceTag := "test_source_tag"
-	clientSourceTag, err := NewClient(NewClientParams{ApiKey: apiKey, SourceTag: sourceTag})
 	require.NoError(t, err)
 
 	serverlessIdx := BuildServerlessTestIndex(client, "serverless-"+GenerateTestIndexName())
 	podIdx := BuildPodTestIndex(client, "pods-"+GenerateTestIndexName())
 
 	podTestSuite := &IntegrationTests{
-		apiKey:          apiKey,
-		indexType:       "pods",
-		host:            podIdx.Host,
-		dimension:       podIdx.Dimension,
-		client:          client,
-		clientSourceTag: clientSourceTag,
-		sourceTag:       sourceTag,
-		idxName:         podIdx.Name,
+		apiKey:    apiKey,
+		indexType: "pods",
+		host:      podIdx.Host,
+		dimension: podIdx.Dimension,
+		client:    client,
+		sourceTag: sourceTag,
+		idxName:   podIdx.Name,
 	}
 
 	serverlessTestSuite := &IntegrationTests{
-		host:            serverlessIdx.Host,
-		dimension:       serverlessIdx.Dimension,
-		apiKey:          apiKey,
-		indexType:       "serverless",
-		client:          client,
-		clientSourceTag: clientSourceTag,
-		sourceTag:       sourceTag,
-		idxName:         serverlessIdx.Name,
-	}
-
-	ctx := context.Background()
-	done := make(chan indexReadyResponse, 2)
-
-	// spawn goroutines to wait until indexes are ready
-	go waitUntilIndexReadyWithChannel(podTestSuite, ctx, done)
-	go waitUntilIndexReadyWithChannel(serverlessTestSuite, ctx, done)
-
-	// wait until indexes are ready before proceeding
-	for i := 0; i < 2; i++ {
-		result := <-done
-		require.True(t, result.ready, "Index %s is not ready", result.indexName)
+		apiKey:    apiKey,
+		indexType: "serverless",
+		host:      serverlessIdx.Host,
+		dimension: serverlessIdx.Dimension,
+		client:    client,
+		sourceTag: sourceTag,
+		idxName:   serverlessIdx.Name,
 	}
 
 	suite.Run(t, podTestSuite)
 	suite.Run(t, serverlessTestSuite)
-}
-
-func waitUntilIndexReadyWithChannel(ts *IntegrationTests, ctx context.Context, done chan<- indexReadyResponse) {
-	ready, err := WaitUntilIndexReady(ts, ctx)
-	if err != nil {
-		require.NoError(ts.T(), err)
-	}
-
-	done <- indexReadyResponse{indexName: ts.idxName, ready: ready}
-}
-
-type indexReadyResponse struct {
-	indexName string
-	ready     bool
 }

--- a/pinecone/test_suite.go
+++ b/pinecone/test_suite.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"runtime"
 	"time"
 
 	"google.golang.org/protobuf/types/known/structpb"
@@ -34,12 +33,11 @@ func (ts *IntegrationTests) SetupSuite() {
 	_, err := WaitUntilIndexReady(ts, ctx)
 	require.NoError(ts.T(), err)
 
-	namespace, err := uuid.NewUUID()
-	require.NoError(ts.T(), err)
+	namespace := uuid.New().String()
 
 	idxConn, err := ts.client.Index(NewIndexConnParams{
 		Host:      ts.host,
-		Namespace: namespace.String(),
+		Namespace: namespace,
 	})
 
 	require.NoError(ts.T(), err)
@@ -106,12 +104,7 @@ func upsertVectors(ts *IntegrationTests, ctx context.Context, vectors []*Vector)
 	require.NoError(ts.T(), err)
 
 	upsertVectors, err := ts.idxConn.UpsertVectors(ctx, vectors)
-	if err != nil {
-		buf := make([]byte, 1<<16)
-		runtime.Stack(buf, true)
-		fmt.Printf("Stack trace: %s\n", buf)
-		return err
-	}
+	require.NoError(ts.T(), err)
 	fmt.Printf("Upserted vectors: %v into host: %s\n", upsertVectors, ts.host)
 
 	return nil

--- a/pinecone/test_suite.go
+++ b/pinecone/test_suite.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"runtime"
 	"time"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/google/uuid"
@@ -19,30 +18,28 @@ type IntegrationTests struct {
 	suite.Suite
 	apiKey           string
 	client           *Client
+	clientSourceTag  *Client
 	host             string
 	dimension        int32
 	indexType        string
 	vectorIds        []string
 	idxName          string
 	idxConn          *IndexConnection
-	sourceTag        string
-	clientSourceTag  Client
 	idxConnSourceTag *IndexConnection
+	sourceTag        string
 }
 
 func (ts *IntegrationTests) SetupSuite() {
 	ctx := context.Background()
 
-	additionalMetadata := map[string]string{"api-key": ts.apiKey}
-
 	namespace, err := uuid.NewUUID()
 	require.NoError(ts.T(), err)
 
-	idxConn, err := newIndexConnection(newIndexParameters{
-		additionalMetadata: additionalMetadata,
-		host:               ts.host,
-		namespace:          namespace.String(),
-		sourceTag:          ""})
+	idxConn, err := ts.client.Index(NewIndexConnParams{
+		Host:      ts.host,
+		Namespace: namespace.String(),
+	})
+
 	require.NoError(ts.T(), err)
 	require.NotNil(ts.T(), idxConn, "Failed to create idxConn")
 
@@ -64,12 +61,10 @@ func (ts *IntegrationTests) SetupSuite() {
 		log.Fatalf("Failed to upsert vectors in SetupSuite: %v", err)
 	}
 
-	ts.sourceTag = "test_source_tag"
-	idxConnSourceTag, err := newIndexConnection(newIndexParameters{
-		additionalMetadata: additionalMetadata,
-		host:               ts.host,
-		namespace:          namespace.String(),
-		sourceTag:          ts.sourceTag})
+	idxConnSourceTag, err := ts.clientSourceTag.Index(NewIndexConnParams{
+		Host:      ts.host,
+		Namespace: namespace.String(),
+	})
 	require.NoError(ts.T(), err)
 	ts.idxConnSourceTag = idxConnSourceTag
 
@@ -79,14 +74,19 @@ func (ts *IntegrationTests) SetupSuite() {
 func (ts *IntegrationTests) TearDownSuite() {
 	ctx := context.Background()
 
-	// Delete test indexes
-	err := ts.client.DeleteIndex(ctx, ts.idxName)
-
-	err = ts.idxConn.Close()
+	err := ts.idxConn.Close()
 	require.NoError(ts.T(), err)
 
 	err = ts.idxConnSourceTag.Close()
 	require.NoError(ts.T(), err)
+
+	// Delete test index
+	_, err = WaitUntilIndexReady(ts, ctx)
+	require.NoError(ts.T(), err)
+
+	err = ts.client.DeleteIndex(ctx, ts.idxName)
+	require.NoError(ts.T(), err)
+
 	fmt.Printf("\n %s setup suite torn down successfully\n", ts.indexType)
 }
 
@@ -96,50 +96,43 @@ func GenerateTestIndexName() string {
 }
 
 func upsertVectors(ts *IntegrationTests, ctx context.Context, vectors []*Vector) error {
-	maxRetries := 12
-	delay := 12 * time.Second
-	fmt.Printf("Attempting to upsert vectors into host \"%s\"...\n", ts.host)
-	for i := 0; i < maxRetries; i++ {
-		ready, err := GetIndexStatus(ts, ctx)
-		if err != nil {
-			fmt.Printf("Error getting index ready: %v\n", err)
-			return err
-		}
-		if ready {
-			upsertVectors, err := ts.idxConn.UpsertVectors(ctx, vectors)
-			require.NoError(ts.T(), err)
-			fmt.Printf("Upserted vectors: %v into host: %s\n", upsertVectors, ts.host)
-			break
-		} else {
-			time.Sleep(delay)
-			fmt.Printf("Host \"%s\" not ready for upserting yet, retrying... (%d/%d)\n", ts.host, i, maxRetries)
-		}
+	_, err := WaitUntilIndexReady(ts, ctx)
+	require.NoError(ts.T(), err)
+
+	upsertVectors, err := ts.idxConn.UpsertVectors(ctx, vectors)
+	if err != nil {
+		buf := make([]byte, 1<<16)
+		runtime.Stack(buf, true)
+		fmt.Printf("Stack trace: %s\n", buf)
+		return err
 	}
+	fmt.Printf("Upserted vectors: %v into host: %s\n", upsertVectors, ts.host)
+
 	return nil
 }
 
-func GetIndexStatus(ts *IntegrationTests, ctx context.Context) (bool, error) {
-	var desc *Index
-	var err error
-	maxRetries := 12
-	delay := 12 * time.Second
+func WaitUntilIndexReady(ts *IntegrationTests, ctx context.Context) (bool, error) {
+	maxRetries := 24
+	delay := 5 * time.Second
+	totalSeconds := 0
+
 	for i := 0; i < maxRetries; i++ {
-		desc, err = ts.client.DescribeIndex(ctx, ts.idxName)
-		if err == nil {
-			break
+		index, err := ts.client.DescribeIndex(ctx, ts.idxName)
+		if err != nil {
+			fmt.Printf("Error describing index: %v\n", err)
 		}
-		if status.Code(err) == codes.Unknown {
-			fmt.Printf("Index \"%s\" not found, retrying... (%d/%d)\n", ts.idxName, i+1, maxRetries)
-			time.Sleep(delay)
+		if index.Status.State == Ready && index.Status.Ready {
+			fmt.Printf("Index \"%s\" is ready!\n", ts.idxName)
+			return true, nil
 		} else {
-			fmt.Printf("Status code = %v\n", status.Code(err))
-			return false, err
+			fmt.Printf("Index \"%s\" not ready yet, retrying... (%d/%d)\n", ts.idxName, i, maxRetries)
+			time.Sleep(delay)
+			totalSeconds += int(delay.Seconds())
 		}
 	}
-	if err != nil {
-		return false, fmt.Errorf("failed to describe index \"%s\" after retries: %v", err, ts.idxName)
-	}
-	return desc.Status.Ready, nil
+
+	fmt.Printf("Index \"%s\" not ready after %d seconds\n", ts.idxName, totalSeconds)
+	return false, nil
 }
 
 func createVectorsForUpsert() []*Vector {

--- a/pinecone/test_suite.go
+++ b/pinecone/test_suite.go
@@ -16,21 +16,23 @@ import (
 
 type IntegrationTests struct {
 	suite.Suite
-	apiKey           string
-	client           *Client
-	clientSourceTag  *Client
-	host             string
-	dimension        int32
-	indexType        string
-	vectorIds        []string
-	idxName          string
-	idxConn          *IndexConnection
-	idxConnSourceTag *IndexConnection
-	sourceTag        string
+	apiKey         string
+	client         *Client
+	host           string
+	dimension      int32
+	indexType      string
+	vectorIds      []string
+	idxName        string
+	idxConn        *IndexConnection
+	collectionName string
+	sourceTag      string
 }
 
 func (ts *IntegrationTests) SetupSuite() {
 	ctx := context.Background()
+
+	_, err := WaitUntilIndexReady(ts, ctx)
+	require.NoError(ts.T(), err)
 
 	namespace, err := uuid.NewUUID()
 	require.NoError(ts.T(), err)
@@ -61,12 +63,10 @@ func (ts *IntegrationTests) SetupSuite() {
 		log.Fatalf("Failed to upsert vectors in SetupSuite: %v", err)
 	}
 
-	idxConnSourceTag, err := ts.clientSourceTag.Index(NewIndexConnParams{
-		Host:      ts.host,
-		Namespace: namespace.String(),
-	})
-	require.NoError(ts.T(), err)
-	ts.idxConnSourceTag = idxConnSourceTag
+	// Create collection for pod index suite
+	if ts.indexType == "pods" {
+		createCollection(ts, ctx)
+	}
 
 	fmt.Printf("\n %s set up suite completed successfully\n", ts.indexType)
 }
@@ -74,16 +74,22 @@ func (ts *IntegrationTests) SetupSuite() {
 func (ts *IntegrationTests) TearDownSuite() {
 	ctx := context.Background()
 
+	// Close index connection
 	err := ts.idxConn.Close()
 	require.NoError(ts.T(), err)
 
-	err = ts.idxConnSourceTag.Close()
-	require.NoError(ts.T(), err)
+	// Delete collection
+	if ts.collectionName != "" {
+		err = ts.client.DeleteCollection(ctx, ts.collectionName)
+		require.NoError(ts.T(), err)
+
+		// Before moving on to deleting the index, wait for collection to be cleaned up
+		time.Sleep(3 * time.Second)
+	}
 
 	// Delete test index
 	_, err = WaitUntilIndexReady(ts, ctx)
 	require.NoError(ts.T(), err)
-
 	err = ts.client.DeleteIndex(ctx, ts.idxName)
 	require.NoError(ts.T(), err)
 
@@ -109,6 +115,21 @@ func upsertVectors(ts *IntegrationTests, ctx context.Context, vectors []*Vector)
 	fmt.Printf("Upserted vectors: %v into host: %s\n", upsertVectors, ts.host)
 
 	return nil
+}
+
+func createCollection(ts *IntegrationTests, ctx context.Context) {
+	name := uuid.New().String()
+	sourceIndex := ts.idxName
+
+	ts.collectionName = name
+
+	collection, err := ts.client.CreateCollection(ctx, &CreateCollectionRequest{
+		Name:   name,
+		Source: sourceIndex,
+	})
+
+	require.NoError(ts.T(), err)
+	require.Equal(ts.T(), name, collection.Name)
 }
 
 func WaitUntilIndexReady(ts *IntegrationTests, ctx context.Context) (bool, error) {


### PR DESCRIPTION
## Problem
We currently have a few things we'd like to clean up in our integration test suite:
- There's a lot of flakiness in our current test setup as we're not checking for index readiness when deleting, working with collections, and configuring indexes. We end up seeing a lot of transient errors along the lines of "Index was not ready for that operation yet."
- We have a number of unit tests which are included in the `IntegrationTests` struct.
- We have different integration tests for `Client` with and without `sourceTag`, which is kind of overkill. We unit test applying the user-agent details, and we don't need to rerun the same tests with and without `sourceTag`.

## Solution
- Refactor `GetIndexStatus` into `WaitUntilIndexReady` - just felt a bit easier to reason about, and also polls at a more frequent cadence.
- Make sure we're calling `WaitUntilIndexReady` in places where we've called `ConfigureIndex` or creating collections from indexes. We also want to make sure indexes are ready before deleting.
- Move unit tests out of the `IntegrationTests` struct and reorganize things a bit.
- Create the collection for pod indexes in `SetupSuite` and reuse this for collection tests rather than creating numerous collections. 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
Make sure integration tests pass in CI. To run locally use `just test` after setting up your `PINECONE_API_KEY`.
