### PR TITLE
Refactor sparse vector integration tests

### DIFF
--- a/pinecone/index_connection_test.go
+++ b/pinecone/index_connection_test.go
@@ -66,17 +66,6 @@ func (ts *IntegrationTests) TestDeleteVectorsById() {
 	}
 }
 
-func (ts *IntegrationTests) TestUpsertSparseVectors() {
-	ctx := context.Background()
-	err := ts.idxConn.DeleteAllVectorsInNamespace(ctx)
-	assert.NoError(ts.T(), err)
-
-	_, err = ts.idxConn.UpsertVectors(ctx, generateVectors(5, ts.dimension))
-	if err != nil {
-		log.Fatalf("Failed to upsert sparse vectors in TestUpsertSparseVectors test. Error: %v", err)
-	}
-}
-
 func (ts *IntegrationTests) TestDeleteVectorsByFilter() {
 	metadataFilter := map[string]interface{}{
 		"genre": "classical",

--- a/pinecone/index_connection_test.go
+++ b/pinecone/index_connection_test.go
@@ -60,9 +60,20 @@ func (ts *IntegrationTests) TestDeleteVectorsById() {
 	err := ts.idxConn.DeleteVectorsById(ctx, ts.vectorIds)
 	assert.NoError(ts.T(), err)
 
-	_, err = ts.idxConn.UpsertVectors(ctx, createVectorsForUpsert())
+	_, err = ts.idxConn.UpsertVectors(ctx, generateVectors(5, ts.dimension))
 	if err != nil {
 		log.Fatalf("Failed to upsert vectors in TestDeleteVectorsById test. Error: %v", err)
+	}
+}
+
+func (ts *IntegrationTests) TestUpsertSparseVectors() {
+	ctx := context.Background()
+	err := ts.idxConn.DeleteAllVectorsInNamespace(ctx)
+	assert.NoError(ts.T(), err)
+
+	_, err = ts.idxConn.UpsertVectors(ctx, generateVectors(5, ts.dimension))
+	if err != nil {
+		log.Fatalf("Failed to upsert sparse vectors in TestUpsertSparseVectors test. Error: %v", err)
 	}
 }
 
@@ -85,7 +96,7 @@ func (ts *IntegrationTests) TestDeleteVectorsByFilter() {
 		assert.NoError(ts.T(), err)
 	}
 
-	_, err = ts.idxConn.UpsertVectors(ctx, createVectorsForUpsert())
+	_, err = ts.idxConn.UpsertVectors(ctx, generateVectors(5, ts.dimension))
 	if err != nil {
 		log.Fatalf("Failed to upsert vectors in TestDeleteVectorsById test. Error: %v", err)
 	}
@@ -96,7 +107,7 @@ func (ts *IntegrationTests) TestDeleteAllVectorsInNamespace() {
 	err := ts.idxConn.DeleteAllVectorsInNamespace(ctx)
 	assert.NoError(ts.T(), err)
 
-	_, err = ts.idxConn.UpsertVectors(ctx, createVectorsForUpsert())
+	_, err = ts.idxConn.UpsertVectors(ctx, generateVectors(5, ts.dimension))
 	if err != nil {
 		log.Fatalf("Failed to upsert vectors in TestDeleteVectorsById test. Error: %v", err)
 	}

--- a/pinecone/index_connection_test.go
+++ b/pinecone/index_connection_test.go
@@ -59,11 +59,21 @@ func (ts *IntegrationTests) TestDeleteVectorsById() {
 	ctx := context.Background()
 	err := ts.idxConn.DeleteVectorsById(ctx, ts.vectorIds)
 	assert.NoError(ts.T(), err)
+	ts.vectorIds = []string{}
 
-	_, err = ts.idxConn.UpsertVectors(ctx, generateVectors(5, ts.dimension))
+	vectors := GenerateVectors(5, ts.dimension, true)
+
+	_, err = ts.idxConn.UpsertVectors(ctx, vectors)
 	if err != nil {
 		log.Fatalf("Failed to upsert vectors in TestDeleteVectorsById test. Error: %v", err)
 	}
+
+	vectorIds := make([]string, len(vectors))
+	for i, v := range vectors {
+		vectorIds[i] = v.Id
+	}
+
+	ts.vectorIds = append(ts.vectorIds, vectorIds...)
 }
 
 func (ts *IntegrationTests) TestDeleteVectorsByFilter() {
@@ -84,22 +94,42 @@ func (ts *IntegrationTests) TestDeleteVectorsByFilter() {
 	} else {
 		assert.NoError(ts.T(), err)
 	}
+	ts.vectorIds = []string{}
 
-	_, err = ts.idxConn.UpsertVectors(ctx, generateVectors(5, ts.dimension))
+	vectors := GenerateVectors(5, ts.dimension, true)
+
+	_, err = ts.idxConn.UpsertVectors(ctx, vectors)
 	if err != nil {
 		log.Fatalf("Failed to upsert vectors in TestDeleteVectorsById test. Error: %v", err)
 	}
+
+	vectorIds := make([]string, len(vectors))
+	for i, v := range vectors {
+		vectorIds[i] = v.Id
+	}
+
+	ts.vectorIds = append(ts.vectorIds, vectorIds...)
 }
 
 func (ts *IntegrationTests) TestDeleteAllVectorsInNamespace() {
 	ctx := context.Background()
 	err := ts.idxConn.DeleteAllVectorsInNamespace(ctx)
 	assert.NoError(ts.T(), err)
+	ts.vectorIds = []string{}
 
-	_, err = ts.idxConn.UpsertVectors(ctx, generateVectors(5, ts.dimension))
+	vectors := GenerateVectors(5, ts.dimension, true)
+
+	_, err = ts.idxConn.UpsertVectors(ctx, vectors)
 	if err != nil {
 		log.Fatalf("Failed to upsert vectors in TestDeleteVectorsById test. Error: %v", err)
 	}
+
+	vectorIds := make([]string, len(vectors))
+	for i, v := range vectors {
+		vectorIds[i] = v.Id
+	}
+
+	ts.vectorIds = append(ts.vectorIds, vectorIds...)
 
 }
 


### PR DESCRIPTION
## Problem
We had a ticket logged for making sure that we covered working with sparse vectors in integration tests.

## Solution
I realized we were already creating sparse vectors whenever we called `createVectorsForUpsert`, but the function was a bit unwieldy to work with. 

I refactored things into a new helper `func GenerateVectors(numOfVectors int, dimension int32, isSparse bool) []*Vector`. This is a bit more flexible.

I also cleaned up how we were handling the `IntegrationTest.vectorIds` field on the test struct. I wanted to make sure we were consistently adding to and deleting from this collection across tests.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
Existing integration tests should pass.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207937493683805