### PR TITLE
Pass `currentVersion` in `release` workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,12 +26,13 @@ on:
         description: "Suffix to add to version number for marking as a pre-release alpha or beta client. Value ignored when isPrerelease is false"
         required: false
         type: string
-        default: "alpha1"
+        default: ""
 
 jobs:
   bump-version-and-release:
     runs-on: ubuntu-latest
-
+    env:
+      SEMVER_VERSION: "" # Set by the get_tag_version step
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -53,13 +54,13 @@ jobs:
           tag=$(git describe --tags --abbrev=0)
           semver=${tag#v}  # Remove the 'v' prefix from version number
           echo "Current Released Version: $semver"
-          echo "semver=$semver" >> $GITHUB_ENV # Set as environment variable
+          echo "SEMVER_VERSION=$semver" >> $GITHUB_ENV # Set as environment variable
 
       - name: Bump version
         id: bump
         uses: "./.github/actions/bump-version"
         with:
-          versionFile: pinecone/__version__
+          currentVersion: ${{ env.SEMVER_VERSION}}
           bumpType: ${{ inputs.releaseLevel }}
           prereleaseSuffix: ${{ inputs.prereleaseSuffix }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SEMVER_VERSION: "" # Set by the get_tag_version step
+      PRERELEASE_SUFFIX: "" # Set by the set_prerelease_suffix step
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,7 +49,7 @@ jobs:
             exit 1
           fi
 
-      - name: Extract current release version through tag
+      - name: Extract current release version through tag and set SEMVER_VERSION
         id: get_tag_version
         run: |
           tag=$(git describe --tags --abbrev=0)
@@ -56,13 +57,19 @@ jobs:
           echo "Current Released Version: $semver"
           echo "SEMVER_VERSION=$semver" >> $GITHUB_ENV # Set as environment variable
 
+      - name: Set PRERELEASE_SUFFIX if isPrerelease is true
+        id: set_prerelease_suffix
+        if: ${{ inputs.isPrerelease == true }}
+        run: |
+          echo "PRERELEASE_SUFFIX=${{ inputs.prereleaseSuffix }}" >> $GITHUB_ENV
+
       - name: Bump version
         id: bump
         uses: "./.github/actions/bump-version"
         with:
           currentVersion: ${{ env.SEMVER_VERSION}}
           bumpType: ${{ inputs.releaseLevel }}
-          prereleaseSuffix: ${{ inputs.prereleaseSuffix }}
+          prereleaseSuffix: ${{ env.PRERELEASE_SUFFIX }}
 
       - name: Verify unique release tag
         run: |


### PR DESCRIPTION
## Problem
I tried running the new `release` action and it errored when trying to push to `main` and when generating the new version tag due to 3 things:
- `main` branch doesn't allow pushes without PRs, we need to disable that to allow more flexibility from CI (we do this in the python and typescript repos).
- The `currentVersion` retrieved using `git describe` was not being passed to the `bump-version` action, so we ended up with NaN in the output.
- The `prereleaseSuffix` defaulting to "alpha1" and then being passed to `bump-version` was an issue because it was being appended whether or not `isPrerelease` was true.

Failed run: https://github.com/pinecone-io/go-pinecone/actions/runs/10529783970/job/29178282163

## Solution
- Add explicit `SEMVER_VERSION` and `PRERELEASE_SUFFIX` variables to the `release` workflow. Make sure these values are set in the `get_tag_version` and `set_prerelease_suffix` steps.
- Pass the `currentVersion` value to `bump-version` properly. 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
Push changes up and rerun the version bump.
