### PR TITLE
Last doc comment clean up

### DIFF
--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -23,20 +23,20 @@ import (
 	"google.golang.org/grpc"
 )
 
-// Client holds the parameters for connecting to the Pinecone service. It is returned by the NewClient and NewClientBase
-// functions. To use Client, first build the parameters of the request using NewClientParams (or NewClientBaseParams).
-// Then, pass those parameters into the NewClient (or NewClientBase) function to create a new Client object.
-// Once instantiated, you can use Client to execute Pinecone API requests (e.g. create an Index, list Indexes,
-// etc.), and Inference API requests. Read more about different Pinecone API routes at [docs.pinecone.io/reference/api].
+// [Client] holds the parameters for connecting to the Pinecone service. It is returned by the [NewClient] and [NewClientBase]
+// functions. To use Client, first build the parameters of the request using [NewClientParams] (or [NewClientBaseParams]).
+// Then, pass those parameters into the [NewClient] (or [NewClientBase]) function to create a new [Client] object.
+// Once instantiated, you can use [Client] to execute Pinecone API requests (e.g. create an [Index], list Indexes,
+// etc.), and Inference API requests. Read more about different Pinecone API routes [here].
 //
 // Note: Client methods are safe for concurrent use.
 //
 // Fields:
-//   - Inference: An InferenceService object that exposes methods for interacting with the Pinecone [Inference API].
+//   - Inference: An [InferenceService] object that exposes methods for interacting with the Pinecone [Inference API].
 //   - restClient: Optional underlying *http.Client object used to communicate with the Pinecone API,
-//     provided through NewClientParams.RestClient or NewClientBaseParams.RestClient. If not provided,
+//     provided through [NewClientParams.RestClient] or [NewClientBaseParams.RestClient]. If not provided,
 //     a default client is created for you.
-//   - baseParams: A NewClientBaseParams object that holds the configuration for the Pinecone client.
+//   - baseParams: A [NewClientBaseParams] object that holds the configuration for the Pinecone client.
 //
 // Example:
 //
