### PR TITLE
Rebase & Implement Rerank

### DIFF
--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -1450,9 +1450,11 @@ func (i *InferenceService) Rerank(ctx context.Context, in *RerankRequest) (*Rera
 	req := inference.RerankJSONRequestBody{
 		Model:           in.Model,
 		Query:           in.Query,
+		Documents:       convertedDocuments,
+		RankFields:      in.RankFields,
 		ReturnDocuments: in.ReturnDocuments,
 		TopN:            in.TopN,
-		Documents:       convertedDocuments,
+		Parameters:      in.Parameters,
 	}
 	res, err := i.client.Rerank(ctx, req)
 	if err != nil {

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -1351,11 +1351,12 @@ type Document map[string]string
 //
 // Fields:
 //   - Model: "The [model] to use for reranking.
-//   - Query: (Required) The query to compare with documents.
-//   - Documents: (Required) A list of Document objects to be reranked.
-//   - RankFields: (Optional) A list of document fields to use for ranking.
-//   - ReturnDocuments: (Optional) Whether to include documents in the response. Defaults to true.
-//   - TopN: (Optional) How many documents to return. Defaults to the length of input Documents.
+//   - Query: (Required) The query to rerank Documents against.
+//   - Documents: (Required) A list of Document objects to be reranked. The default is "text", but you can
+//     specify this behavior with [RerankRequest.RankFields].
+//   - RankFields: (Optional) The fields to rank the Documents by. If not provided, the default is "text".
+//   - ReturnDocuments: (Optional) Whether to include Documents in the response. Defaults to true.
+//   - TopN: (Optional) How many Documents to return. Defaults to the length of input Documents.
 //   - Parameters: (Optional) Additional model-specific parameters for the reranker
 //
 // [model]: https://docs.pinecone.io/guides/inference/understanding-inference#models
@@ -1373,9 +1374,9 @@ type RerankRequest struct {
 //
 // Fields:
 //   - Document: The [Document].
-//   - Index: The index position of the document from the original request. This can be used
+//   - Index: The index position of the Document from the original request. This can be used
 //     to locate the position of the document relative to others described in the request.
-//   - Score: The relevance score of the document indicating how closely it matches the query.
+//   - Score: The relevance score of the Document indicating how closely it matches the query.
 type RankedDocument struct {
 	Document *Document `json:"document,omitempty"`
 	Index    int       `json:"index"`
@@ -1385,17 +1386,19 @@ type RankedDocument struct {
 // RerankResponse is the result of a reranking operation.
 //
 // Fields:
-//   - Data: A list of documents which have been reranked. The documents are sorted in order of relevance,
+//   - Data: A list of Documents which have been reranked. The Documents are sorted in order of relevance,
 //     with the first being the most relevant.
-//   - Model: The model used to rerank documents.
-//   - Usage: Usage statistics for the reranking operation.
+//   - Model: The model used to rerank Documents.
+//   - Usage: Usage statistics ([Rerank Units]) for the reranking operation.
+//
+// [Read Units]: https://docs.pinecone.io/guides/organizations/manage-cost/understanding-cost#rerank
 type RerankResponse struct {
 	Data  []RankedDocument `json:"data,omitempty"`
 	Model string           `json:"model"`
 	Usage RerankUsage      `json:"usage"`
 }
 
-// Rerank documents with associated relevance scores that represent the relevance of each document
+// Rerank Documents with associated relevance scores that represent the relevance of each Document
 // to the provided query using the specified model.
 //
 // Parameters:
@@ -1421,15 +1424,15 @@ type RerankResponse struct {
 //	     topN := 2
 //	     retunDocuments := true
 //	     documents := []pinecone.Document{
-//		        {"id": "vec1", "text": "Apple is a popular fruit known for its sweetness and crisp texture."},
-//		        {"id": "vec2", "text": "Many people enjoy eating apples as a healthy snack."},
-//		        {"id": "vec3", "text": "Apple Inc. has revolutionized the tech industry with its sleek designs and user-friendly interfaces."},
-//		        {"id": "vec4", "text": "An apple a day keeps the doctor away, as the saying goes."},
+//		        {"id": "doc1", "text": "Apple is a popular fruit known for its sweetness and crisp texture."},
+//		        {"id": "doc2", "text": "Many people enjoy eating apples as a healthy snack."},
+//		        {"id": "doc3", "text": "Apple Inc. has revolutionized the tech industry with its sleek designs and user-friendly interfaces."},
+//		        {"id": "doc4", "text": "An apple a day keeps the doctor away, as the saying goes."},
 //	     }
 //
 //	     ranking, err := pc.Inference.Rerank(ctx, &pinecone.RerankRequest{
 //		        Model:           rerankModel,
-//		        Query:           "i love cats",
+//		        Query:           "i love to eat apples",
 //		        ReturnDocuments: &retunDocuments,
 //		        TopN:            &topN,
 //		        RankFields:      &[]string{"text"},

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -316,21 +316,23 @@ func (ts *IntegrationTests) TestGenerateEmbeddingsInvalidInputs() {
 func (ts *IntegrationTests) TestRerankDocument() {
 	ctx := context.Background()
 	rerankModel := "bge-reranker-v2-m3"
+	topN := 4
 	ranking, err := ts.client.Inference.Rerank(ctx, &RerankRequest{
 		Model:           rerankModel,
-		Query:           "The tech company Apple is known for its innovative products like the iPhone.",
-		ReturnDocuments: true,
-		TopN:            4,
+		Query:           "i love cats",
+		ReturnDocuments: nil,
+		TopN:            &topN,
+		RankFields:      &[]string{"text"},
 		Documents: []Document{
-			{Id: "vec1", Text: "Apple is a popular fruit known for its sweetness and crisp texture."},
-			{Id: "vec2", Text: "Many people enjoy eating apples as a healthy snack."},
-			{Id: "vec3", Text: "Apple Inc. has revolutionized the tech industry with its sleek designs and user-friendly interfaces."},
-			{Id: "vec4", Text: "An apple a day keeps the doctor away, as the saying goes."},
+			{"id": "vec1", "text": "Apple is a popular fruit known for its sweetness and crisp texture."},
+			{"id": "vec2", "text": "Many people enjoy eating apples as a healthy snack."},
+			{"id": "vec3", "text": "Apple Inc. has revolutionized the tech industry with its sleek designs and user-friendly interfaces."},
+			{"id": "vec4", "text": "An apple a day keeps the doctor away, as the saying goes."},
 		}})
 
 	require.NoError(ts.T(), err)
 	require.NotNil(ts.T(), ranking, "Expected reranking result to be non-nil")
-	require.Equal(ts.T(), 4, len(*ranking.Data), "Expected 4 rankings")
+	require.Equal(ts.T(), 4, len(ranking.Data), "Expected 4 rankings")
 }
 
 // Unit tests:

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -317,10 +317,11 @@ func (ts *IntegrationTests) TestRerankDocument() {
 	ctx := context.Background()
 	rerankModel := "bge-reranker-v2-m3"
 	topN := 4
+	retunDocuments := true
 	ranking, err := ts.client.Inference.Rerank(ctx, &RerankRequest{
 		Model:           rerankModel,
 		Query:           "i love cats",
-		ReturnDocuments: nil,
+		ReturnDocuments: &retunDocuments,
 		TopN:            &topN,
 		RankFields:      &[]string{"text"},
 		Documents: []Document{

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -313,6 +313,26 @@ func (ts *IntegrationTests) TestGenerateEmbeddingsInvalidInputs() {
 	require.Contains(ts.T(), err.Error(), "TextInputs must contain at least one value")
 }
 
+func (ts *IntegrationTests) TestRerankDocument() {
+	ctx := context.Background()
+	rerankModel := "bge-reranker-v2-m3"
+	ranking, err := ts.client.Inference.Rerank(ctx, &RerankRequest{
+		Model:           rerankModel,
+		Query:           "The tech company Apple is known for its innovative products like the iPhone.",
+		ReturnDocuments: true,
+		TopN:            4,
+		Documents: []Document{
+			{Id: "vec1", Text: "Apple is a popular fruit known for its sweetness and crisp texture."},
+			{Id: "vec2", Text: "Many people enjoy eating apples as a healthy snack."},
+			{Id: "vec3", Text: "Apple Inc. has revolutionized the tech industry with its sleek designs and user-friendly interfaces."},
+			{Id: "vec4", Text: "An apple a day keeps the doctor away, as the saying goes."},
+		}})
+
+	require.NoError(ts.T(), err)
+	require.NotNil(ts.T(), ranking, "Expected reranking result to be non-nil")
+	require.Equal(ts.T(), 4, len(*ranking.Data), "Expected 4 rankings")
+}
+
 // Unit tests:
 func TestExtractAuthHeaderUnit(t *testing.T) {
 	globalApiKey := os.Getenv("PINECONE_API_KEY")

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -13,11 +13,11 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
 	"github.com/pinecone-io/go-pinecone/internal/gen"
 	"github.com/pinecone-io/go-pinecone/internal/gen/db_control"
 	"github.com/pinecone-io/go-pinecone/internal/provider"
 
-	"github.com/google/uuid"
 	"github.com/pinecone-io/go-pinecone/internal/utils"
 
 	"github.com/stretchr/testify/assert"
@@ -277,6 +277,11 @@ func (ts *IntegrationTests) TestConfigureIndexHitPodLimit() {
 }
 
 func (ts *IntegrationTests) TestGenerateEmbeddings() {
+	// Run Embed tests once rather than duplicating across serverless & pods
+	if ts.indexType == "pod" {
+		ts.T().Skip("Skipping Embed tests for pods")
+	}
+
 	ctx := context.Background()
 	embeddingModel := "multilingual-e5-large"
 	embeddings, err := ts.client.Inference.Embed(ctx, &EmbedRequest{
@@ -313,17 +318,21 @@ func (ts *IntegrationTests) TestGenerateEmbeddingsInvalidInputs() {
 	require.Contains(ts.T(), err.Error(), "TextInputs must contain at least one value")
 }
 
-func (ts *IntegrationTests) TestRerankDocument() {
+func (ts *IntegrationTests) TestRerankDocumentDefaultField() {
+	// Run Rerank tests once rather than duplicating across serverless & pods
+	if ts.indexType == "pod" {
+		ts.T().Skip("Skipping Rerank tests for pods")
+	}
+
 	ctx := context.Background()
 	rerankModel := "bge-reranker-v2-m3"
-	topN := 4
+	topN := 2
 	retunDocuments := true
 	ranking, err := ts.client.Inference.Rerank(ctx, &RerankRequest{
 		Model:           rerankModel,
-		Query:           "i love cats",
+		Query:           "i love apples",
 		ReturnDocuments: &retunDocuments,
 		TopN:            &topN,
-		RankFields:      &[]string{"text"},
 		Documents: []Document{
 			{"id": "vec1", "text": "Apple is a popular fruit known for its sweetness and crisp texture."},
 			{"id": "vec2", "text": "Many people enjoy eating apples as a healthy snack."},
@@ -333,7 +342,138 @@ func (ts *IntegrationTests) TestRerankDocument() {
 
 	require.NoError(ts.T(), err)
 	require.NotNil(ts.T(), ranking, "Expected reranking result to be non-nil")
-	require.Equal(ts.T(), 4, len(ranking.Data), "Expected 4 rankings")
+	require.Equal(ts.T(), topN, len(ranking.Data), "Expected %v rankings", topN)
+
+	doc := *ranking.Data[0].Document
+	_, exists := doc["text"]
+	require.True(ts.T(), exists, "Expected '%s' to exist in Document map", "text")
+	_, exists = doc["id"]
+	require.True(ts.T(), exists, "Expected '%s' to exist in Document map", "id")
+}
+
+func (ts *IntegrationTests) TestRerankDocumentCustomField() {
+	// Run Rerank tests once rather than duplicating across serverless & pods
+	if ts.indexType == "pod" {
+		ts.T().Skip("Skipping Rerank tests for pods")
+	}
+
+	ctx := context.Background()
+	rerankModel := "bge-reranker-v2-m3"
+	topN := 2
+	retunDocuments := true
+	ranking, err := ts.client.Inference.Rerank(ctx, &RerankRequest{
+		Model:           rerankModel,
+		Query:           "i love apples",
+		ReturnDocuments: &retunDocuments,
+		TopN:            &topN,
+		RankFields:      &[]string{"customField"},
+		Documents: []Document{
+			{"id": "vec1", "customField": "Apple is a popular fruit known for its sweetness and crisp texture."},
+			{"id": "vec2", "customField": "Many people enjoy eating apples as a healthy snack."},
+			{"id": "vec3", "customField": "Apple Inc. has revolutionized the tech industry with its sleek designs and user-friendly interfaces."},
+			{"id": "vec4", "customField": "An apple a day keeps the doctor away, as the saying goes."},
+		}})
+
+	require.NoError(ts.T(), err)
+	require.NotNil(ts.T(), ranking, "Expected reranking result to be non-nil")
+	require.Equal(ts.T(), topN, len(ranking.Data), "Expected %v rankings", topN)
+
+	doc := *ranking.Data[0].Document
+	_, exists := doc["customField"]
+	require.True(ts.T(), exists, "Expected '%s' to exist in Document map", "customField")
+	_, exists = doc["id"]
+	require.True(ts.T(), exists, "Expected '%s' to exist in Document map", "id")
+}
+
+func (ts *IntegrationTests) TestRerankDocumentAllDefaults() {
+	// Run Rerank tests once rather than duplicating across serverless & pods
+	if ts.indexType == "pod" {
+		ts.T().Skip("Skipping Rerank tests for pods")
+	}
+
+	ctx := context.Background()
+	rerankModel := "bge-reranker-v2-m3"
+	ranking, err := ts.client.Inference.Rerank(ctx, &RerankRequest{
+		Model: rerankModel,
+		Query: "i love apples",
+		Documents: []Document{
+			{"id": "vec1", "text": "Apple is a popular fruit known for its sweetness and crisp texture."},
+			{"id": "vec2", "text": "Many people enjoy eating apples as a healthy snack."},
+			{"id": "vec3", "text": "Apple Inc. has revolutionized the tech industry with its sleek designs and user-friendly interfaces."},
+			{"id": "vec4", "text": "An apple a day keeps the doctor away, as the saying goes."},
+		}})
+
+	require.NoError(ts.T(), err)
+	require.NotNil(ts.T(), ranking, "Expected reranking result to be non-nil")
+	require.Equal(ts.T(), 4, len(ranking.Data), "Expected %v rankings", 4)
+
+	doc := *ranking.Data[0].Document
+	_, exists := doc["text"]
+	require.True(ts.T(), exists, "Expected '%s' to exist in Document map", "text")
+	_, exists = doc["id"]
+	require.True(ts.T(), exists, "Expected '%s' to exist in Document map", "id")
+}
+
+func (ts *IntegrationTests) TestRerankDocumentsMultipleRankFields() {
+	// Run Rerank tests once rather than duplicating across serverless & pods
+	if ts.indexType == "pod" {
+		ts.T().Skip("Skipping Rerank tests for pods")
+	}
+
+	ctx := context.Background()
+	rerankModel := "bge-reranker-v2-m3"
+	_, err := ts.client.Inference.Rerank(ctx, &RerankRequest{
+		Model:      rerankModel,
+		Query:      "i love apples",
+		RankFields: &[]string{"text", "custom-field"},
+		Documents: []Document{
+			{
+				"id":           "vec1",
+				"text":         "Apple is a popular fruit known for its sweetness and crisp texture.",
+				"custom-field": "another field",
+			},
+			{
+				"id":           "vec2",
+				"text":         "Many people enjoy eating apples as a healthy snack.",
+				"custom-field": "another field",
+			},
+			{
+				"id":           "vec3",
+				"text":         "Apple Inc. has revolutionized the tech industry with its sleek designs and user-friendly interfaces.",
+				"custom-field": "another field",
+			},
+			{
+				"id":           "vec4",
+				"text":         "An apple a day keeps the doctor away, as the saying goes.",
+				"custom-field": "another field",
+			},
+		}})
+
+	require.Error(ts.T(), err)
+	require.Contains(ts.T(), err.Error(), "Only one rank field is supported for model")
+}
+
+func (ts *IntegrationTests) TestRerankDocumentFieldError() {
+	// Run Rerank tests once rather than duplicating across serverless & pods
+	if ts.indexType == "pod" {
+		ts.T().Skip("Skipping Rerank tests for pods")
+	}
+
+	ctx := context.Background()
+	rerankModel := "bge-reranker-v2-m3"
+	_, err := ts.client.Inference.Rerank(ctx, &RerankRequest{
+		Model:      rerankModel,
+		Query:      "i love apples",
+		RankFields: &[]string{"custom-field"},
+		Documents: []Document{
+			{"id": "vec1", "text": "Apple is a popular fruit known for its sweetness and crisp texture."},
+			{"id": "vec2", "text": "Many people enjoy eating apples as a healthy snack."},
+			{"id": "vec3", "text": "Apple Inc. has revolutionized the tech industry with its sleek designs and user-friendly interfaces."},
+			{"id": "vec4", "text": "An apple a day keeps the doctor away, as the saying goes."},
+		}})
+
+	require.Error(ts.T(), err)
+	require.Contains(ts.T(), err.Error(), "field 'custom-field' not found in document")
 }
 
 // Unit tests:

--- a/pinecone/models.go
+++ b/pinecone/models.go
@@ -158,6 +158,9 @@ type Usage struct {
 	ReadUnits uint32 `json:"read_units"`
 }
 
+// RerankUsage is the usage stats ([Rerank Units]) for a reranking request.
+//
+// [Read Units]: https://docs.pinecone.io/guides/organizations/manage-cost/understanding-cost#rerank
 type RerankUsage struct {
 	RerankUnits *int `json:"rerank_units,omitempty"`
 }

--- a/pinecone/models.go
+++ b/pinecone/models.go
@@ -160,7 +160,7 @@ type Usage struct {
 
 // RerankUsage is the usage stats ([Rerank Units]) for a reranking request.
 //
-// [Read Units]: https://docs.pinecone.io/guides/organizations/manage-cost/understanding-cost#rerank
+// [Rerank Units]: https://docs.pinecone.io/guides/organizations/manage-cost/understanding-cost#rerank
 type RerankUsage struct {
 	RerankUnits *int `json:"rerank_units,omitempty"`
 }

--- a/pinecone/models.go
+++ b/pinecone/models.go
@@ -158,6 +158,10 @@ type Usage struct {
 	ReadUnits uint32 `json:"read_units"`
 }
 
+type RerankUsage struct {
+	RerankUnits *int `json:"rerank_units,omitempty"`
+}
+
 // MetadataFilter represents the [metadata filters] attached to a Pinecone request.
 // These optional metadata filters are applied to query and deletion requests.
 //


### PR DESCRIPTION
## Problem
The `InferenceService` and `Embed` operation were implemented in a previous PR: https://github.com/pinecone-io/go-pinecone/pull/67

As a part of the `2024-10` release we are also adding `Rerank` to the client, which will live under `InferenceService` with `Embed`.

## Solution
This work builds on top of external contributions from @Stosan (https://github.com/pinecone-io/go-pinecone/pull/73) Thank you for you diligence in getting this started!

- Update `InferenceService` to expose the new `Rerank` method.
- Add various request and response types to represent the interface.
- Add doc comments and an integration test for calling the reranker.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
`just test`

If you want to use the code yourself, here's an example:

```go
	ctx := context.Background()

	clientParams := pinecone.NewClientParams{
		ApiKey:    "YOUR_API_KEY",
	}

	pc, err := pinecone.NewClient(clientParams)
	if err != nil {
		log.Fatalf("Failed to create Client: %v", err)
	}

	rerankModel := "bge-reranker-v2-m3"
	topN := 2
	retunDocuments := true
	documents := []pinecone.Document{
		{
                    "id": "vec1", 
                    "text": "Apple is a popular fruit known for its sweetness and crisp texture."},
		{
                    "id": "vec2", 
                    "text": "Many people enjoy eating apples as a healthy snack."},
		{
                    "id": "vec3", 
                    "text": "Apple Inc. has revolutionized the tech industry with its sleek designs and user-friendly interfaces."},
		{
                    "id": "vec4", 
                    "text": "An apple a day keeps the doctor away, as the saying goes."},
        }

	ranking, err := pc.Inference.Rerank(ctx, &pinecone.RerankRequest{
		Model:           rerankModel,
		Query:           "i love cats",
		ReturnDocuments: &retunDocuments,
		TopN:            &topN,
		RankFields:      &[]string{"text"},
		Documents:       documents,
	})
	if err != nil {
		log.Fatalf("Failed to rerank: %v", err)
	}
	fmt.Printf("Rerank result: %+v\n", ranking)
```
