### PR TITLE
Add /rerank and /import sections to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,7 +589,7 @@ In order to import vectors from object storage, they must be stored in Parquet f
 [file format](https://docs.pinecone.io/guides/data/understanding-imports#parquet-file-format). Your object storage
 must also adhere to the necessary [directory structure](https://docs.pinecone.io/guides/data/understanding-imports#directory-structure).
 
-The following example imports 10 vectors from an Amazon S3 bucket into a Pinecone serverless index:
+The following example imports vectors from an Amazon S3 bucket into a Pinecone serverless index:
 
 ```go
     ctx := context.Background()

--- a/README.md
+++ b/README.md
@@ -1307,13 +1307,17 @@ func main() {
 
 ## Inference
 
-The `Client` object has an `Inference` namespace which allows interacting with Pinecone's [Inference API](https://docs.pinecone.io/reference/api/2024-07/inference/generate-embeddings). The Inference API is a service that gives you access to embedding models hosted on Pinecone's infrastructure. Read more at [Understanding Pinecone Inference](https://docs.pinecone.io/guides/inference/understanding-inference).
+The `Client` object has an `Inference` namespace which allows interacting with
+Pinecone's [Inference API](https://docs.pinecone.io/reference/api/2024-07/inference/generate-embeddings). The Inference
+API is a service that gives you access to embedding models hosted on Pinecone's infrastructure. Read more
+at [Understanding Pinecone Inference](https://docs.pinecone.io/guides/inference/understanding-inference).
 
 **Notes:**
 
 Models currently supported:
 
-- [multilingual-e5-large](https://docs.pinecone.io/guides/inference/understanding-inference#embedding-models)
+- Embedding: [multilingual-e5-large](https://docs.pinecone.io/guides/inference/understanding-inference#embedding-models)
+- Reranking: [bge-reranker-v2-m3](https://docs.pinecone.io/models/bge-reranker-v2-m3)
 
 ### Create Embeddings
 
@@ -1368,11 +1372,67 @@ Send text to Pinecone's inference API to generate embeddings for documents and q
 	}
 	fmt.Printf("query embedding response: %+v", queryEmbeddingsResponse)
 
-	// << Send query to Pinecone to retrieve similar documents >>
+    // << Send query to Pinecone to retrieve similar documents >>
+```
 
+### Rerank documents
+
+Rerank documents in descending relevance-order against a query.
+
+**Note:** The `score` represents the absolute measure of relevance of a given query and passage pair. Normalized
+between [0, 1], the `score` represents how closely relevant a specific item and query are, with scores closer to 1
+indicating higher relevance.
+
+```go
+    ctx := context.Background()
+
+    pc, err := pinecone.NewClient(pinecone.NewClientParams{
+        ApiKey: "YOUR-API-KEY"
+	})
+
+    if err != nil {
+        log.Fatalf("Failed to create Client: %v", err)
+    }
+
+    rerankModel := "bge-reranker-v2-m3"
+    query := "What are some good Turkey dishes for Thanksgiving?"
+  
+    documents := []pinecone.Document{
+      {"title": "Turkey Sandwiches", "body": "Turkey is a classic meat to eat at American Thanksgiving."},
+      {"title": "Lemon Turkey", "body": "A lemon brined Turkey with apple sausage stuffing is a classic Thanksgiving main course."},
+      {"title": "Thanksgiving", "body": "My favorite Thanksgiving dish is pumpkin pie"},
+      {"title": "Protein Sources", "body": "Turkey is a great source of protein."},
+    }
+
+    // Optional arguments
+    topN := 3
+    returnDocuments := false
+    rankFields := []string{"body"}
+    modelParams := map[string]string{
+      "truncate": "END",
+    }
+
+    rerankRequest := pinecone.RerankRequest{
+      Model:           rerankModel,
+      Query:           query,
+      Documents:       documents,
+      TopN:            &topN,
+      ReturnDocuments: &returnDocuments,
+      RankFields:      &rankFields,
+      Parameters:      &modelParams,
+    }
+
+    rerankResponse, err := pc.Inference.Rerank(ctx, &rerankRequest)
+
+    if err != nil {
+      log.Fatalf("Failed to rerank documents: %v", err)
+    }
+
+    fmt.Printf("rerank response: %+v", rerankResponse)
 ```
 
 ## Support
 
-To get help using go-pinecone you can file an issue on [GitHub](https://github.com/pinecone-io/go-pinecone/issues), visit the [community forum](https://community.pinecone.io/),
+To get help using go-pinecone you can file an issue on [GitHub](https://github.com/pinecone-io/go-pinecone/issues),
+visit the [community forum](https://community.pinecone.io/),
 or reach out to support@pinecone.io.

--- a/README.md
+++ b/README.md
@@ -602,8 +602,6 @@ The following example imports vectors from an Amazon S3 bucket into a Pinecone s
 
     if err != nil {
         log.Fatalf("Failed to create Client: %v", err)
-    } else {
-        fmt.Println("Successfully created a new Client object!")
     }
 
     indexName := "sample-index"
@@ -618,8 +616,6 @@ The following example imports vectors from an Amazon S3 bucket into a Pinecone s
 
     if err != nil {
         log.Fatalf("Failed to create serverless index: %v", err)
-    } else {
-        fmt.Printf("Successfully created serverless index: %s", idx.Name)
     }
 
     idx, err = pc.DescribeIndex(ctx, "pinecone-index")


### PR DESCRIPTION
## Problem

In anticipation of the upcoming major release, we need to update the Go README to incorporate sections for `rerank` and `import`.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [x] Non-code change (docs, etc)
- [ ] None of the above: (explain here)
