### PR TITLE
Fix runner in `release` workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   bump-version-and-release:
-    runs-on: ubuntu-lastest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Problem
Was trying to run the new GitHub release action for the Go SDK and realized there's a misspelling in `ubuntu-latest`.

## Solution
Fix `runs-on` to properly be `ubuntu-latest`.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
N/A - rerun the workflow once this is merged
