### PR TITLE
Fix `normalizeHost`, allow for non-secure connections

### DIFF
--- a/pinecone/index_connection_test.go
+++ b/pinecone/index_connection_test.go
@@ -1000,33 +1000,29 @@ func TestToUsageUnit(t *testing.T) {
 
 func TestNormalizeHostUnit(t *testing.T) {
 	tests := []struct {
-		name         string
-		host         string
-		expectedHost string
+		name             string
+		host             string
+		expectedHost     string
+		expectedIsSecure bool
 	}{
 		{
-			name:         "https:// scheme should be removed",
-			host:         "https://this-is-my-host.io",
-			expectedHost: "this-is-my-host.io:443",
+			name:             "https:// scheme should be removed",
+			host:             "https://this-is-my-host.io",
+			expectedHost:     "this-is-my-host.io",
+			expectedIsSecure: true,
 		}, {
-			name:         "https:// scheme with a port should be removed",
-			host:         "https://this-is-my-host.io:33445",
-			expectedHost: "this-is-my-host.io:33445",
-		}, {
-			name:         "http:// scheme without a port should be removed",
-			host:         "http://this-is-my-host.io",
-			expectedHost: "this-is-my-host.io:443",
-		}, {
-			name:         "http:// scheme and port should be maintained",
-			host:         "http://this-is-my-host.io:8080",
-			expectedHost: "http://this-is-my-host.io:8080",
+			name:             "https:// scheme should be removed",
+			host:             "https://this-is-my-host.io:33445",
+			expectedHost:     "this-is-my-host.io:33445",
+			expectedIsSecure: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := normalizeHost(tt.host)
+			result, isSecure := normalizeHost(tt.host)
 			assert.Equal(t, tt.expectedHost, result, "Expected result to be '%s', but got '%s'", tt.expectedHost, result)
+			assert.Equal(t, tt.expectedIsSecure, isSecure, "Expected isSecure to be '%t', but got '%t'", tt.expectedIsSecure, isSecure)
 		})
 	}
 }


### PR DESCRIPTION
## Problem
When working with specific environments and hosts that require a non-secure connection, calling `pc.Index(pinecone.NewIndexConnParams{Host: idx.Host})` with a `Host` value that is insecure, you'll run into unexpected behavior seeing `:443` attached as a port, or gRPC errors around connecting insecurely without explicitly passing a `grpc.DialOption`.

Our `normalizeHost` function has a bug in that it applies port `:443` to `Host` values which are passed without an explicit scheme.

## Solution
- We can simplify the `normalizeHost` function to only deal with stripping away any provided scheme, and then checking to see if the connection is explicitly insecure. This is accomplished by providing `http://` as a part of the `NewIndexConnParams{ Host: yourHost }` value, which would need to be accounted for in documentation, etc.

This felt most straightforward because of how the `grpc` module handles host addresses. Ultimately, we need to strip the scheme off any hosts that are passed, but we also need to decide whether we're dialing in a secure or insecure fashion. I thought of providing an explicit `bool` as a part of the `NewIndexConnParams`, but it felt more unwieldy adding new fields.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

I have a local test harness that I'm using to interact with a locally hosted index. I was overriding the `go-pinecone` package in `go.mod` to work against my local copy of the SDK. You can pull this branch down and do something similar locally. Here are some of my results:

### Before
![Screenshot 2024-09-12 at 10 09 45 PM](https://github.com/user-attachments/assets/1ba87d57-24ee-44ab-bb14-08b7fe98a683)

### After
![Screenshot 2024-09-12 at 10 33 59 PM](https://github.com/user-attachments/assets/c26ad177-3ca6-4664-a708-31ea4fccff3e)


