### PR TITLE
Fix `v2.X.X` releases for the client, update `go.mod`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/oapi-codegen/runtime v1.1.1
-	github.com/pinecone-io/go-pinecone v1.1.1
 	github.com/stretchr/testify v1.8.4
 	google.golang.org/genproto/googleapis/api v0.0.0-20240528184218-531527333157
 	google.golang.org/grpc v1.65.0

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pinecone-io/go-pinecone
+module github.com/pinecone-io/go-pinecone/v2
 
 go 1.21
 
@@ -6,6 +6,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/oapi-codegen/runtime v1.1.1
+	github.com/pinecone-io/go-pinecone v1.1.1
 	github.com/stretchr/testify v1.8.4
 	google.golang.org/genproto/googleapis/api v0.0.0-20240528184218-531527333157
 	google.golang.org/grpc v1.65.0

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=
 github.com/oapi-codegen/runtime v1.1.1 h1:EXLHh0DXIJnWhdRPN2w4MXAzFyE4CskzhNLUmtpMYro=
 github.com/oapi-codegen/runtime v1.1.1/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
+github.com/pinecone-io/go-pinecone v1.1.1 h1:pKoIiYcBIbrR7gaq0JXPiVnNEtevFYeq/AYL7T0NbbE=
+github.com/pinecone-io/go-pinecone v1.1.1/go.mod h1:KfJhn4yThX293+fbtrZLnxe2PJYo8557Py062W4FYKk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,6 @@ github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=
 github.com/oapi-codegen/runtime v1.1.1 h1:EXLHh0DXIJnWhdRPN2w4MXAzFyE4CskzhNLUmtpMYro=
 github.com/oapi-codegen/runtime v1.1.1/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
-github.com/pinecone-io/go-pinecone v1.1.1 h1:pKoIiYcBIbrR7gaq0JXPiVnNEtevFYeq/AYL7T0NbbE=
-github.com/pinecone-io/go-pinecone v1.1.1/go.mod h1:KfJhn4yThX293+fbtrZLnxe2PJYo8557Py062W4FYKk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=

--- a/internal/useragent/useragent.go
+++ b/internal/useragent/useragent.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pinecone-io/go-pinecone/internal"
+	"github.com/pinecone-io/go-pinecone/v2/internal"
 )
 
 func getPackageVersion() string {

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -14,12 +14,12 @@ import (
 	"os"
 	"strings"
 
-	"github.com/pinecone-io/go-pinecone/internal/gen"
-	"github.com/pinecone-io/go-pinecone/internal/gen/db_control"
-	db_data_rest "github.com/pinecone-io/go-pinecone/internal/gen/db_data/rest"
-	"github.com/pinecone-io/go-pinecone/internal/gen/inference"
-	"github.com/pinecone-io/go-pinecone/internal/provider"
-	"github.com/pinecone-io/go-pinecone/internal/useragent"
+	"github.com/pinecone-io/go-pinecone/v2/internal/gen"
+	"github.com/pinecone-io/go-pinecone/v2/internal/gen/db_control"
+	db_data_rest "github.com/pinecone-io/go-pinecone/v2/internal/gen/db_data/rest"
+	"github.com/pinecone-io/go-pinecone/v2/internal/gen/inference"
+	"github.com/pinecone-io/go-pinecone/v2/internal/provider"
+	"github.com/pinecone-io/go-pinecone/v2/internal/useragent"
 	"google.golang.org/grpc"
 )
 

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -14,11 +14,11 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
-	"github.com/pinecone-io/go-pinecone/internal/gen"
-	"github.com/pinecone-io/go-pinecone/internal/gen/db_control"
-	"github.com/pinecone-io/go-pinecone/internal/provider"
+	"github.com/pinecone-io/go-pinecone/v2/internal/gen"
+	"github.com/pinecone-io/go-pinecone/v2/internal/gen/db_control"
+	"github.com/pinecone-io/go-pinecone/v2/internal/provider"
 
-	"github.com/pinecone-io/go-pinecone/internal/utils"
+	"github.com/pinecone-io/go-pinecone/v2/internal/utils"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pinecone/index_connection.go
+++ b/pinecone/index_connection.go
@@ -11,9 +11,9 @@ import (
 	"net/url"
 	"strings"
 
-	db_data_grpc "github.com/pinecone-io/go-pinecone/internal/gen/db_data/grpc"
-	db_data_rest "github.com/pinecone-io/go-pinecone/internal/gen/db_data/rest"
-	"github.com/pinecone-io/go-pinecone/internal/useragent"
+	db_data_grpc "github.com/pinecone-io/go-pinecone/v2/internal/gen/db_data/grpc"
+	db_data_rest "github.com/pinecone-io/go-pinecone/v2/internal/gen/db_data/rest"
+	"github.com/pinecone-io/go-pinecone/v2/internal/useragent"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"

--- a/pinecone/index_connection_test.go
+++ b/pinecone/index_connection_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	db_data_grpc "github.com/pinecone-io/go-pinecone/internal/gen/db_data/grpc"
-	"github.com/pinecone-io/go-pinecone/internal/utils"
+	db_data_grpc "github.com/pinecone-io/go-pinecone/v2/internal/gen/db_data/grpc"
+	"github.com/pinecone-io/go-pinecone/v2/internal/utils"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/structpb"


### PR DESCRIPTION
## Problem
We made a mistake when releasing the previous `v2.X.X` of the Go client. In order to handle major versions properly, the Go module ecosystem requires that packages include a `/vX` path for major versions. This needs to be represented in the `go.mod` file for the module. See https://go.dev/doc/modules/version-numbers under "Major version".

Without making this change to the `go.mod` file, when attempting to install >v2.x.x, you end up with an error:

```
go get -u github.com/pinecone-io/go-pinecone/pinecone@v2.0.0
go: github.com/pinecone-io/go-pinecone/pinecone@v2.0.0: github.com/pinecone-io/go-pinecone@v2.0.0: invalid version: module contains a go.mod file, so module path must match major version ("github.com/pinecone-io/go-pinecone/v2")
```

## Solution
- Update `go.mod` for v2 -> `module github.com/pinecone-io/go-pinecone/v2`.
- Update places where we're importing from `github.com/pinecone-io/go-pinecone/internal` to `github.com/pinecone-io/go-pinecone/v2/internal`.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
We need to tag and release a new `v2.2.0` to test that this works as expected. Testing against previous 2.x.x releases is hampered by the fact that the `go.mod` file is incorrect.
