### PR TITLE
Return error for serverless index creation failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ func main() {
 	})
 
 	if err != nil {
-		log.Fatalf("Failed to create serverless index: %s", indexName)
+		log.Fatalf("Failed to create serverless index: %v", err)
 	} else {
 		fmt.Printf("Successfully created serverless index: %s", idx.Name)
 	}


### PR DESCRIPTION
## Problem

The create serverless index example doesn't return the error on index creation failure. 

## Solution

Fix the error message.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [x] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.