@@ -66,7 +66,7 @@ import (
 //		       log.Println("IndexConnection created successfully!")
 //	    }
 //
-// [docs.pinecone.io/reference/api]: https://docs.pinecone.io/reference/api/control-plane/list_indexes
+// [here]: https://docs.pinecone.io/reference/api/control-plane/list_indexes
 // [Inference API]: https://docs.pinecone.io/reference/api/2024-07/inference/generate-embeddings
 type Client struct {
 	Inference  *InferenceService
@@ -74,7 +74,7 @@ type Client struct {
 	baseParams *NewClientBaseParams
 }
 
-// NewClientParams holds the parameters for creating a new Client instance while authenticating via an API key.
+// [NewClientParams] holds the parameters for creating a new [Client] instance while authenticating via an API key.
 //
 // Fields:
 //   - ApiKey: (Required) The API key used to authenticate with the Pinecone API.
@@ -84,7 +84,7 @@ type Client struct {
 //   - RestClient: An optional HTTP client to use for communication with the Pinecone API.
 //   - SourceTag: An optional string used to help Pinecone attribute API activity.
 //
-// See Client for code example.
+// See [Client] for code example.
 type NewClientParams struct {
 	ApiKey     string            // required - provide through NewClientParams or environment variable PINECONE_API_KEY
 	Headers    map[string]string // optional
@@ -93,7 +93,7 @@ type NewClientParams struct {
 	SourceTag  string            // optional
 }
 
-// NewClientBaseParams holds the parameters for creating a new Client instance while passing custom authentication
+// [NewClientBaseParams] holds the parameters for creating a new [Client] instance while passing custom authentication
 // headers. If there is no API key or authentication provided through Headers, API calls will fail.
 //
 // Fields:
@@ -104,7 +104,7 @@ type NewClientParams struct {
 //   - RestClient: (Optional) An *http.Client object to use for communication with the Pinecone API.
 //   - SourceTag: (Optional) A string used to help Pinecone attribute API activity.
 //
-// See Client for code example.
+// See [Client] for code example.
 type NewClientBaseParams struct {
 	Headers    map[string]string
 	Host       string
@@ -112,31 +112,31 @@ type NewClientBaseParams struct {
 	SourceTag  string
 }
 
-// NewIndexConnParams holds the parameters for creating an IndexConnection to a Pinecone index.
+// [NewIndexConnParams] holds the parameters for creating an [IndexConnection] to a Pinecone index.
 //
 // Fields:
-//   - Host: (Required) The host URL of the Pinecone index. To find your host url use the DescribeIndex or ListIndexes methods.
+//   - Host: (Required) The host URL of the Pinecone index. To find your host url use the [Client.DescribeIndex] or [Client.ListIndexes] methods.
 //     Alternatively, the host is displayed in the Pinecone web console.
 //   - Namespace: (Optional) The index namespace to use for operations. If not provided, the default namespace of "" will be used.
 //   - AdditionalMetadata: (Optional) Metadata to be sent with each RPC request.
 //
-// See Client.Index for code example.
+// See [Client.Index] for code example.
 type NewIndexConnParams struct {
 	Host               string            // required - obtained through DescribeIndex or ListIndexes
 	Namespace          string            // optional - if not provided the default namespace of "" will be used
 	AdditionalMetadata map[string]string // optional
 }
 
-// NewClient creates and initializes a new instance of Client.
+// [NewClient] creates and initializes a new instance of [Client].
 // This function sets up the Pinecone client with the necessary configuration for authentication and communication.
 //
 // Parameters:
-//   - in: A NewClientParams object. See NewClientParams for more information.
+//   - in: A [NewClientParams] object. See [NewClientParams] for more information.
 //
 // Note: It is important to handle the error returned by this function to ensure that the
 // Pinecone client has been created successfully before attempting to make API calls.
 //
-// Returns a pointer to an initialized Client instance or an error.
+// Returns a pointer to an initialized [Client] instance or an error.
 //
 // Example:
 //
@@ -175,18 +175,18 @@ func NewClient(in NewClientParams) (*Client, error) {
 	return NewClientBase(NewClientBaseParams{Headers: clientHeaders, Host: in.Host, RestClient: in.RestClient, SourceTag: in.SourceTag})
 }
 
-// NewClientBase creates and initializes a new instance of Client with custom authentication headers.
+// [NewClientBase] creates and initializes a new instance of [Client] with custom authentication headers.
 //
 // Parameters:
-//   - in: A NewClientBaseParams object that includes the necessary configuration for the Pinecone client. See
-//     NewClientBaseParams for more information.
+//   - in: A [NewClientBaseParams] object that includes the necessary configuration for the Pinecone client. See
+//     [NewClientBaseParams] for more information.
 //
 // Notes:
 //   - It is important to handle the error returned by this function to ensure that the
 //     Pinecone client has been created successfully before attempting to make API calls.
-//   - A Pinecone API key is not required when using NewClientBase.
+//   - A Pinecone API key is not required when using [NewClientBase].
 //
-// Returns a pointer to an initialized Client instance or an error.
+// Returns a pointer to an initialized [Client] instance or an error.
 //
 // Example:
 //
@@ -236,16 +236,16 @@ func NewClientBase(in NewClientBaseParams) (*Client, error) {
 	return &c, nil
 }
 
-// Index creates an IndexConnection to a specified host.
+// [Client.Index] creates an [IndexConnection] to a specified host.
 //
 // Parameters:
-//   - in: A NewIndexConnParams object that includes the necessary configuration to create an IndexConnection.
+//   - in: A [NewIndexConnParams] object that includes the necessary configuration to create an [IndexConnection].
 //     See NewIndexConnParams for more information.
 //
-// Note: It is important to handle the error returned by this method to ensure that the IndexConnection is created
+// Note: It is important to handle the error returned by this method to ensure that the [IndexConnection] is created
 // successfully before making data plane calls.
 //
-// Returns a pointer to an IndexConnection instance or an error.
+// Returns a pointer to an [IndexConnection] instance or an error.
 //
 // Example:
 //
@@ -334,7 +334,7 @@ func ensureHostHasHttps(host string) string {
 	return host
 }
 
-// ListIndexes retrieves a list of all Indexes in a Pinecone [project].
+// [Client.ListIndexes] retrieves a list of all Indexes in a Pinecone [project].
 //
 // Parameters:
 //   - ctx: A context.Context object controls the request's lifetime, allowing for the request
@@ -392,23 +392,23 @@ func (c *Client) ListIndexes(ctx context.Context) ([]*Index, error) {
 	return indexes, nil
 }
 
-// CreatePodIndexRequest holds the parameters for creating a new pods-based Index.
+// [CreatePodIndexRequest] holds the parameters for creating a new pods-based Index.
 //
 // Fields:
-//   - Name: (Required) The name of the Index. Resource name must be 1-45 characters long,
+//   - Name: (Required) The name of the [Index]. Resource name must be 1-45 characters long,
 //     start and end with an alphanumeric character,
 //     and consist only of lower case alphanumeric characters or '-'.
 //   - Dimension: (Required) The [dimensionality] of the vectors to be inserted in the Index.
 //   - Metric: (Required) The distance metric to be used for [similarity] search. You can use
 //     'euclidean', 'cosine', or 'dotproduct'.
 //   - Environment: (Required) The [cloud environment] where the Index will be hosted.
-//   - PodType: (Required) The [type of pod] to use for the Index. One of `s1`, `p1`, or `p2` appended with `.` and
+//   - PodType: (Required) The [type of pod] to use for the [Index]. One of `s1`, `p1`, or `p2` appended with `.` and
 //     one of `x1`, `x2`, `x4`, or `x8`.
 //   - Shards: (Optional) The number of shards to use for the Index (defaults to 1).
 //     Shards split your data across multiple pods, so you can fit more data into an Index.
 //   - Replicas: (Optional) The number of [replicas] to use for the Index (defaults to 1). Replicas duplicate your Index.
 //     They provide higher availability and throughput. Replicas can be scaled up or down as your needs change.
-//   - SourceCollection: (Optional) The name of the Collection to be used as the source for the Index.
+//   - SourceCollection: (Optional) The name of the [Collection] to be used as the source for the Index.
 //   - MetadataConfig: (Optional) The [metadata configuration] for the behavior of Pinecone's internal metadata Index. By
 //     default, all metadata is indexed; when `metadata_config` is present,
 //     only specified metadata fields are indexed. These configurations are
@@ -416,7 +416,7 @@ func (c *Client) ListIndexes(ctx context.Context) ([]*Index, error) {
 //   - DeletionProtection: (Optional) determines whether [deletion protection] is "enabled" or "disabled" for the index.
 //     When "enabled", the index cannot be deleted. Defaults to "disabled".
 //
-// To create a new pods-based Index, use the CreatePodIndex method on the Client object.
+// To create a new pods-based Index, use the [Client.CreatePodIndex] method.
 //
 // Example:
 //
@@ -475,31 +475,31 @@ type CreatePodIndexRequest struct {
 	MetadataConfig     *PodSpecMetadataConfig
 }
 
-// ReplicaCount ensures the replica count of a pods-based Index is >1.
-// It returns a pointer to the number of replicas on a CreatePodIndexRequest object.
+// [CreatePodIndexRequestReplicaCount] ensures the replica count of a pods-based Index is >1.
+// It returns a pointer to the number of replicas on a [CreatePodIndexRequest] object.
 func (req CreatePodIndexRequest) ReplicaCount() int32 {
 	return minOne(req.Replicas)
 }
 
-// ShardCount ensures the number of shards on a pods-based Index is >1. It returns a pointer to the number of shards on
-// a CreatePodIndexRequest object.
+// [CreatePodIndexRequestShardCount] ensures the number of shards on a pods-based Index is >1. It returns a pointer to the number of shards on
+// a [CreatePodIndexRequest] object.
 func (req CreatePodIndexRequest) ShardCount() int32 {
 	return minOne(req.Shards)
 }
 
-// TotalCount calculates and returns the total number of pods (replicas*shards) on a CreatePodIndexRequest object.
+// [CreatePodIndexRequest.TotalCount] calculates and returns the total number of pods (replicas*shards) on a [CreatePodIndexRequest] object.
 func (req CreatePodIndexRequest) TotalCount() int {
 	return int(req.ReplicaCount() * req.ShardCount())
 }
 
-// CreatePodIndex creates and initializes a new pods-based Index via the specified Client.
+// [Client.CreatePodIndex] creates and initializes a new pods-based Index via the specified [Client].
 //
 // Parameters:
 //   - ctx: A context.Context object controls the request's lifetime, allowing for the request
 //     to be canceled or to timeout according to the context's deadline.
-//   - in: A pointer to a CreatePodIndexRequest object. See CreatePodIndexRequest for more information.
+//   - in: A pointer to a [CreatePodIndexRequest] object. See [CreatePodIndexRequest] for more information.
 //
-// Returns a pointer to an Index object or an error.
+// Returns a pointer to an [Index] object or an error.
 //
 // Example:
 //
@@ -584,21 +584,21 @@ func (c *Client) CreatePodIndex(ctx context.Context, in *CreatePodIndexRequest) 
 	return decodeIndex(res.Body)
 }
 
-// CreateServerlessIndexRequest holds the parameters for creating a new [Serverless] Index.
+// [CreateServerlessIndexRequest] holds the parameters for creating a new [Serverless] Index.
 //
 // Fields:
-//   - Name: (Required) The name of the Index. Resource name must be 1-45 characters long,
+//   - Name: (Required) The name of the [Index]. Resource name must be 1-45 characters long,
 //     start and end with an alphanumeric character,
 //     and consist only of lower case alphanumeric characters or '-'.
-//   - Dimension: (Required) The [dimensionality] of the vectors to be inserted in the Index.
+//   - Dimension: (Required) The [dimensionality] of the vectors to be inserted in the [Index].
 //   - Metric: (Required) The metric used to measure the [similarity] between vectors ('euclidean', 'cosine', or 'dotproduct').
-//   - Cloud: (Required) The public [cloud provider] where you would like your Index hosted.
-//     For serverless Indexes, you define only the cloud and region where the Index should be hosted.
-//   - Region: (Required) The [region] where you would like your Index to be created.
+//   - Cloud: (Required) The public [cloud provider] where you would like your [Index] hosted.
+//     For serverless Indexes, you define only the cloud and region where the [Index] should be hosted.
+//   - Region: (Required) The [region] where you would like your [Index] to be created.
 //   - DeletionProtection: (Optional) Determines whether [deletion protection] is "enabled" or "disabled" for the index.
 //     When "enabled", the index cannot be deleted. Defaults to "disabled".
 //
-// To create a new Serverless Index, use the CreateServerlessIndex method on the Client object.
+// To create a new Serverless Index, use the [Client.CreateServerlessIndex] method.
 //
 // Example:
 //
@@ -647,14 +647,14 @@ type CreateServerlessIndexRequest struct {
 	Region             string
 }
 
-// CreateServerlessIndex creates and initializes a new serverless Index via the specified Client.
+// [Client.CreateServerlessIndex] creates and initializes a new serverless Index via the specified [Client].
 //
 // Parameters:
 //   - ctx: A context.Context object controls the request's lifetime, allowing for the request
 //     to be canceled or to timeout according to the context's deadline.
-//   - in: A pointer to a CreateServerlessIndexRequest object. See CreateServerlessIndexRequest for more information.
+//   - in: A pointer to a [CreateServerlessIndexRequest] object. See [CreateServerlessIndexRequest] for more information.
 //
-// Returns a pointer to an Index object or an error.
+// Returns a pointer to an [Index] object or an error.
 //
 // Example:
 //
@@ -721,14 +721,14 @@ func (c *Client) CreateServerlessIndex(ctx context.Context, in *CreateServerless
 	return decodeIndex(res.Body)
 }
 
-// DescribeIndex retrieves information about a specific Index. See Index for more information.
+// [Client.DescribeIndex] retrieves information about a specific [Index]. See [Index] for more information.
 //
 // Parameters:
 //   - ctx: A context.Context object controls the request's lifetime, allowing for the request
 //     to be canceled or to timeout according to the context's deadline.
-//   - idxName: The name of the Index to describe.
+//   - idxName: The name of the [Index] to describe.
 //
-// Returns a pointer to an Index object or an error.
+// Returns a pointer to an [Index] object or an error.
 //
 // Example:
 //
@@ -773,12 +773,12 @@ func (c *Client) DescribeIndex(ctx context.Context, idxName string) (*Index, err
 	return decodeIndex(res.Body)
 }
 
-// DeleteIndex deletes a specific Index.
+// [Client.DeleteIndex] deletes a specific [Index].
 //
 // Parameters:
 //   - ctx: A context.Context object controls the request's lifetime, allowing for the request
 //     to be canceled or to timeout according to the context's deadline.
-//   - idxName: The name of the Index to delete.
+//   - idxName: The name of the [Index] to delete.
 //
 // Returns an error if the deletion fails.
 //
@@ -820,8 +820,8 @@ func (c *Client) DeleteIndex(ctx context.Context, idxName string) error {
 	return nil
 }
 
-// ConfigureIndexParams contains parameters for configuring an index. For both pod-based
-// and serverless indexes you can configure the DeletionProtection status for an index.
+// [ConfigureIndexParams] contains parameters for configuring an [Index]. For both pod-based
+// and serverless indexes you can configure the DeletionProtection status for an [Index].
 // For pod-based indexes you can also configure the number of Replicas and the PodType.
 // Each of the fields is optional, but at least one field must be set.
 // See [scale a pods-based index] for more information.
@@ -863,19 +863,19 @@ type ConfigureIndexParams struct {
 	DeletionProtection DeletionProtection
 }
 
-// ConfigureIndex is used to [scale a pods-based index] up or down by changing the size of the pods or the number of
-// replicas, or to enable and disable deletion protection for an index.
+// [Client.ConfigureIndex] is used to [scale a pods-based index] up or down by changing the size of the pods or the number of
+// replicas, or to enable and disable deletion protection for an [Index].
 //
 // Parameters:
 //   - ctx: A context.Context object controls the request's lifetime, allowing for the request
 //     to be canceled or to timeout according to the context's deadline.
-//   - name: The name of the index to configure.
-//   - in: A pointer to a ConfigureIndexParams object that contains the parameters for configuring the index.
+//   - name: The name of the [Index] to configure.
+//   - in: A pointer to a ConfigureIndexParams object that contains the parameters for configuring the [Index].
 //
-// Note: You can only scale an index up, not down. If you want to scale an index down,
+// Note: You can only scale an [Index] up, not down. If you want to scale an [Index] down,
 // you must create a new index with the desired configuration.
 //
-// Returns a pointer to a configured Index object or an error.
+// Returns a pointer to a configured [Index] object or an error.
 //
 // Example:
 //
@@ -947,7 +947,7 @@ func (c *Client) ConfigureIndex(ctx context.Context, name string, in ConfigureIn
 	return decodeIndex(res.Body)
 }
 
-// ListCollections retrieves a list of all Collections in a Pinecone [project]. See Collection for more information.
+// [Client.ListCollections] retrieves a list of all Collections in a Pinecone [project]. See [understanding collections] for more information.
 //
 // Parameters:
 //   - ctx: A context.Context object controls the request's lifetime, allowing for the request
@@ -988,7 +988,7 @@ func (c *Client) ConfigureIndex(ctx context.Context, name string, in ConfigureIn
 //	    }
 //
 // [project]: https://docs.pinecone.io/guides/projects/understanding-projects
-// [Collection]: https://docs.pinecone.io/guides/indexes/understanding-collections
+// [understanding collections]: https://docs.pinecone.io/guides/indexes/understanding-collections
 func (c *Client) ListCollections(ctx context.Context) ([]*Collection, error) {
 	res, err := c.restClient.ListCollections(ctx)
 	if err != nil {
@@ -1013,24 +1013,25 @@ func (c *Client) ListCollections(ctx context.Context) ([]*Collection, error) {
 	return collections, nil
 }
 
-// DescribeCollection retrieves information about a specific [Collection].
+// [Client.DescribeCollection] retrieves information about a specific [Collection]. See [understanding collections]
+// for more information.
 //
 // Parameters:
 //   - ctx: A context.Context object controls the request's lifetime, allowing for the request
 //     to be canceled or to timeout according to the context's deadline.
-//   - collectionName: The name of the Collection to describe.
+//   - collectionName: The name of the [Collection] to describe.
 //
-// Returns a pointer to a Collection object or an error.
+// Returns a pointer to a [Collection] object or an error.
 //
 // Note: Collections are only available for pods-based Indexes.
 //
-// Since the returned value is a pointer to a Collection object, it will have the following fields:
-//   - Name: The name of the Collection.
-//   - Size: The size of the Collection in bytes.
-//   - Status: The status of the Collection.
-//   - Dimension: The [dimensionality] of the vectors stored in each record held in the Collection.
-//   - VectorCount: The number of records stored in the Collection.
-//   - Environment: The cloud environment where the Collection is hosted.
+// Since the returned value is a pointer to a [Collection] object, it will have the following fields:
+//   - Name: The name of the [Collection].
+//   - Size: The size of the [Collection] in bytes.
+//   - Status: The status of the [Collection].
+//   - Dimension: The [dimensionality] of the vectors stored in each record held in the [Collection].
+//   - VectorCount: The number of records stored in the [Collection].
+//   - Environment: The cloud environment where the [Collection] is hosted.
 //
 // Example:
 //
@@ -1056,7 +1057,7 @@ func (c *Client) ListCollections(ctx context.Context) ([]*Collection, error) {
 //	    }
 //
 // [dimensionality]: https://docs.pinecone.io/guides/indexes/choose-a-pod-type-and-size#dimensionality-of-vectors
-// [Collection]: https://docs.pinecone.io/guides/indexes/understanding-collections
+// [understanding collections]: https://docs.pinecone.io/guides/indexes/understanding-collections
 func (c *Client) DescribeCollection(ctx context.Context, collectionName string) (*Collection, error) {
 	res, err := c.restClient.DescribeCollection(ctx, collectionName)
 	if err != nil {
@@ -1071,13 +1072,13 @@ func (c *Client) DescribeCollection(ctx context.Context, collectionName string) 
 	return decodeCollection(res.Body)
 }
 
-// CreateCollectionRequest holds the parameters for creating a new [Collection].
+// [CreateCollectionRequest] holds the parameters for creating a new [Collection].
 //
 // Fields:
-//   - Name: (Required) The name of the Collection.
-//   - Source: (Required) The name of the Index to be used as the source for the Collection.
+//   - Name: (Required) The name of the [Collection].
+//   - Source: (Required) The name of the Index to be used as the source for the [Collection].
 //
-// To create a new Collection, use the CreateCollection method on the Client object.
+// To create a new [Collection], use the [Client.CreateCollection] method.
 //
 // Note: Collections are only available for pods-based Indexes.
 //
@@ -1106,23 +1107,21 @@ func (c *Client) DescribeCollection(ctx context.Context, collectionName string) 
 //	    } else {
 //		       fmt.Printf("Successfully created collection \"%s\".", collection.Name)
 //	    }
-//
-// [Collection]: https://docs.pinecone.io/guides/indexes/understanding-collections
 type CreateCollectionRequest struct {
 	Name   string
 	Source string
 }
 
-// CreateCollection creates and initializes a new [Collection] via the specified Client.
+// [Client.CreateCollection] creates and initializes a new [Collection] via the specified [Client].
 //
 // Parameters:
 //   - ctx: A context.Context object controls the request's lifetime, allowing for the request
 //     to be canceled or to timeout according to the context's deadline.
-//   - in: A pointer to a CreateCollectionRequest object.
+//   - in: A pointer to a [CreateCollectionRequest] object.
 //
 // Note: Collections are only available for pods-based Indexes.
 //
-// Returns a pointer to a Collection object or an error.
+// Returns a pointer to a [Collection] object or an error.
 //
 // Example:
 //
@@ -1149,8 +1148,6 @@ type CreateCollectionRequest struct {
 //	    } else {
 //		       fmt.Printf("Successfully created collection \"%s\".", collection.Name)
 //	    }
-//
-// [Collection]: https://docs.pinecone.io/guides/indexes/understanding-collections
 func (c *Client) CreateCollection(ctx context.Context, in *CreateCollectionRequest) (*Collection, error) {
 	if in.Source == "" || in.Name == "" {
 		return nil, fmt.Errorf("fields Name and Source must be included in CreateCollectionRequest")
@@ -1174,12 +1171,12 @@ func (c *Client) CreateCollection(ctx context.Context, in *CreateCollectionReque
 	return decodeCollection(res.Body)
 }
 
-// DeleteCollection deletes a specific [Collection]
+// [Client.DeleteCollection] deletes a specific [Collection]
 //
 // Parameters:
 //   - ctx: A context.Context object controls the request's lifetime, allowing for the request
 //     to be canceled or to timeout according to the context's deadline.
-//   - collectionName: The name of the Collection to delete.
+//   - collectionName: The name of the [Collection] to delete.
 //
 // Note: Collections are only available for pods-based Indexes.
 //
@@ -1209,8 +1206,6 @@ func (c *Client) CreateCollection(ctx context.Context, in *CreateCollectionReque
 //	    } else {
 //		       log.Printf("Successfully deleted collection \"%s\"\n", collectionName)
 //	    }
-//
-// [Collection]: https://docs.pinecone.io/guides/indexes/understanding-collections
 func (c *Client) DeleteCollection(ctx context.Context, collectionName string) error {
 	res, err := c.restClient.DeleteCollection(ctx, collectionName)
 	if err != nil {
@@ -1225,7 +1220,7 @@ func (c *Client) DeleteCollection(ctx context.Context, collectionName string) er
 	return nil
 }
 
-// InferenceService is a struct which exposes methods for interacting with the Pinecone Inference API. InferenceService
+// [InferenceService] is a struct which exposes methods for interacting with the Pinecone Inference API. [InferenceService]
 // can be accessed via the Client object through the Client.Inference namespace.
 //
 // [Pinecone Inference API]: https://docs.pinecone.io/guides/inference/understanding-inference#embedding-models
@@ -1233,7 +1228,7 @@ type InferenceService struct {
 	client *inference.Client
 }
 
-// EmbedRequest holds the parameters for generating embeddings for a list of input strings.
+// [EmbedRequest] holds the parameters for generating embeddings for a list of input strings.
 //
 // Fields:
 //   - Model: (Required) The model to use for generating embeddings.
@@ -1245,7 +1240,7 @@ type EmbedRequest struct {
 	Parameters EmbedParameters
 }
 
-// EmbedParameters contains model-specific parameters that can be used for generating embeddings.
+// [EmbedParameters] contains model-specific parameters that can be used for generating embeddings.
 //
 // Fields:
 //   - InputType: (Optional) A common property used to distinguish between different types of data. For example, "passage", or "query".
@@ -1256,10 +1251,10 @@ type EmbedParameters struct {
 	Truncate  string
 }
 
-// EmbedResponse represents holds the embeddings generated for a single input.
+// [EmbedResponse] represents holds the embeddings generated for a single input.
 //
 // Fields:
-//   - Data: A list of Embedding objects containing the embeddings generated for the input.
+//   - Data: A list of [Embedding] objects containing the embeddings generated for the input.
 //   - Model: The model used to generate the embeddings.
 //   - Usage: Usage statistics ([Total Tokens]) for the request.
 //
@@ -1272,7 +1267,7 @@ type EmbedResponse struct {
 	} `json:"usage"`
 }
 
-// Embed generates embeddings for a list of inputs using the specified model and (optional) parameters.
+// [InferenceService.Embed] generates embeddings for a list of inputs using the specified model and (optional) parameters.
 //
 // Parameters:
 //   - ctx: A context.Context object controls the request's lifetime, allowing for the request
@@ -1280,7 +1275,7 @@ type EmbedResponse struct {
 //   - in: A pointer to an EmbedRequest object that contains the model to use for embedding generation, the
 //     list of input strings to generate embeddings for, and any additional parameters to use for generation.
 //
-// Returns a pointer to an EmbeddingsList object or an error.
+// Returns a pointer to an [EmbeddingsList] object or an error.
 //
 // Example:
 //
@@ -1359,10 +1354,10 @@ func (i *InferenceService) Embed(ctx context.Context, in *EmbedRequest) (*EmbedR
 	return decodeEmbeddingsList(res.Body)
 }
 
-// Document is a map representing the document to be reranked.
+// [Document] is a map representing the document to be reranked.
 type Document map[string]string
 
-// RerankRequest holds the parameters for calling [InferenceService.Rerank] and reranking documents
+// [RerankRequest] holds the parameters for calling [InferenceService.Rerank] and reranking documents
 // by a specified query and model.
 //
 // Fields:
@@ -1399,12 +1394,12 @@ type RankedDocument struct {
 	Score    float32   `json:"score"`
 }
 
-// RerankResponse is the result of a reranking operation.
+// [RerankResponse] is the result of a reranking operation.
 //
 // Fields:
-//   - Data: A list of Documents which have been reranked. The Documents are sorted in order of relevance,
+//   - Data: A list of [RankedDocument] objects which have been reranked. The RankedDocuments are sorted in order of relevance,
 //     with the first being the most relevant.
-//   - Model: The model used to rerank Documents.
+//   - Model: The model used to rerank documents.
 //   - Usage: Usage statistics ([Rerank Units]) for the reranking operation.
 //
 // [Read Units]: https://docs.pinecone.io/guides/organizations/manage-cost/understanding-cost#rerank
@@ -1414,7 +1409,7 @@ type RerankResponse struct {
 	Usage RerankUsage      `json:"usage"`
 }
 
-// Rerank Documents with associated relevance scores that represent the relevance of each Document
+// [InferenceService.Rerank] reranks documents with associated relevance scores that represent the relevance of each [Document]
 // to the provided query using the specified model.
 //
 // Parameters:

--- a/pinecone/index_connection.go
+++ b/pinecone/index_connection.go
@@ -20,7 +20,8 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-// IndexConnection holds the parameters for a Pinecone IndexConnection object.
+// [IndexConnection] holds the parameters for a Pinecone [IndexConnection] object. You can
+// instantiate an [IndexConnection] by calling the [Client.Index] method with a [NewIndexConnParams] object.
 //
 // Fields:
 //   - Namespace: The namespace where index operations will be performed.
@@ -83,7 +84,7 @@ func newIndexConnection(in newIndexParameters, dialOpts ...grpc.DialOption) (*In
 	return &idx, nil
 }
 
-// Close closes the grpc.ClientConn to a Pinecone index.
+// [IndexConnection.Close] closes the grpc.ClientConn to a Pinecone [Index].
 //
 // Returns an error if the connection cannot be closed, otherwise returns nil.
 //
@@ -124,7 +125,7 @@ func (idx *IndexConnection) Close() error {
 	return err
 }
 
-// UpsertVectors upserts vectors into a Pinecone index.
+// [IndexConnection.UpsertVectors] upserts vectors into a Pinecone [Index].
 //
 // Parameters:
 //   - ctx: A context.Context object controls the request's lifetime,
@@ -209,8 +210,7 @@ func (idx *IndexConnection) UpsertVectors(ctx context.Context, in []*Vector) (ui
 	return res.UpsertedCount, nil
 }
 
-// FetchVectorsResponse holds the parameters for the FetchVectorsResponse object,
-// which is returned by the FetchVectors method.
+// [FetchVectorsResponse] is returned by the [IndexConnection.FetchVectors] method.
 //
 // Fields:
 //   - Vectors: The vectors fetched.
@@ -222,7 +222,7 @@ type FetchVectorsResponse struct {
 	Namespace string             `json:"namespace"`
 }
 
-// FetchVectors fetches vectors by ID from a Pinecone index.
+// [IndexConnection.FetchVectors] fetches vectors by ID from a Pinecone [Index].
 //
 // Parameters:
 //   - ctx: A context.Context object controls the request's lifetime,
@@ -292,8 +292,7 @@ func (idx *IndexConnection) FetchVectors(ctx context.Context, ids []string) (*Fe
 	}, nil
 }
 
-// ListVectorsRequest holds the parameters for the ListVectorsRequest object,
-// which is passed into the ListVectors method.
+// [ListVectorsRequest] holds the parameters passed into the [IndexConnection.ListVectors] method.
 //
 // Fields:
 //   - Prefix: (Optional) The prefix by which to filter. If unspecified,
@@ -306,8 +305,7 @@ type ListVectorsRequest struct {
 	PaginationToken *string
 }
 
-// ListVectorsResponse holds the parameters for the ListVectorsResponse object,
-// which is returned by the ListVectors method.
+// [ListVectorsResponse] is returned by the [IndexConnection.ListVectors] method.
 //
 // Fields:
 //   - VectorIds: The unique IDs of the returned vectors.
@@ -321,17 +319,17 @@ type ListVectorsResponse struct {
 	Namespace           string    `json:"namespace"`
 }
 
-// ListVectors lists vectors in a Pinecone index. You can filter vectors by prefix,
+// [IndexConnection.ListVectors] lists vectors in a Pinecone index. You can filter vectors by prefix,
 // limit the number of vectors returned, and paginate through results.
 //
 // Note: ListVectors is only available for Serverless indexes.
 //
-// Returns a pointer to a ListVectorsResponse object or an error if the request fails.
+// Returns a pointer to a [ListVectorsResponse] object or an error if the request fails.
 //
 // Parameters:
 //   - ctx: A context.Context object controls the request's lifetime,
 //     allowing for the request to be canceled or to timeout according to the context's deadline.
-//   - in: A ListVectorsRequest object with the parameters for the request.
+//   - in: A [ListVectorsRequest] object with the parameters for the request.
 //
 // Example:
 //
@@ -402,8 +400,7 @@ func (idx *IndexConnection) ListVectors(ctx context.Context, in *ListVectorsRequ
 	}, nil
 }
 
-// QueryByVectorValuesRequest holds the parameters for the QueryByVectorValuesRequest object,
-// which is passed into the QueryByVectorValues method.
+// [QueryByVectorValuesRequest] holds the parameters for the [IndexConnection.QueryByVectorValues] method.
 //
 // Fields:
 //   - Vector: (Required) The query vector used to find similar vectors.
@@ -421,8 +418,7 @@ type QueryByVectorValuesRequest struct {
 	SparseValues    *SparseValues
 }
 
-// QueryVectorsResponse holds the parameters for the QueryVectorsResponse object,
-// which is returned by the QueryByVectorValues method.
+// [QueryVectorsResponse] is returned by the [IndexConnection.QueryByVectorValues] method.
 //
 // Fields:
 //   - Matches: The vectors that are most similar to the query vector.
@@ -434,9 +430,9 @@ type QueryVectorsResponse struct {
 	Namespace string          `json:"namespace"`
 }
 
-// QueryByVectorValues queries a Pinecone index for vectors that are most similar to a provided query vector.
+// [IndexConnection.QueryByVectorValues] queries a Pinecone [Index] for vectors that are most similar to a provided query vector.
 //
-// Returns a pointer to a QueryVectorsResponse object or an error if the request fails.
+// Returns a pointer to a [QueryVectorsResponse] object or an error if the request fails.
 //
 // Note: To issue a hybrid query with both dense and sparse values,
 // your index's similarity metric must be dot-product.
@@ -444,7 +440,7 @@ type QueryVectorsResponse struct {
 // Parameters:
 //   - ctx: A context.Context object controls the request's lifetime,
 //     allowing for the request to be canceled or to timeout according to the context's deadline.
-//   - in: A QueryByVectorValuesRequest object with the parameters for the request.
+//   - in: A [QueryByVectorValuesRequest] object with the parameters for the request.
 //
 // Example:
 //
@@ -521,8 +517,7 @@ func (idx *IndexConnection) QueryByVectorValues(ctx context.Context, in *QueryBy
 	return idx.query(ctx, req)
 }
 
-// QueryByVectorIdRequest holds the parameters for the QueryByVectorIdRequest object,
-// which is passed into the QueryByVectorId method.
+// [QueryByVectorIdRequest] holds the parameters for the [IndexConnection.QueryByVectorId] method.
 //
 // Fields:
 //   - VectorId: (Required) The unique ID of the vector used to find similar vectors.
@@ -540,12 +535,12 @@ type QueryByVectorIdRequest struct {
 	SparseValues    *SparseValues
 }
 
-// QueryByVectorId uses a vector ID to query a Pinecone index and retrieve vectors that are most similar to the
+// [IndexConnection.QueryByVectorId] uses a vector ID to query a Pinecone [Index] and retrieve vectors that are most similar to the
 // provided ID's underlying vector.
 //
-// Returns a pointer to a QueryVectorsResponse object or an error if the request fails.
+// Returns a pointer to a [QueryVectorsResponse] object or an error if the request fails.
 //
-// Note: QueryByVectorId executes a nearest neighbors search, meaning that unless TopK=1 in the QueryByVectorIdRequest
+// Note: QueryByVectorId executes a nearest neighbors search, meaning that unless TopK=1 in the [QueryByVectorIdRequest]
 // object, it will return 2+ vectors. The vector with a score of 1.0 is the vector with the same ID as the query vector.
 //
 // Parameters:
@@ -611,13 +606,12 @@ func (idx *IndexConnection) QueryByVectorId(ctx context.Context, in *QueryByVect
 	return idx.query(ctx, req)
 }
 
-// DeleteVectorsById deletes vectors by ID from a Pinecone index.
+// [IndexConnection.DeleteVectorsById] deletes vectors by ID from a Pinecone [Index].
 //
-// Returns an error if the request fails,
-// otherwise returns nil. This method will also return nil if the passed vector ID does not exist in the index or
-// namespace.
+// Returns an error if the request fails, otherwise returns nil. This method will also return
+// nil if the passed vector ID does not exist in the index or namespace.
 //
-// Note: You must instantiate an Index connection with a Namespace in NewIndexConnParams in order to delete vectors
+// Note: You must create an [IndexConnection] with a Namespace in [NewIndexConnParams] in order to delete vectors
 // in a namespace other than the default: "".
 //
 // Parameters:
@@ -667,13 +661,13 @@ func (idx *IndexConnection) DeleteVectorsById(ctx context.Context, ids []string)
 	return idx.delete(ctx, &req)
 }
 
-// DeleteVectorsByFilter deletes vectors from a Pinecone index, given a filter.
+// [IndexConnection.DeleteVectorsByFilter] deletes vectors from a Pinecone [Index], given a filter.
 //
 // Returns an error if the request fails, otherwise returns nil.
 //
-// Note: DeleteVectorsByFilter is only available on pods-based indexes.
-// Additionally, you must instantiate an IndexConnection using the Index method with a Namespace in NewIndexConnParams
-// in order to delete vectors in a namespace other than the default.
+// Note: [DeleteVectorsByFilter] is only available on pods-based indexes.
+// Additionally, you must create an [IndexConnection] using the [Client.Index] method with a Namespace in [NewIndexConnParams]
+// in order to delete vectors in a namespace other than the default: "".
 //
 // Parameters:
 //   - ctx: A context.Context object controls the request's lifetime,
@@ -731,12 +725,12 @@ func (idx *IndexConnection) DeleteVectorsByFilter(ctx context.Context, metadataF
 	return idx.delete(ctx, &req)
 }
 
-// DeleteAllVectorsInNamespace deletes all vectors in a specific namespace.
+// [IndexConnection.DeleteAllVectorsInNamespace] deletes all vectors in a specific namespace.
 //
 // Returns an error if the request fails, otherwise returns nil.
 //
-// Note: You must instantiate an IndexConnection using the Index method with a Namespace in NewIndexConnParams
-// in order to delete vectors in a namespace other than the default.
+// Note: You must instantiate an [IndexConnection] using the [Client.Index] method with a Namespace in [NewIndexConnParams]
+// in order to delete vectors in a namespace other than the default: "".
 //
 // Parameters:
 //   - ctx: A context.Context object controls the request's lifetime,
@@ -783,8 +777,7 @@ func (idx *IndexConnection) DeleteAllVectorsInNamespace(ctx context.Context) err
 	return idx.delete(ctx, &req)
 }
 
-// UpdateVectorRequest holds the parameters for the UpdateVectorRequest object,
-// which is passed into the UpdateVector method.
+// [UpdateVectorRequest] holds the parameters for the [IndexConnection.UpdateVector] method.
 //
 // Fields:
 //   - Id: (Required) The unique ID of the vector to update.
@@ -798,14 +791,14 @@ type UpdateVectorRequest struct {
 	Metadata     *Metadata
 }
 
-// UpdateVector updates a vector in a Pinecone index by ID.
+// [IndexConnection.UpdateVector] updates a vector in a Pinecone [Index] by ID.
 //
 // Returns an error if the request fails, returns nil otherwise.
 //
 // Parameters:
 //   - ctx: A context.Context object controls the request's lifetime,
 //     allowing for the request to be canceled or to timeout according to the context's deadline.
-//   - in: An UpdateVectorRequest object with the parameters for the request.
+//   - in: An [UpdateVectorRequest] object with the parameters for the request.
 //
 // Example:
 //
@@ -861,14 +854,13 @@ func (idx *IndexConnection) UpdateVector(ctx context.Context, in *UpdateVectorRe
 	return err
 }
 
-// DescribeIndexStatsResponse holds the parameters for the DescribeIndexStatsResponse object,
-// which is returned by the DescribeIndexStats method.
+// [DescribeIndexStatsResponse] is returned by the [IndexConnection.DescribeIndexStats] method.
 //
 // Fields:
-//   - Dimension: The dimension of the index.
-//   - IndexFullness: The fullness level of the index. Note: only available on pods-based indexes.
-//   - TotalVectorCount: The total number of vectors in the index.
-//   - Namespaces: The namespace(s) in the index.
+//   - Dimension: The dimension of the [Index].
+//   - IndexFullness: The fullness level of the [Index]. Note: only available on pods-based indexes.
+//   - TotalVectorCount: The total number of vectors in the [Index].
+//   - Namespaces: The namespace(s) in the [Index].
 type DescribeIndexStatsResponse struct {
 	Dimension        uint32                       `json:"dimension"`
 	IndexFullness    float32                      `json:"index_fullness"`
@@ -876,9 +868,9 @@ type DescribeIndexStatsResponse struct {
 	Namespaces       map[string]*NamespaceSummary `json:"namespaces,omitempty"`
 }
 
-// DescribeIndexStats returns statistics about a Pinecone index.
+// [IndexConnection.DescribeIndexStats] returns statistics about a Pinecone [Index].
 //
-// Returns a pointer to a DescribeIndexStatsResponse object or an error if the request fails.
+// Returns a pointer to a [DescribeIndexStatsResponse] object or an error if the request fails.
 //
 // Parameters:
 //   - ctx: A context.Context object controls the request's lifetime,
@@ -922,9 +914,9 @@ func (idx *IndexConnection) DescribeIndexStats(ctx context.Context) (*DescribeIn
 	return idx.DescribeIndexStatsFiltered(ctx, nil)
 }
 
-// DescribeIndexStatsFiltered returns statistics about a Pinecone index, filtered by a given filter.
+// [IndexConnection.DescribeIndexStatsFiltered] returns statistics about a Pinecone [Index], filtered by a given filter.
 //
-// Returns a pointer to a DescribeIndexStatsResponse object or an error if the request fails.
+// Returns a pointer to a [DescribeIndexStatsResponse] object or an error if the request fails.
 //
 // Note: DescribeIndexStatsFiltered is only available on pods-based indexes.
 //
@@ -1003,7 +995,7 @@ func (idx *IndexConnection) DescribeIndexStatsFiltered(ctx context.Context, meta
 	}, nil
 }
 
-// StartImportResponse holds the response parameters for the StartImport method.
+// [StartImportResponse] holds the response parameters for the [IndexConnection.StartImport] method.
 //
 // Fields:
 //   - Id: The ID of the import process that was started.
@@ -1011,11 +1003,11 @@ type StartImportResponse struct {
 	Id string `json:"id,omitempty"`
 }
 
-// StartImport imports data from a storage provider into an index. The uri parameter must start with the
+// [IndexConnection.StartImport] imports data from a storage provider into an [Index]. The uri parameter must start with the
 // scheme of a supported storage provider (e.g. "s3://"). For buckets that are not publicly readable, you will also need to
 // separately configure a [storage integration] and pass the integration id.
 //
-// Returns a pointer to a StartImportResponse object with the import ID or an error if the request fails.
+// Returns a pointer to a [StartImportResponse] object with the [Import] ID or an error if the request fails.
 //
 // Parameters:
 //   - ctx: A context.Context object controls the request's lifetime,
@@ -1088,9 +1080,9 @@ func (idx *IndexConnection) StartImport(ctx context.Context, uri string, integra
 	return decodeStartImportResponse(res.Body)
 }
 
-// DescribeImport retrieves information about a specific import operation.
+// [IndexConnection.DescribeImport] retrieves information about a specific [Import] operation.
 //
-// Returns an Import object representing the current state of the import or an error if the request fails.
+// Returns a pointer to an [Import] object representing the current state of the import process, or an error if the request fails.
 //
 // Parameters:
 //   - ctx: A context.Context object controls the request's lifetime,
@@ -1140,7 +1132,7 @@ func (idx *IndexConnection) DescribeImport(ctx context.Context, id string) (*Imp
 	return toImport(importModel), nil
 }
 
-// ListImportsRequest holds the parameters for the ListImports method.
+// [ListImportsRequest] holds the parameters for the [IndexConnection.ListImports] method.
 //
 // Fields:
 //   - Limit: The maximum number of imports to return.
@@ -1150,25 +1142,25 @@ type ListImportsRequest struct {
 	PaginationToken *string
 }
 
-// ListImportsResponse holds the result of listing bulk imports.
+// [ListImportsResponse] holds the result of listing [Import] objects.
 //
 // Fields:
-//   - Imports: The list of Import objects returned.
+//   - Imports: The list of [Import] objects returned.
 //   - NextPaginationToken: The token for paginating through results, if more imports are available.
 type ListImportsResponse struct {
 	Imports             []*Import `json:"imports,omitempty"`
 	NextPaginationToken *string   `json:"next_pagination_token,omitempty"`
 }
 
-// ListImports returns information about import operations. It returns operations in a
+// [IndexConnection.ListImports] returns information about [Import] operations. It returns operations in a
 // paginated form, with a pagination token to fetch the next page of results.
 //
-// Returns a pointer to a ListImportsResponse object or an error if the request fails.
+// Returns a pointer to a [ListImportsResponse] object or an error if the request fails.
 //
 // Parameters:
 //   - ctx: A context.Context object controls the request's lifetime,
 //     allowing for the request to be canceled or to timeout according to the context's deadline.
-//   - req: A ListImportsRequest object containing pagination and filter options.
+//   - req: A [ListImportsRequest] object containing pagination and filter options.
 //
 // Example:
 //
@@ -1226,14 +1218,14 @@ func (idx *IndexConnection) ListImports(ctx context.Context, limit *int32, pagin
 	return listImportsResponse, nil
 }
 
-// CancelImport cancels an import operation by id.
+// [IndexConnection.CancelImport] cancels an [Import] operation by id.
 //
 // Returns an error if the request fails.
 //
 // Parameters:
 //   - ctx: A context.Context object controls the request's lifetime,
 //     allowing for the request to be canceled or to timeout according to the context's deadline.
-//   - id: The id of the import operation to cancel.
+//   - id: The id of the [Import] operation to cancel.
 //
 // Example:
 //

--- a/pinecone/index_connection_test.go
+++ b/pinecone/index_connection_test.go
@@ -280,8 +280,9 @@ func (ts *IntegrationTests) TestImportFlowHappyPath() {
 
 	testImportUri := "s3://dev-bulk-import-datasets-pub/10-records-dim-10/"
 	ctx := context.Background()
+	errorMode := "continue"
 
-	startRes, err := ts.idxConn.StartImport(ctx, testImportUri, nil, nil)
+	startRes, err := ts.idxConn.StartImport(ctx, testImportUri, nil, (*ImportErrorMode)(&errorMode))
 	assert.NoError(ts.T(), err)
 	assert.NotNil(ts.T(), startRes)
 

--- a/pinecone/models.go
+++ b/pinecone/models.go
@@ -6,7 +6,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-// IndexMetric is the [distance metric] to be used by similarity search against a Pinecone Index.
+// [IndexMetric] is the [distance metric] to be used by similarity search against a Pinecone [Index].
 //
 // [distance metric]: https://docs.pinecone.io/guides/indexes/understanding-indexes#distance-metrics
 type IndexMetric string
@@ -17,7 +17,7 @@ const (
 	Euclidean  IndexMetric = "euclidean"  // Ideal for distance-based data (e.g. lat/long points)
 )
 
-// IndexStatusState is the state of a Pinecone Index.
+// [IndexStatusState] is the state of a Pinecone [Index].
 type IndexStatusState string
 
 const (
@@ -31,8 +31,8 @@ const (
 	Terminating          IndexStatusState = "Terminating"
 )
 
-// DeletionProtection determines whether [deletion protection] is "enabled" or "disabled" for the index.
-// When "enabled", the index cannot be deleted. Defaults to "disabled".
+// [DeletionProtection] determines whether [deletion protection] is "enabled" or "disabled" for the [Index].
+// When "enabled", the [Index] cannot be deleted. Defaults to "disabled".
 //
 // [deletion protection]: http://docs.pinecone.io/guides/indexes/prevent-index-deletion
 type DeletionProtection string
@@ -42,7 +42,7 @@ const (
 	DeletionProtectionDisabled DeletionProtection = "disabled"
 )
 
-// Cloud is the [cloud provider] to be used for a Pinecone serverless Index.
+// [Cloud] is the [cloud provider] to be used for a Pinecone serverless [Index].
 //
 // [cloud provider]: https://docs.pinecone.io/troubleshooting/available-cloud-regions
 type Cloud string
@@ -53,19 +53,19 @@ const (
 	Gcp   Cloud = "gcp"
 )
 
-// IndexStatus is the status of a Pinecone Index.
+// [IndexStatus] is the status of a Pinecone [Index].
 type IndexStatus struct {
 	Ready bool             `json:"ready"`
 	State IndexStatusState `json:"state"`
 }
 
-// IndexSpec is the infrastructure specification (pods vs serverless) of a Pinecone Index.
+// [IndexSpec] is the infrastructure specification (pods vs serverless) of a Pinecone [Index].
 type IndexSpec struct {
 	Pod        *PodSpec        `json:"pod,omitempty"`
 	Serverless *ServerlessSpec `json:"serverless,omitempty"`
 }
 
-// Index is a Pinecone Index object. Can be either a pod-based or a serverless Index, depending on the IndexSpec.
+// [Index] is a Pinecone [Index] object. Can be either a pod-based or a serverless [Index], depending on the [IndexSpec].
 type Index struct {
 	Name               string             `json:"name"`
 	Dimension          int32              `json:"dimension"`
@@ -76,9 +76,9 @@ type Index struct {
 	Status             *IndexStatus       `json:"status,omitempty"`
 }
 
-// Collection is a Pinecone [Collection object]. Only available for pod-based Indexes.
+// [Collection] is a Pinecone [collection entity]. Only available for pod-based Indexes.
 //
-// [Collection object]: https://docs.pinecone.io/guides/indexes/understanding-collections
+// [collection entity]: https://docs.pinecone.io/guides/indexes/understanding-collections
 type Collection struct {
 	Name        string           `json:"name"`
 	Size        int64            `json:"size"`
@@ -88,7 +88,7 @@ type Collection struct {
 	Environment string           `json:"environment"`
 }
 
-// CollectionStatus is the status of a Pinecone Collection.
+// [CollectionStatus] is the status of a Pinecone [Collection].
 type CollectionStatus string
 
 const (
@@ -97,12 +97,12 @@ const (
 	CollectionStatusTerminating  CollectionStatus = "Terminating"
 )
 
-// PodSpecMetadataConfig represents the metadata fields to be indexed when a Pinecone Index is created.
+// [PodSpecMetadataConfig] represents the metadata fields to be indexed when a Pinecone [Index] is created.
 type PodSpecMetadataConfig struct {
 	Indexed *[]string `json:"indexed,omitempty"`
 }
 
-// PodSpec is the infrastructure specification of a pod-based Pinecone Index. Only available for pod-based Indexes.
+// [PodSpec] is the infrastructure specification of a pod-based Pinecone [Index]. Only available for pod-based Indexes.
 type PodSpec struct {
 	Environment      string                 `json:"environment"`
 	PodType          string                 `json:"pod_type"`
@@ -113,13 +113,13 @@ type PodSpec struct {
 	MetadataConfig   *PodSpecMetadataConfig `json:"metadata_config,omitempty"`
 }
 
-// ServerlessSpec is the infrastructure specification of a serverless Pinecone Index. Only available for serverless Indexes.
+// [ServerlessSpec] is the infrastructure specification of a serverless Pinecone [Index]. Only available for serverless Indexes.
 type ServerlessSpec struct {
 	Cloud  Cloud  `json:"cloud"`
 	Region string `json:"region"`
 }
 
-// Vector is a [dense or sparse vector object] with optional metadata.
+// [Vector] is a [dense or sparse vector object] with optional metadata.
 //
 // [dense or sparse vector object]: https://docs.pinecone.io/guides/get-started/key-concepts#dense-vector
 type Vector struct {
@@ -129,14 +129,14 @@ type Vector struct {
 	Metadata     *Metadata     `json:"metadata,omitempty"`
 }
 
-// ScoredVector is a vector with an associated similarity score calculated according to the distance metric of the
-// Index.
+// [ScoredVector] is a vector with an associated similarity score calculated according to the distance metric of the
+// [Index].
 type ScoredVector struct {
 	Vector *Vector `json:"vector,omitempty"`
 	Score  float32 `json:"score"`
 }
 
-// SparseValues is a sparse vector objects, most commonly used for [hybrid search].
+// [SparseValues] is a sparse vector objects, most commonly used for [hybrid search].
 //
 // [hybrid search]: https://docs.pinecone.io/guides/data/understanding-hybrid-search#hybrid-search-in-pinecone
 type SparseValues struct {
@@ -144,54 +144,54 @@ type SparseValues struct {
 	Values  []float32 `json:"values,omitempty"`
 }
 
-// NamespaceSummary is a summary of stats for a Pinecone [namespace].
+// [NamespaceSummary] is a summary of stats for a Pinecone [namespace].
 //
 // [namespace]: https://docs.pinecone.io/guides/indexes/use-namespaces
 type NamespaceSummary struct {
 	VectorCount uint32 `json:"vector_count"`
 }
 
-// Usage is the usage stats ([Read Units]) for a Pinecone Index.
+// [Usage] is the usage stats ([Read Units]) for a Pinecone [Index].
 //
 // [Read Units]: https://docs.pinecone.io/guides/organizations/manage-cost/understanding-cost#serverless-indexes
 type Usage struct {
 	ReadUnits uint32 `json:"read_units"`
 }
 
-// RerankUsage is the usage stats ([Rerank Units]) for a reranking request.
+// [RerankUsage] is the usage stats ([Rerank Units]) for a reranking request.
 //
 // [Rerank Units]: https://docs.pinecone.io/guides/organizations/manage-cost/understanding-cost#rerank
 type RerankUsage struct {
 	RerankUnits *int `json:"rerank_units,omitempty"`
 }
 
-// MetadataFilter represents the [metadata filters] attached to a Pinecone request.
+// [MetadataFilter] represents the [metadata filters] attached to a Pinecone request.
 // These optional metadata filters are applied to query and deletion requests.
 //
 // [metadata filters]: https://docs.pinecone.io/guides/data/filter-with-metadata#querying-an-index-with-metadata-filters
 type MetadataFilter = structpb.Struct
 
-// Metadata represents optional,
+// [Metadata] represents optional,
 // additional information that can be [attached to, or updated for, a vector] in a Pinecone Index.
 //
 // [attached to, or updated for, a vector]: https://docs.pinecone.io/guides/data/filter-with-metadata#inserting-metadata-into-an-index
 type Metadata = structpb.Struct
 
-// The embedding of a single input which is returned after [generating embeddings].
+// [Embedding] represents the embedding of a single input which is returned after [generating embeddings].
 //
 // [generating embeddings]: https://docs.pinecone.io/guides/inference/generate-embeddings#3-generate-embeddings
 type Embedding struct {
 	Values *[]float32 `json:"values,omitempty"`
 }
 
-// ImportStatus represents the status of an import operation.
+// [ImportStatus] represents the status of an [Import] operation.
 //
 // Values:
-//   - Cancelled: The import was canceled.
-//   - Completed: The import completed successfully.
-//   - Failed: The import encountered an error and did not complete successfully.
-//   - InProgress: The import is currently in progress.
-//   - Pending: The import is pending and has not yet started.
+//   - Cancelled: The [Import] was canceled.
+//   - Completed: The [Import] completed successfully.
+//   - Failed: The [Import] encountered an error and did not complete successfully.
+//   - InProgress: The [Import] is currently in progress.
+//   - Pending: The [Import] is pending and has not yet started.
 type ImportStatus string
 
 const (
@@ -202,11 +202,11 @@ const (
 	Pending    ImportStatus = "Pending"
 )
 
-// ImportErrorMode specifies how errors are handled during an import.
+// ImportErrorMode specifies how errors are handled during an [Import].
 //
 // Values:
-//   - Abort: The import process will abort upon encountering an error.
-//   - Continue: The import process will continue, skipping over records that produce errors.
+//   - Abort: The [Import] process will abort upon encountering an error.
+//   - Continue: The [Import] process will continue, skipping over records that produce errors.
 type ImportErrorMode string
 
 const (
@@ -214,17 +214,17 @@ const (
 	Continue ImportErrorMode = "continue"
 )
 
-// Import represents the details and status of a bulk import process.
+// [Import] represents the details and status of an import process.
 //
 // Fields:
-//   - Id: The unique identifier of the import process.
-//   - PercentComplete: The percentage of the import process that has been completed.
+//   - Id: The unique identifier of the [Import] process.
+//   - PercentComplete: The percentage of the [Import] process that has been completed.
 //   - RecordsImported: The total number of records successfully imported.
-//   - Status: The current status of the import (e.g., "InProgress", "Completed", "Failed").
-//   - Uri: The URI of the source data for the import.
-//   - CreatedAt: The time at which the import process was initiated.
-//   - FinishedAt: The time at which the import process finished (either successfully or with an error).
-//   - Error: If the import failed, contains the error message associated with the failure.
+//   - Status: The current status of the [Import] (e.g., "InProgress", "Completed", "Failed").
+//   - Uri: The URI of the source data for the [Import].
+//   - CreatedAt: The time at which the [Import] process was initiated.
+//   - FinishedAt: The time at which the [Import] process finished (either successfully or with an error).
+//   - Error: If the [Import] failed, contains the error message associated with the failure.
 type Import struct {
 	Id              string       `json:"id,omitempty"`
 	PercentComplete float32      `json:"percent_complete,omitempty"`


### PR DESCRIPTION
## Problem
We can actually hyperlink to all of the contents of the `Pinecone` package in our doc comments, which is nice. There's also a few final tweaks I want to get in before the release.

## Solution
- Clean up doc comments and add links for various namespaces.
- Add an example of passing errorMode for import in integration test.

All of the changes here are to code comments, there aren't any actual changes to code included in this PR.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [X] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
`just docs` locally to serve the webpage including all of the client documentation
