### PR TITLE
Regenerate client code for `2024-10`

### DIFF
--- a/internal/gen/db_control/db_control_2024-10.oas.go
+++ b/internal/gen/db_control/db_control_2024-10.oas.go
@@ -272,13 +272,13 @@ type PodSpec struct {
 	PodType string `json:"pod_type"`
 
 	// Pods The number of pods to be used in the index. This should be equal to `shards` x `replicas`.'
-	Pods int `json:"pods"`
+	Pods *int `json:"pods,omitempty"`
 
 	// Replicas The number of replicas. Replicas duplicate your index. They provide higher availability and throughput. Replicas can be scaled up or down as your needs change.
-	Replicas int32 `json:"replicas"`
+	Replicas *int32 `json:"replicas,omitempty"`
 
 	// Shards The number of shards. Shards split your data across multiple pods so you can fit more data into an index.
-	Shards int32 `json:"shards"`
+	Shards *int32 `json:"shards,omitempty"`
 
 	// SourceCollection The name of the collection to be used as the source for the index.
 	SourceCollection *string `json:"source_collection,omitempty"`
@@ -1220,6 +1220,7 @@ type DeleteIndexResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON401      *ErrorResponse
+	JSON403      *ErrorResponse
 	JSON404      *ErrorResponse
 	JSON412      *ErrorResponse
 	JSON500      *ErrorResponse
@@ -1744,6 +1745,13 @@ func ParseDeleteIndexResponse(rsp *http.Response) (*DeleteIndexResponse, error) 
 			return nil, err
 		}
 		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
 		var dest ErrorResponse

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -1509,9 +1509,9 @@ func toIndex(idx *db_control.IndexModel) *Index {
 		spec.Pod = &PodSpec{
 			Environment:      idx.Spec.Pod.Environment,
 			PodType:          idx.Spec.Pod.PodType,
-			PodCount:         derefOrDefault(idx.Spec.Pod.Pods, 0),
-			Replicas:         derefOrDefault(idx.Spec.Pod.Replicas, 0),
-			ShardCount:       derefOrDefault(idx.Spec.Pod.Shards, 0),
+			PodCount:         derefOrDefault(idx.Spec.Pod.Pods, 1),
+			Replicas:         derefOrDefault(idx.Spec.Pod.Replicas, 1),
+			ShardCount:       derefOrDefault(idx.Spec.Pod.Shards, 1),
 			SourceCollection: idx.Spec.Pod.SourceCollection,
 		}
 		if idx.Spec.Pod.MetadataConfig != nil {

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -544,6 +544,9 @@ func (c *Client) CreatePodIndex(ctx context.Context, in *CreatePodIndexRequest) 
 
 	deletionProtection := pointerOrNil(db_control.DeletionProtection(in.DeletionProtection))
 	metric := pointerOrNil(db_control.CreateIndexRequestMetric(in.Metric))
+	pods := in.TotalCount()
+	replicas := in.ReplicaCount()
+	shards := in.ShardCount()
 
 	req := db_control.CreateIndexRequest{
 		Name:               in.Name,
@@ -556,9 +559,9 @@ func (c *Client) CreatePodIndex(ctx context.Context, in *CreatePodIndexRequest) 
 		Pod: &db_control.PodSpec{
 			Environment:      in.Environment,
 			PodType:          in.PodType,
-			Pods:             in.TotalCount(),
-			Replicas:         in.ReplicaCount(),
-			Shards:           in.ShardCount(),
+			Pods:             &pods,
+			Replicas:         &replicas,
+			Shards:           &shards,
 			SourceCollection: in.SourceCollection,
 		},
 	}
@@ -1506,9 +1509,9 @@ func toIndex(idx *db_control.IndexModel) *Index {
 		spec.Pod = &PodSpec{
 			Environment:      idx.Spec.Pod.Environment,
 			PodType:          idx.Spec.Pod.PodType,
-			PodCount:         int32(idx.Spec.Pod.Pods),
-			Replicas:         idx.Spec.Pod.Replicas,
-			ShardCount:       idx.Spec.Pod.Shards,
+			PodCount:         derefOrDefault(idx.Spec.Pod.Pods, 0),
+			Replicas:         derefOrDefault(idx.Spec.Pod.Replicas, 0),
+			ShardCount:       derefOrDefault(idx.Spec.Pod.Shards, 0),
 			SourceCollection: idx.Spec.Pod.SourceCollection,
 		}
 		if idx.Spec.Pod.MetadataConfig != nil {

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -971,6 +971,9 @@ func TestEnsureURLSchemeUnit(t *testing.T) {
 func TestToIndexUnit(t *testing.T) {
 	deletionProtectionEnabled := db_control.Enabled
 	deletionProtectionDisabled := db_control.Disabled
+	pods := 1
+	replicas := int32(1)
+	shards := int32(1)
 
 	tests := []struct {
 		name           string
@@ -999,9 +1002,9 @@ func TestToIndexUnit(t *testing.T) {
 				}{Pod: &db_control.PodSpec{
 					Environment:      "test-environ",
 					PodType:          "p1.x2",
-					Pods:             1,
-					Replicas:         1,
-					Shards:           1,
+					Pods:             &pods,
+					Replicas:         &replicas,
+					Shards:           &shards,
 					SourceCollection: nil,
 					MetadataConfig:   nil,
 				}}),

--- a/pinecone/models.go
+++ b/pinecone/models.go
@@ -106,7 +106,7 @@ type PodSpecMetadataConfig struct {
 type PodSpec struct {
 	Environment      string                 `json:"environment"`
 	PodType          string                 `json:"pod_type"`
-	PodCount         int32                  `json:"pod_count"`
+	PodCount         int                    `json:"pod_count"`
 	Replicas         int32                  `json:"replicas"`
 	ShardCount       int32                  `json:"shard_count"`
 	SourceCollection *string                `json:"source_collection,omitempty"`


### PR DESCRIPTION
## Problem
PR was merged today making some slight adjustments to the db control spec to better align with the server impl: https://github.com/pinecone-io/apis/pull/181

## Solution
Slightly adjust the `PodSpec` type and related code to account for the new shape.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
`just test` - CI
