### PR TITLE
Add `EmbedResponse` type, regenerate core for `2024-10`

### DIFF
--- a/internal/gen/db_control/db_control_2024-10.oas.go
+++ b/internal/gen/db_control/db_control_2024-10.oas.go
@@ -134,7 +134,7 @@ type ConfigureIndexRequest struct {
 	} `json:"spec,omitempty"`
 
 	// Tags Custom user tags added to an index. Keys must be alphanumeric and 80 characters or less. Values must be 120 characters or less.
-	Tags *IndexTags `json:"tags,omitempty"`
+	Tags *IndexTags `json:"tags"`
 }
 
 // CreateCollectionRequest The configuration needed to create a Pinecone collection.
@@ -166,7 +166,7 @@ type CreateIndexRequest struct {
 	Spec IndexSpec `json:"spec"`
 
 	// Tags Custom user tags added to an index. Keys must be alphanumeric and 80 characters or less. Values must be 120 characters or less.
-	Tags *IndexTags `json:"tags,omitempty"`
+	Tags *IndexTags `json:"tags"`
 }
 
 // CreateIndexRequestMetric The distance metric to be used for similarity search. You can use 'euclidean', 'cosine', or 'dotproduct'.
@@ -227,7 +227,7 @@ type IndexModel struct {
 	} `json:"status"`
 
 	// Tags Custom user tags added to an index. Keys must be alphanumeric and 80 characters or less. Values must be 120 characters or less.
-	Tags *IndexTags `json:"tags,omitempty"`
+	Tags *IndexTags `json:"tags"`
 }
 
 // IndexModelMetric The distance metric to be used for similarity search. You can use 'euclidean', 'cosine', or 'dotproduct'.
@@ -255,7 +255,7 @@ type IndexSpec0 = interface{}
 type IndexSpec1 = interface{}
 
 // IndexTags Custom user tags added to an index. Keys must be alphanumeric and 80 characters or less. Values must be 120 characters or less.
-type IndexTags map[string]*string
+type IndexTags map[string]string
 
 // PodSpec Configuration needed to deploy a pod-based index.
 type PodSpec struct {

--- a/internal/gen/db_data/rest/db_data_2024-10.oas.go
+++ b/internal/gen/db_data/rest/db_data_2024-10.oas.go
@@ -271,7 +271,7 @@ type StartImportRequest struct {
 	IntegrationId *string `json:"integrationId,omitempty"`
 
 	// Uri The URI prefix under which the data to import is available. All data within this prefix will be listed then imported into the target index. Currently only `s3://` URIs are supported.
-	Uri *string `json:"uri,omitempty"`
+	Uri string `json:"uri"`
 }
 
 // StartImportResponse The response for the `start_import` operation.

--- a/pinecone/index_connection.go
+++ b/pinecone/index_connection.go
@@ -1065,7 +1065,7 @@ func (idx *IndexConnection) StartImport(ctx context.Context, uri string, integra
 	}
 
 	req := db_data_rest.StartImportRequest{
-		Uri:           &uri,
+		Uri:           uri,
 		IntegrationId: integrationId,
 	}
 

--- a/pinecone/models.go
+++ b/pinecone/models.go
@@ -177,6 +177,13 @@ type MetadataFilter = structpb.Struct
 // [attached to, or updated for, a vector]: https://docs.pinecone.io/guides/data/filter-with-metadata#inserting-metadata-into-an-index
 type Metadata = structpb.Struct
 
+// The embedding of a single input which is returned after [generating embeddings].
+//
+// [generating embeddings]: https://docs.pinecone.io/guides/inference/generate-embeddings#3-generate-embeddings
+type Embedding struct {
+	Values *[]float32 `json:"values,omitempty"`
+}
+
 // ImportStatus represents the status of an import operation.
 //
 // Values:


### PR DESCRIPTION
## Problem
There have been a few small PRs that have gone into the `apis` repo that we need to regenerate code for:

- https://github.com/pinecone-io/apis/pull/175
- https://github.com/pinecone-io/apis/pull/171

We're also returning the generated `EmbeddingsList` type for the `Embed` method rather than a custom type like we're doing elsewhere.

## Solution
- Add new `EmbedResponse`, and `Embedding` types and return from `Embed`. Add doc comments.
- Regenerate core SDK code from `2024-10`

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
Make sure CI is successful.
