### PR TITLE
Implement `IndexTags`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
         env:
           PORT: 5081
           DIMENSION: 1536
-          METRIC: dot-product
+          METRIC: dotproduct
           INDEX_TYPE: serverless
       pc-index-pod:
         image: ghcr.io/pinecone-io/pinecone-index:latest

--- a/pinecone/models.go
+++ b/pinecone/models.go
@@ -65,6 +65,9 @@ type IndexSpec struct {
 	Serverless *ServerlessSpec `json:"serverless,omitempty"`
 }
 
+// [IndexTags] is a set of key-value pairs that can be attached to a Pinecone [Index].
+type IndexTags map[string]string
+
 // [Index] is a Pinecone [Index] object. Can be either a pod-based or a serverless [Index], depending on the [IndexSpec].
 type Index struct {
 	Name               string             `json:"name"`
@@ -74,6 +77,7 @@ type Index struct {
 	DeletionProtection DeletionProtection `json:"deletion_protection,omitempty"`
 	Spec               *IndexSpec         `json:"spec,omitempty"`
 	Status             *IndexStatus       `json:"status,omitempty"`
+	Tags               *IndexTags         `json:"tags,omitempty"`
 }
 
 // [Collection] is a Pinecone [collection entity]. Only available for pod-based Indexes.

--- a/pinecone/suite_runner_test.go
+++ b/pinecone/suite_runner_test.go
@@ -24,9 +24,10 @@ func RunSuites(t *testing.T) {
 	client, err := NewClient(NewClientParams{ApiKey: apiKey, SourceTag: sourceTag})
 	require.NotNil(t, client, "Client should not be nil after creation")
 	require.NoError(t, err)
+	indexTags := IndexTags{"test1": "test-tag-1", "test2": "test-tag-2"}
 
-	serverlessIdx := BuildServerlessTestIndex(client, "serverless-"+GenerateTestIndexName())
-	podIdx := BuildPodTestIndex(client, "pods-"+GenerateTestIndexName())
+	serverlessIdx := BuildServerlessTestIndex(client, "serverless-"+GenerateTestIndexName(), indexTags)
+	podIdx := BuildPodTestIndex(client, "pods-"+GenerateTestIndexName(), indexTags)
 
 	podTestSuite := &IntegrationTests{
 		apiKey:    apiKey,
@@ -36,6 +37,7 @@ func RunSuites(t *testing.T) {
 		client:    client,
 		sourceTag: sourceTag,
 		idxName:   podIdx.Name,
+		indexTags: &indexTags,
 	}
 
 	serverlessTestSuite := &IntegrationTests{
@@ -46,6 +48,7 @@ func RunSuites(t *testing.T) {
 		client:    client,
 		sourceTag: sourceTag,
 		idxName:   serverlessIdx.Name,
+		indexTags: &indexTags,
 	}
 
 	suite.Run(t, podTestSuite)

--- a/pinecone/test_suite.go
+++ b/pinecone/test_suite.go
@@ -24,6 +24,7 @@ type IntegrationTests struct {
 	idxConn        *IndexConnection
 	collectionName string
 	sourceTag      string
+	indexTags      *IndexTags
 }
 
 func (ts *IntegrationTests) SetupSuite() {
@@ -207,7 +208,7 @@ func generateVectorValues(dimension int32) []float32 {
 	return values
 }
 
-func BuildServerlessTestIndex(in *Client, idxName string) *Index {
+func BuildServerlessTestIndex(in *Client, idxName string, tags IndexTags) *Index {
 	ctx := context.Background()
 
 	fmt.Printf("Creating Serverless index: %s\n", idxName)
@@ -217,6 +218,7 @@ func BuildServerlessTestIndex(in *Client, idxName string) *Index {
 		Metric:    Cosine,
 		Region:    "us-east-1",
 		Cloud:     "aws",
+		Tags:      &tags,
 	})
 	if err != nil {
 		log.Fatalf("Failed to create Serverless index \"%s\" in integration test: %v", err, idxName)
@@ -226,7 +228,7 @@ func BuildServerlessTestIndex(in *Client, idxName string) *Index {
 	return serverlessIdx
 }
 
-func BuildPodTestIndex(in *Client, name string) *Index {
+func BuildPodTestIndex(in *Client, name string, tags IndexTags) *Index {
 	ctx := context.Background()
 
 	fmt.Printf("Creating pod index: %s\n", name)
@@ -236,6 +238,7 @@ func BuildPodTestIndex(in *Client, name string) *Index {
 		Metric:      Cosine,
 		Environment: "us-east-1-aws",
 		PodType:     "p1",
+		Tags:        &tags,
 	})
 	if err != nil {
 		log.Fatalf("Failed to create pod index in buildPodTestIndex test: %v", err)


### PR DESCRIPTION
## Problem
[Index tags are a feature ](https://docs.pinecone.io/guides/indexes/tag-an-index) which was included in the `2024-10` API specification, but was not implemented in the SDK interface.

## Solution
- Add new `IndexTags` type to `models.go`. This just represents `map[string]string`, lining up with the generated type.
- Update `CreateServerlessIndexRequest`, `CreatePodIndexRequest`, and `ConfigureIndexParams` to allow passing `IndexTags` optionally.
- Update integration test setup / teardown to support working with tags. Add a new test method to exercise validating tags, and updating them through `ConfigureIndex`.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
CI Integration Tests should pass - these create serverless & pod indexes with tags, and then a test checks the tags and updates them as a part of the integration test suite.

To work with tags directly in Go:

```go
	indexTags := IndexTags{"test1": "test-tag-1", "test2": "test-tag-2"}
	serverlessIdx, err := in.CreateServerlessIndex(ctx, &CreateServerlessIndexRequest{
		Name:      "test-index",
		Dimension: uint32(5),
		Metric:    Cosine,
		Region:    "us-east-1",
		Cloud:     "aws",
		Tags:      &indexTags,
	})
```


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208820098587324