### PR TITLE
Implement Inference API

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ func main() {
 
 The following examlpe describes the statistics of an index by name.
 
-```Go
+```go
 package main
 
 import (
@@ -781,7 +781,7 @@ func main() {
 The following example deletes a vector by its ID value from `example-index` and `example-namespace`. You can pass a
 slice of vector IDs to `DeleteVectorsById`.
 
-```Go
+```go
 package main
 
 import (
@@ -829,7 +829,7 @@ func main() {
 
 The following example deletes vectors from `example-index` using a metadata filter.
 
-```Go
+```go
 package main
 
 import (
@@ -884,7 +884,7 @@ func main() {
 
 The following example deletes all vectors from `example-index` and `example-namespace`.
 
-```Go
+```go
 package main
 
 import (
@@ -1012,7 +1012,7 @@ func main() {
 
 The following example updates vectors by ID in `example-index` and `example-namespace`.
 
-```Go
+```go
 package main
 
 import (
@@ -1145,7 +1145,7 @@ Collections are only available for pod-based indexes.
 
 The following example creates a collection from a source index.
 
-```Go
+```go
 package main
 
 import (
@@ -1186,7 +1186,7 @@ func main() {
 
 The following example lists all collections in your Pinecone project.
 
-```Go
+```go
 package main
 
 import (
@@ -1231,7 +1231,7 @@ func main() {
 
 The following example describes a collection by name.
 
-```Go
+```go
 package main
 
 import (
@@ -1269,7 +1269,7 @@ func main() {
 
 The following example deletes a collection by name.
 
-```Go
+```go
 package main
 
 import (
@@ -1303,6 +1303,73 @@ func main() {
 		log.Printf("Successfully deleted collection \"%s\"\n", collectionName)
 	}
 }
+```
+
+## Inference
+
+The `Client` object has an `Inference` namespace which allows interacting with Pinecone's [Inference API](https://docs.pinecone.io/reference/api/2024-07/inference/generate-embeddings). The Inference API is a service that gives you access to embedding models hosted on Pinecone's infrastructure. Read more at [Understanding Pinecone Inference](https://docs.pinecone.io/guides/inference/understanding-inference).
+
+**Notes:**
+
+Models currently supported:
+
+- [multilingual-e5-large](https://docs.pinecone.io/guides/inference/understanding-inference#embedding-models)
+
+### Create Embeddings
+
+Send text to Pinecone's inference API to generate embeddings for documents and queries.
+
+```go
+	ctx := context.Background()
+
+	pc, err := pinecone.NewClient(pinecone.NewClientParams{
+		ApiKey: "YOUR_API_KEY",
+	})
+	if err !=  nil {
+		log.Fatalf("Failed to create Client: %v", err)
+	}
+
+	embeddingModel := "multilingual-e5-large"
+	documents := []string{
+		"Turkey is a classic meat to eat at American Thanksgiving."
+		"Many people enjoy the beautiful mosques in Turkey."
+	}
+	docParameters := pinecone.EmbedParameters{
+		InputType: "passage",
+		Truncate: "END",
+	}
+
+	docEmbeddingsResponse, err := pc.Inference.Embed(ctx, &pinecone.EmbedRequest{
+		Model: embeddingModel,
+		TextInputs: documents,
+		Parameters: docParameters,
+	})
+	if err != nil {
+		log.Fatalf("Failed to embed documents: %v", err)
+	}
+	fmt.Printf("docs embedding response: %+v", docEmbeddingsResponse)
+
+	// << Upsert documents into Pinecone >>
+
+	userQuery := []string{
+		"How should I prepare my turkey?"
+	}
+	queryParameters := pinecone.EmbedParameters{
+		InputType: "query",
+		Truncate: "END",
+	}
+	queryEmbeddingsResponse, err := pc.Inference.Embed(ctx, &pinecone.EmbedRequest{
+		Model: embeddingModel,
+		TextInputs: userQuery,
+		Parameters: queryParameters
+	})
+	if err != nil {
+		log.Fatalf("Failed to embed query: %v", err)
+	}
+	fmt.Printf("query embedding response: %+v", queryEmbeddingsResponse)
+
+	// << Send query to Pinecone to retrieve similar documents >>
+
 ```
 
 ## Support

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -24,16 +24,16 @@ import (
 // Client holds the parameters for connecting to the Pinecone service. It is returned by the NewClient and NewClientBase
 // functions. To use Client, first build the parameters of the request using NewClientParams (or NewClientBaseParams).
 // Then, pass those parameters into the NewClient (or NewClientBase) function to create a new Client object.
-// Once instantiated, you can use Client to execute control plane API requests (e.g. create an Index, list Indexes,
-// etc.), and Inference API requests. Read more about different control plane API routes at [docs.pinecone.io/reference/api].
+// Once instantiated, you can use Client to execute Pinecone API requests (e.g. create an Index, list Indexes,
+// etc.), and Inference API requests. Read more about different Pinecone API routes at [docs.pinecone.io/reference/api].
 //
 // Note: Client methods are safe for concurrent use.
 //
 // Fields:
 //   - Inference: An InferenceService object that exposes methods for interacting with the Pinecone [Inference API].
-//   - headers: An optional map of additional HTTP headers to include in each API request to the control plane,
-//     provided through NewClientParams.Headers or NewClientBaseParams.Headers.
-//   - restClient: Optional underlying *http.Client object used to communicate with the Pinecone control plane API,
+//   - headers: An optional map of additional HTTP headers to include in each API request, provided through
+//     NewClientParams.Headers or NewClientBaseParams.Headers.
+//   - restClient: Optional underlying *http.Client object used to communicate with the Pinecone API,
 //     provided through NewClientParams.RestClient or NewClientBaseParams.RestClient. If not provided,
 //     a default client is created for you.
 //   - sourceTag: An optional string used to help Pinecone attribute API activity, provided through NewClientParams.SourceTag
@@ -79,12 +79,11 @@ type Client struct {
 // NewClientParams holds the parameters for creating a new Client instance while authenticating via an API key.
 //
 // Fields:
-//   - ApiKey: (Required) The API key used to authenticate with the Pinecone control plane API.
+//   - ApiKey: (Required) The API key used to authenticate with the Pinecone API.
 //     This value must be passed by the user unless it is set as an environment variable ("PINECONE_API_KEY").
-//   - Headers: An optional map of additional HTTP headers to include in each API request to the control plane.
-//   - Host: (Optional) The host URL of the Pinecone control plane API. If not provided,
-//     the default value is "https://api.pinecone.io".
-//   - RestClient: An optional HTTP client to use for communication with the control plane API.
+//   - Headers: An optional map of additional HTTP headers to include in each API request.
+//   - Host: (Optional) The host URL of the Pinecone API. If not provided, the default value is "https://api.pinecone.io".
+//   - RestClient: An optional HTTP client to use for communication with the Pinecone API.
 //   - SourceTag: An optional string used to help Pinecone attribute API activity.
 //
 // See Client for code example.
@@ -100,11 +99,11 @@ type NewClientParams struct {
 // headers.
 //
 // Fields:
-//   - Headers: An optional map of additional HTTP headers to include in each API request to the control plane.
+//   - Headers: An optional map of additional HTTP headers to include in each API request.
 //     "Authorization" and "X-Project-Id" headers are required if authenticating using a JWT.
-//   - Host: (Optional) The host URL of the Pinecone control plane API. If not provided,
+//   - Host: (Optional) The host URL of the Pinecone API. If not provided,
 //     the default value is "https://api.pinecone.io".
-//   - RestClient: An optional *http.Client object to use for communication with the control plane API.
+//   - RestClient: An optional *http.Client object to use for communication with the Pinecone API.
 //   - SourceTag: An optional string used to help Pinecone attribute API activity.
 //
 // See Client for code example.
@@ -131,13 +130,13 @@ type NewIndexConnParams struct {
 }
 
 // NewClient creates and initializes a new instance of Client.
-// This function sets up the control plane client with the necessary configuration for authentication and communication.
+// This function sets up the Pinecone client with the necessary configuration for authentication and communication.
 //
 // Parameters:
 //   - in: A NewClientParams object. See NewClientParams for more information.
 //
 // Note: It is important to handle the error returned by this function to ensure that the
-// control plane client has been created successfully before attempting to make API calls.
+// Pinecone client has been created successfully before attempting to make API calls.
 //
 // Returns a pointer to an initialized Client instance or an error.
 //
@@ -181,12 +180,12 @@ func NewClient(in NewClientParams) (*Client, error) {
 // NewClientBase creates and initializes a new instance of Client with custom authentication headers.
 //
 // Parameters:
-//   - in: A NewClientBaseParams object that includes the necessary configuration for the control plane client. See
+//   - in: A NewClientBaseParams object that includes the necessary configuration for the Pinecone client. See
 //     NewClientBaseParams for more information.
 //
 // Notes:
 //   - It is important to handle the error returned by this function to ensure that the
-//     control plane client has been created successfully before attempting to make API calls.
+//     Pinecone client has been created successfully before attempting to make API calls.
 //   - A Pinecone API key is not required when using NewClientBase.
 //
 // Returns a pointer to an initialized Client instance or an error.

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -1218,7 +1218,7 @@ type EmbedRequest struct {
 // Fields:
 //   - InputType: (Optional) A common property used to distinguish between different types of data. For example, "passage", or "query".
 //   - Truncate: (Optional) How to handle inputs longer than those supported by the model. if "NONE", when the input exceeds
-//     the maximum input token length an error will be returned.
+//     the maximum input token length, an error will be returned.
 type EmbedParameters struct {
 	InputType string
 	Truncate  string

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -31,7 +31,7 @@ import (
 //
 // Fields:
 //   - Inference: An InferenceService object that exposes methods for interacting with the Pinecone [Inference API].
-//   - headers: An optional map of additional HTTP headers to include in each API request, provided through
+//   - headers: An optional map of HTTP headers to include in each API request, provided through
 //     NewClientParams.Headers or NewClientBaseParams.Headers.
 //   - restClient: Optional underlying *http.Client object used to communicate with the Pinecone API,
 //     provided through NewClientParams.RestClient or NewClientBaseParams.RestClient. If not provided,
@@ -81,7 +81,7 @@ type Client struct {
 // Fields:
 //   - ApiKey: (Required) The API key used to authenticate with the Pinecone API.
 //     This value must be passed by the user unless it is set as an environment variable ("PINECONE_API_KEY").
-//   - Headers: An optional map of additional HTTP headers to include in each API request.
+//   - Headers: (Optional) An optional map of HTTP headers to include in each API request.
 //   - Host: (Optional) The host URL of the Pinecone API. If not provided, the default value is "https://api.pinecone.io".
 //   - RestClient: An optional HTTP client to use for communication with the Pinecone API.
 //   - SourceTag: An optional string used to help Pinecone attribute API activity.
@@ -96,15 +96,15 @@ type NewClientParams struct {
 }
 
 // NewClientBaseParams holds the parameters for creating a new Client instance while passing custom authentication
-// headers.
+// headers. If there is no API key or authentication provided through Headers, API calls will fail.
 //
 // Fields:
-//   - Headers: An optional map of additional HTTP headers to include in each API request.
+//   - Headers: (Optional) A map of HTTP headers to include in each API request.
 //     "Authorization" and "X-Project-Id" headers are required if authenticating using a JWT.
 //   - Host: (Optional) The host URL of the Pinecone API. If not provided,
 //     the default value is "https://api.pinecone.io".
-//   - RestClient: An optional *http.Client object to use for communication with the Pinecone API.
-//   - SourceTag: An optional string used to help Pinecone attribute API activity.
+//   - RestClient: (Optional) An *http.Client object to use for communication with the Pinecone API.
+//   - SourceTag: (Optional) A string used to help Pinecone attribute API activity.
 //
 // See Client for code example.
 type NewClientBaseParams struct {
@@ -119,8 +119,8 @@ type NewClientBaseParams struct {
 // Fields:
 //   - Host: (Required) The host URL of the Pinecone index. To find your host url use the DescribeIndex or ListIndexes methods.
 //     Alternatively, the host is displayed in the Pinecone web console.
-//   - Namespace: Optional index namespace to use for operations. If not provided, the default namespace of "" will be used.
-//   - AdditionalMetadata: Optional additional metadata to be sent with each RPC request.
+//   - Namespace: (Optional) The index namespace to use for operations. If not provided, the default namespace of "" will be used.
+//   - AdditionalMetadata: (Optional) Metadata to be sent with each RPC request.
 //
 // See Client.Index for code example.
 type NewIndexConnParams struct {
@@ -571,7 +571,7 @@ func (c *Client) CreatePodIndex(ctx context.Context, in *CreatePodIndexRequest) 
 //   - Cloud: (Required) The public [cloud provider] where you would like your Index hosted.
 //     For serverless Indexes, you define only the cloud and region where the Index should be hosted.
 //   - Region: (Required) The [region] where you would like your Index to be created.
-//   - DeletionProtection: (Optional) determines whether [deletion protection] is "enabled" or "disabled" for the index.
+//   - DeletionProtection: (Optional) Determines whether [deletion protection] is "enabled" or "disabled" for the index.
 //     When "enabled", the index cannot be deleted. Defaults to "disabled".
 //
 // To create a new Serverless Index, use the CreateServerlessIndex method on the Client object.
@@ -1237,7 +1237,7 @@ type InferenceService struct {
 // Parameters:
 //   - ctx: A context.Context object controls the request's lifetime, allowing for the request
 //     to be canceled or to timeout according to the context's deadline.
-//   - in: A pointer to an EmbedRequest object that contains the model to use for embedding generation, the
+//   - in: A pointer to an EmbedRequest object that contains the model t4o use for embedding generation, the
 //     list of input strings to generate embeddings for, and any additional parameters to use for generation.
 //
 // Returns a pointer to an EmbeddingsList object or an error.

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -1209,7 +1209,8 @@ func TestBuildClientBaseOptionsUnit(t *testing.T) {
 
 // Helper functions:
 func (ts *IntegrationTests) deleteIndex(name string) error {
-	time.Sleep(3 * time.Second)
+	time.Sleep(5 * time.Second)
+
 	_, err := WaitUntilIndexReady(ts, context.Background())
 	require.NoError(ts.T(), err)
 

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -1213,6 +1213,10 @@ func (ts *IntegrationTests) deleteIndex(name string) error {
 	_, err := WaitUntilIndexReady(ts, context.Background())
 	require.NoError(ts.T(), err)
 
+	index, err := ts.client.DescribeIndex(context.Background(), name)
+	require.NoError(ts.T(), err)
+	fmt.Printf("<<< TRYING TO DELETE INDEX >>> : %+v\n", index)
+
 	err = ts.client.DeleteIndex(context.Background(), name)
 	require.NoError(ts.T(), err)
 	return nil

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pinecone-io/go-pinecone/internal/gen"
@@ -165,6 +166,9 @@ func (ts *IntegrationTests) TestDeletionProtection() {
 	_, err = ts.client.ConfigureIndex(context.Background(), ts.idxName, ConfigureIndexParams{DeletionProtection: "disabled"})
 	require.NoError(ts.T(), err)
 
+	// allow time for the index to start upgrading
+	time.Sleep(3 * time.Second)
+
 	// Before moving on to another test, wait for the index to be done upgrading
 	_, err = WaitUntilIndexReady(ts, context.Background())
 	require.NoError(ts.T(), err)
@@ -215,6 +219,9 @@ func (ts *IntegrationTests) TestConfigureIndexScaleUpNoPods() {
 	_, err = ts.client.ConfigureIndex(context.Background(), name, ConfigureIndexParams{Replicas: 2})
 	require.NoError(ts.T(), err)
 
+	// allow time for the index to start upgrading
+	time.Sleep(3 * time.Second)
+
 	// Before moving on to another test, wait for the index to be done upgrading
 	_, err = WaitUntilIndexReady(ts, context.Background())
 	require.NoError(ts.T(), err)
@@ -241,6 +248,9 @@ func (ts *IntegrationTests) TestConfigureIndexScaleUpNoReplicas() {
 
 	_, err = ts.client.ConfigureIndex(context.Background(), name, ConfigureIndexParams{PodType: "p1.x4"})
 	require.NoError(ts.T(), err)
+
+	// allow time for the index to start upgrading
+	time.Sleep(3 * time.Second)
 
 	// Before moving on to another test, wait for the index to be done upgrading
 	_, err = WaitUntilIndexReady(ts, context.Background())

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -211,6 +211,7 @@ func (ts *IntegrationTests) TestConfigureIndexScaleUpNoPods() {
 	_, err = ts.client.ConfigureIndex(context.Background(), name, ConfigureIndexParams{Replicas: 2})
 	require.NoError(ts.T(), err)
 
+	// give index a bit of time to start upgrading before we poll
 	time.Sleep(500 * time.Millisecond)
 
 	isReady, _ := WaitUntilIndexReady(ts, context.Background())
@@ -237,6 +238,7 @@ func (ts *IntegrationTests) TestConfigureIndexScaleUpNoReplicas() {
 	_, err = ts.client.ConfigureIndex(context.Background(), name, ConfigureIndexParams{PodType: "p1.x4"})
 	require.NoError(ts.T(), err)
 
+	// give index a bit of time to start upgrading before we poll
 	time.Sleep(500 * time.Millisecond)
 
 	isReady, _ := WaitUntilIndexReady(ts, context.Background())
@@ -1199,14 +1201,6 @@ func TestBuildClientBaseOptionsUnit(t *testing.T) {
 // Helper functions:
 func (ts *IntegrationTests) deleteIndex(name string) error {
 	_, err := WaitUntilIndexReady(ts, context.Background())
-	require.NoError(ts.T(), err)
-
-	index, err := ts.client.DescribeIndex(context.Background(), name)
-	require.NoError(ts.T(), err)
-	fmt.Printf("<<< TRYING TO DELETE INDEX >>> : %+v\n", index)
-	fmt.Printf("<<< STATE >>> : %+v\n\n", index.Status)
-
-	_, err = WaitUntilIndexReady(ts, context.Background())
 	require.NoError(ts.T(), err)
 
 	return ts.client.DeleteIndex(context.Background(), name)

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -197,11 +197,6 @@ func (ts *IntegrationTests) TestConfigureIndexIllegalScaleDown() {
 func (ts *IntegrationTests) TestConfigureIndexScaleUpNoPods() {
 	name := uuid.New().String()
 
-	// defer func(ts *IntegrationTests, name string) {
-	// 	err := ts.deleteIndex(name)
-	// 	require.NoError(ts.T(), err)
-	// }(ts, name)
-
 	_, err := ts.client.CreatePodIndex(context.Background(), &CreatePodIndexRequest{
 		Name:        name,
 		Dimension:   2,
@@ -216,11 +211,10 @@ func (ts *IntegrationTests) TestConfigureIndexScaleUpNoPods() {
 	_, err = ts.client.ConfigureIndex(context.Background(), name, ConfigureIndexParams{Replicas: 2})
 	require.NoError(ts.T(), err)
 
-	time.Sleep(4 * time.Second)
+	time.Sleep(500 * time.Millisecond)
 
-	// Before moving on to another test, wait for the index to be done upgrading
-	_, err = WaitUntilIndexReady(ts, context.Background())
-	require.NoError(ts.T(), err)
+	isReady, _ := WaitUntilIndexReady(ts, context.Background())
+	require.True(ts.T(), isReady, "Expected index to be ready")
 
 	err = ts.client.DeleteIndex(context.Background(), name)
 	require.NoError(ts.T(), err)
@@ -228,11 +222,6 @@ func (ts *IntegrationTests) TestConfigureIndexScaleUpNoPods() {
 
 func (ts *IntegrationTests) TestConfigureIndexScaleUpNoReplicas() {
 	name := uuid.New().String()
-
-	// defer func(ts *IntegrationTests, name string) {
-	// 	err := ts.deleteIndex(name)
-	// 	require.NoError(ts.T(), err)
-	// }(ts, name)
 
 	_, err := ts.client.CreatePodIndex(context.Background(), &CreatePodIndexRequest{
 		Name:        name,
@@ -248,11 +237,10 @@ func (ts *IntegrationTests) TestConfigureIndexScaleUpNoReplicas() {
 	_, err = ts.client.ConfigureIndex(context.Background(), name, ConfigureIndexParams{PodType: "p1.x4"})
 	require.NoError(ts.T(), err)
 
-	time.Sleep(4 * time.Second)
+	time.Sleep(500 * time.Millisecond)
 
-	// Before moving on to another test, wait for the index to be done upgrading
-	_, err = WaitUntilIndexReady(ts, context.Background())
-	require.NoError(ts.T(), err)
+	isReady, _ := WaitUntilIndexReady(ts, context.Background())
+	require.True(ts.T(), isReady, "Expected index to be ready")
 
 	err = ts.client.DeleteIndex(context.Background(), name)
 	require.NoError(ts.T(), err)

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -1215,7 +1215,8 @@ func (ts *IntegrationTests) deleteIndex(name string) error {
 
 	index, err := ts.client.DescribeIndex(context.Background(), name)
 	require.NoError(ts.T(), err)
-	fmt.Printf("<<< TRYING TO DELETE INDEX >>> : %+v\n", index)
+	fmt.Printf("<<< TRYING TO DELETE INDEX >>> : %+v", index)
+	fmt.Printf("<<< STATE >>> : %+v\n", index.Status)
 
 	err = ts.client.DeleteIndex(context.Background(), name)
 	require.NoError(ts.T(), err)

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -216,7 +216,7 @@ func (ts *IntegrationTests) TestConfigureIndexScaleUpNoPods() {
 	_, err = ts.client.ConfigureIndex(context.Background(), name, ConfigureIndexParams{Replicas: 2})
 	require.NoError(ts.T(), err)
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(4 * time.Second)
 
 	// Before moving on to another test, wait for the index to be done upgrading
 	_, err = WaitUntilIndexReady(ts, context.Background())
@@ -248,13 +248,13 @@ func (ts *IntegrationTests) TestConfigureIndexScaleUpNoReplicas() {
 	_, err = ts.client.ConfigureIndex(context.Background(), name, ConfigureIndexParams{PodType: "p1.x4"})
 	require.NoError(ts.T(), err)
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(4 * time.Second)
 
 	// Before moving on to another test, wait for the index to be done upgrading
 	_, err = WaitUntilIndexReady(ts, context.Background())
 	require.NoError(ts.T(), err)
 
-	ts.client.DeleteIndex(context.Background(), name)
+	err = ts.client.DeleteIndex(context.Background(), name)
 	require.NoError(ts.T(), err)
 }
 

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -1209,6 +1209,7 @@ func TestBuildClientBaseOptionsUnit(t *testing.T) {
 
 // Helper functions:
 func (ts *IntegrationTests) deleteIndex(name string) error {
+	time.Sleep(3 * time.Second)
 	_, err := WaitUntilIndexReady(ts, context.Background())
 	require.NoError(ts.T(), err)
 

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -40,7 +40,7 @@ func (ts *IntegrationTests) TestCreatePodIndex() {
 
 	idx, err := ts.client.CreatePodIndex(context.Background(), &CreatePodIndexRequest{
 		Name:        name,
-		Dimension:   10,
+		Dimension:   2,
 		Metric:      Cosine,
 		Environment: "us-east1-gcp",
 		PodType:     "p1.x1",
@@ -180,7 +180,7 @@ func (ts *IntegrationTests) TestConfigureIndexIllegalScaleDown() {
 
 	_, err := ts.client.CreatePodIndex(context.Background(), &CreatePodIndexRequest{
 		Name:        name,
-		Dimension:   10,
+		Dimension:   2,
 		Metric:      Cosine,
 		Environment: "us-east1-gcp",
 		PodType:     "p1.x2",
@@ -203,7 +203,7 @@ func (ts *IntegrationTests) TestConfigureIndexScaleUpNoPods() {
 
 	_, err := ts.client.CreatePodIndex(context.Background(), &CreatePodIndexRequest{
 		Name:        name,
-		Dimension:   10,
+		Dimension:   2,
 		Metric:      Cosine,
 		Environment: "us-east1-gcp",
 		PodType:     "p1.x2",
@@ -230,7 +230,7 @@ func (ts *IntegrationTests) TestConfigureIndexScaleUpNoReplicas() {
 
 	_, err := ts.client.CreatePodIndex(context.Background(), &CreatePodIndexRequest{
 		Name:        name,
-		Dimension:   10,
+		Dimension:   2,
 		Metric:      Cosine,
 		Environment: "us-east1-gcp",
 		PodType:     "p1.x2",
@@ -262,7 +262,7 @@ func (ts *IntegrationTests) TestConfigureIndexHitPodLimit() {
 
 	_, err := ts.client.CreatePodIndex(context.Background(), &CreatePodIndexRequest{
 		Name:        name,
-		Dimension:   10,
+		Dimension:   2,
 		Metric:      Cosine,
 		Environment: "us-east1-gcp",
 		PodType:     "p1.x2",

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -10,7 +10,6 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pinecone-io/go-pinecone/internal/gen"
@@ -166,9 +165,6 @@ func (ts *IntegrationTests) TestDeletionProtection() {
 	_, err = ts.client.ConfigureIndex(context.Background(), ts.idxName, ConfigureIndexParams{DeletionProtection: "disabled"})
 	require.NoError(ts.T(), err)
 
-	// allow time for the index to start upgrading
-	time.Sleep(5 * time.Second)
-
 	// Before moving on to another test, wait for the index to be done upgrading
 	_, err = WaitUntilIndexReady(ts, context.Background())
 	require.NoError(ts.T(), err)
@@ -219,9 +215,6 @@ func (ts *IntegrationTests) TestConfigureIndexScaleUpNoPods() {
 	_, err = ts.client.ConfigureIndex(context.Background(), name, ConfigureIndexParams{Replicas: 2})
 	require.NoError(ts.T(), err)
 
-	// allow time for the index to start upgrading
-	time.Sleep(5 * time.Second)
-
 	// Before moving on to another test, wait for the index to be done upgrading
 	_, err = WaitUntilIndexReady(ts, context.Background())
 	require.NoError(ts.T(), err)
@@ -248,9 +241,6 @@ func (ts *IntegrationTests) TestConfigureIndexScaleUpNoReplicas() {
 
 	_, err = ts.client.ConfigureIndex(context.Background(), name, ConfigureIndexParams{PodType: "p1.x4"})
 	require.NoError(ts.T(), err)
-
-	// allow time for the index to start upgrading
-	time.Sleep(5 * time.Second)
 
 	// Before moving on to another test, wait for the index to be done upgrading
 	_, err = WaitUntilIndexReady(ts, context.Background())
@@ -1209,8 +1199,6 @@ func TestBuildClientBaseOptionsUnit(t *testing.T) {
 
 // Helper functions:
 func (ts *IntegrationTests) deleteIndex(name string) error {
-	time.Sleep(5 * time.Second)
-
 	_, err := WaitUntilIndexReady(ts, context.Background())
 	require.NoError(ts.T(), err)
 
@@ -1219,9 +1207,7 @@ func (ts *IntegrationTests) deleteIndex(name string) error {
 	fmt.Printf("<<< TRYING TO DELETE INDEX >>> : %+v", index)
 	fmt.Printf("<<< STATE >>> : %+v\n", index.Status)
 
-	err = ts.client.DeleteIndex(context.Background(), name)
-	require.NoError(ts.T(), err)
-	return nil
+	return ts.client.DeleteIndex(context.Background(), name)
 }
 
 func mockResponse(body string, statusCode int) *http.Response {

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -167,7 +167,7 @@ func (ts *IntegrationTests) TestDeletionProtection() {
 	require.NoError(ts.T(), err)
 
 	// allow time for the index to start upgrading
-	time.Sleep(3 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	// Before moving on to another test, wait for the index to be done upgrading
 	_, err = WaitUntilIndexReady(ts, context.Background())
@@ -220,7 +220,7 @@ func (ts *IntegrationTests) TestConfigureIndexScaleUpNoPods() {
 	require.NoError(ts.T(), err)
 
 	// allow time for the index to start upgrading
-	time.Sleep(3 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	// Before moving on to another test, wait for the index to be done upgrading
 	_, err = WaitUntilIndexReady(ts, context.Background())
@@ -250,7 +250,7 @@ func (ts *IntegrationTests) TestConfigureIndexScaleUpNoReplicas() {
 	require.NoError(ts.T(), err)
 
 	// allow time for the index to start upgrading
-	time.Sleep(3 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	// Before moving on to another test, wait for the index to be done upgrading
 	_, err = WaitUntilIndexReady(ts, context.Background())

--- a/pinecone/test_suite.go
+++ b/pinecone/test_suite.go
@@ -137,6 +137,7 @@ func WaitUntilIndexReady(ts *IntegrationTests, ctx context.Context) (bool, error
 		}
 		if index.Status.State == Ready && index.Status.Ready {
 			fmt.Printf("Index \"%s\" is ready!\n", ts.idxName)
+			fmt.Printf("BUT YEAH YOU SHOULD DOUBLE CHECK : %+v\n", index.Status)
 			return true, nil
 		} else {
 			fmt.Printf("Index \"%s\" not ready yet, retrying... (%d/%d)\n", ts.idxName, i, maxRetries)

--- a/pinecone/test_suite.go
+++ b/pinecone/test_suite.go
@@ -129,6 +129,7 @@ func WaitUntilIndexReady(ts *IntegrationTests, ctx context.Context) (bool, error
 	maxRetries := 24
 	delay := 5 * time.Second
 	totalSeconds := 0
+	time.Sleep(2 * time.Second)
 
 	for i := 0; i < maxRetries; i++ {
 		index, err := ts.client.DescribeIndex(ctx, ts.idxName)

--- a/pinecone/test_suite.go
+++ b/pinecone/test_suite.go
@@ -141,10 +141,13 @@ func WaitUntilIndexReady(ts *IntegrationTests, ctx context.Context) (bool, error
 
 		totalSeconds := time.Since(start)
 
+		if totalSeconds >= maxWaitTimeSeconds {
+			return false, fmt.Errorf("Index \"%s\" not ready after %f seconds", ts.idxName, totalSeconds.Seconds())
+		}
+
 		fmt.Printf("Index \"%s\" not ready yet, retrying... (%f/%f)\n", ts.idxName, totalSeconds.Seconds(), maxWaitTimeSeconds.Seconds())
 		time.Sleep(delay)
 	}
-
 }
 
 func createVectorsForUpsert() []*Vector {

--- a/pinecone/test_suite.go
+++ b/pinecone/test_suite.go
@@ -139,7 +139,6 @@ func WaitUntilIndexReady(ts *IntegrationTests, ctx context.Context) (bool, error
 			return true, err
 		}
 
-		time.Sleep(delay)
 		totalSeconds := time.Since(start)
 
 		fmt.Printf("Index \"%s\" not ready yet, retrying... (%f/%f)\n", ts.idxName, totalSeconds.Seconds(), maxWaitTimeSeconds.Seconds())


### PR DESCRIPTION
## Problem
The `2024-07` release of the Pinecone API included [Inference operations](https://docs.pinecone.io/reference/api/2024-07/inference/generate-embeddings). Currently `pinecone-ts-client`, `pinecone-python-client`, and `pinecone-rust-client` support Inference.

We'd like to expose the `Embed` operation in the Go SDK.

## Solution
I followed a similar approach to how we've addressed adding inference in other SDKs. Specifically, after discussing things internally I've opted to add an `Inference` namespace to the `Client` struct to add separation between existing index management operations, and inference-related operations such as `Embed`. This approach is similar to the implementation in Python and TypeScript.

- Add new structs: `EmbedRequest`, `EmbedParameters`, and `InferenceService`. Add a new `Inference` field to `Client` which holds an `*InferenceService` value allowing users to interact with the Inference API.
- Attach new `Embed` method to `InferenceService` which wraps the underlying `Embed` call on `*control.Client`, and handles massaging the input and output to match the generated types.
- Add new integration tests to cover `Embed` in `client_test.go`.
- Add doc comments to new code, update README to include an Inference section.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
Added integration tests to validate calling the new `client.Inference.Embed()` function.

In order to test yourself you'll need to consume this branch as a dependency locally, and then call the `Embed` operation:

`go get` the branch for this PR:
```bash
go get github.com/pinecone-io/go-pinecone@adenoble/implement-inference
```
In your Go code:
```go
ctx := context.Background()

pc, err := pinecone.NewClient(pinecone.NewClientParams{
    ApiKey: "YOUR_API_KEY",
})
if err !=  nil {
    log.Fatalf("Failed to create Client: %v", err)
}

embeddingModel := "multilingual-e5-large"
documents := []string{
    "Turkey is a classic meat to eat at American Thanksgiving."
    "Many people enjoy the beautiful mosques in Turkey."
}
docParameters := pinecone.EmbedParameters{
    InputType: "passage",
    Truncate: "END",
}

docEmbeddingsResponse, err := pc.Inference.Embed(ctx, &pinecone.EmbedRequest{
    Model: embeddingModel,
    TextInputs: documents,
    Parameters: docParameters,
})
if err != nil {
    log.Fatalf("Failed to embed documents: %v", err)
}
fmt.Printf("docs embedding response: %+v", docEmbeddingsResponse)
```
