### PR TITLE
Implement sparse index support

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ func main() {
 
 **Create a serverless index**
 
-The following example creates a serverless index in the `us-east-1`
+The following example creates a `dense` serverless index in the `us-east-1`
 region of AWS. For more information on serverless and regional availability,
 see [Understanding indexes](https://docs.pinecone.io/guides/indexes/understanding-indexes#serverless-indexes).
 
@@ -157,6 +157,53 @@ func main() {
 		Cloud:     pinecone.Aws,
 		Region:    "us-east-1",
 		Tags:      &pinecone.IndexTags{"environment": "development"},
+	})
+
+	if err != nil {
+		log.Fatalf("Failed to create serverless index: %v", err)
+	} else {
+		fmt.Printf("Successfully created serverless index: %s", idx.Name)
+	}
+}
+```
+
+You can also create `sparse` only serverless indexes. These indexes enable direct indexing and retrieval of sparse vectors, supporting traditional methods like BM25 and learned sparse models such as [pinecone-sparse-english-v0](https://docs.pinecone.io/models/pinecone-sparse-english-v0). A `sparse` index must have a distance metric of `dotproduct` and does not require a specified dimension:
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/pinecone-io/go-pinecone/v2/pinecone"
+	"log"
+	"os"
+)
+
+func main() {
+	ctx := context.Background()
+
+	clientParams := pinecone.NewClientParams{
+		ApiKey: os.Getenv("PINECONE_API_KEY"),
+	}
+
+	pc, err := pinecone.NewClient(clientParams)
+	if err != nil {
+		log.Fatalf("Failed to create Client: %v", err)
+	} else {
+		fmt.Println("Successfully created a new Client object!")
+	}
+
+	indexName := "my-serverless-index"
+	vectorType := "dense"
+
+	idx, err := pc.CreateServerlessIndex(ctx, &pinecone.CreateServerlessIndexRequest{
+		Name:       indexName,
+		Metric:     pinecone.Dotproduct,
+		VectorType: &vectorType,
+		Cloud:      pinecone.Aws,
+		Region:     "us-east-1",
+		Tags:       &pinecone.IndexTags{"environment": "development"},
 	})
 
 	if err != nil {

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ func main() {
 	}
 
 	indexName := "my-serverless-index"
-	vectorType := "dense"
+	vectorType := "sparse"
 
 	idx, err := pc.CreateServerlessIndex(ctx, &pinecone.CreateServerlessIndexRequest{
 		Name:       indexName,

--- a/internal/gen/db_data/grpc/db_data_2025-01_grpc.pb.go
+++ b/internal/gen/db_data/grpc/db_data_2025-01_grpc.pb.go
@@ -34,47 +34,47 @@ const (
 type VectorServiceClient interface {
 	// Upsert vectors
 	//
-	// The `upsert` operation writes vectors into a namespace. If a new value is upserted for an existing vector ID, it will overwrite the previous value.
+	// Writes vectors into a namespace. If a new value is upserted for an existing vector ID, it will overwrite the previous value.
 	//
 	// For guidance and examples, see [Upsert data](https://docs.pinecone.io/guides/data/upsert-data).
 	Upsert(ctx context.Context, in *UpsertRequest, opts ...grpc.CallOption) (*UpsertResponse, error)
 	// Delete vectors
 	//
-	// The `delete` operation deletes vectors, by id, from a single namespace.
+	// Delete vectors by id from a single namespace.
 	//
 	// For guidance and examples, see [Delete data](https://docs.pinecone.io/guides/data/delete-data).
 	Delete(ctx context.Context, in *DeleteRequest, opts ...grpc.CallOption) (*DeleteResponse, error)
 	// Fetch vectors
 	//
-	// The `fetch` operation looks up and returns vectors, by ID, from a single namespace. The returned vectors include the vector data and/or metadata.
+	// Look up and returns vectors by ID from a single namespace. The returned vectors include the vector data and/or metadata.
 	//
 	// For guidance and examples, see [Fetch data](https://docs.pinecone.io/guides/data/fetch-data).
 	Fetch(ctx context.Context, in *FetchRequest, opts ...grpc.CallOption) (*FetchResponse, error)
 	// List vector IDs
 	//
-	// The `list` operation lists the IDs of vectors in a single namespace of a serverless index. An optional prefix can be passed to limit the results to IDs with a common prefix.
+	// List the IDs of vectors in a single namespace of a serverless index. An optional prefix can be passed to limit the results to IDs with a common prefix.
 	//
-	// `list` returns up to 100 IDs at a time by default in sorted order (bitwise/"C" collation). If the `limit` parameter is set, `list` returns up to that number of IDs instead. Whenever there are additional IDs to return, the response also includes a `pagination_token` that you can use to get the next batch of IDs. When the response does not include a `pagination_token`, there are no more IDs to return.
+	// This returns up to 100 IDs at a time by default in sorted order (bitwise/"C" collation). If the `limit` parameter is set, `list` returns up to that number of IDs instead. Whenever there are additional IDs to return, the response also includes a `pagination_token` that you can use to get the next batch of IDs. When the response does not include a `pagination_token`, there are no more IDs to return.
 	//
 	// For guidance and examples, see [List record IDs](https://docs.pinecone.io/guides/data/list-record-ids).
 	//
-	// **Note:** `list` is supported only for serverless indexes.
+	// **Note:** This is supported only for serverless indexes.
 	List(ctx context.Context, in *ListRequest, opts ...grpc.CallOption) (*ListResponse, error)
 	// Query vectors
 	//
-	// The `query` operation searches a namespace, using a query vector. It retrieves the ids of the most similar items in a namespace, along with their similarity scores.
+	// Searches a namespace, using a query vector. It retrieves the ids of the most similar items in a namespace, along with their similarity scores.
 	//
 	// For guidance and examples, see [Query data](https://docs.pinecone.io/guides/data/query-data).
 	Query(ctx context.Context, in *QueryRequest, opts ...grpc.CallOption) (*QueryResponse, error)
 	// Update a vector
 	//
-	// The `update` operation updates a vector in a namespace. If a value is included, it will overwrite the previous value. If a `set_metadata` is included, the values of the fields specified in it will be added or overwrite the previous value.
+	// Update a vector in a namespace. If a value is included, it will overwrite the previous value. If a `set_metadata` is included, the values of the fields specified in it will be added or overwrite the previous value.
 	//
 	// For guidance and examples, see [Update data](https://docs.pinecone.io/guides/data/update-data).
 	Update(ctx context.Context, in *UpdateRequest, opts ...grpc.CallOption) (*UpdateResponse, error)
 	// Get index stats
 	//
-	// The `describe_index_stats` operation returns statistics about the contents of an index, including the vector count per namespace, the number of dimensions, and the index fullness.
+	// Return statistics about the contents of an index, including the vector count per namespace, the number of dimensions, and the index fullness.
 	//
 	// Serverless indexes scale automatically as needed, so index fullness is relevant only for pod-based indexes.
 	DescribeIndexStats(ctx context.Context, in *DescribeIndexStatsRequest, opts ...grpc.CallOption) (*DescribeIndexStatsResponse, error)
@@ -157,47 +157,47 @@ func (c *vectorServiceClient) DescribeIndexStats(ctx context.Context, in *Descri
 type VectorServiceServer interface {
 	// Upsert vectors
 	//
-	// The `upsert` operation writes vectors into a namespace. If a new value is upserted for an existing vector ID, it will overwrite the previous value.
+	// Writes vectors into a namespace. If a new value is upserted for an existing vector ID, it will overwrite the previous value.
 	//
 	// For guidance and examples, see [Upsert data](https://docs.pinecone.io/guides/data/upsert-data).
 	Upsert(context.Context, *UpsertRequest) (*UpsertResponse, error)
 	// Delete vectors
 	//
-	// The `delete` operation deletes vectors, by id, from a single namespace.
+	// Delete vectors by id from a single namespace.
 	//
 	// For guidance and examples, see [Delete data](https://docs.pinecone.io/guides/data/delete-data).
 	Delete(context.Context, *DeleteRequest) (*DeleteResponse, error)
 	// Fetch vectors
 	//
-	// The `fetch` operation looks up and returns vectors, by ID, from a single namespace. The returned vectors include the vector data and/or metadata.
+	// Look up and returns vectors by ID from a single namespace. The returned vectors include the vector data and/or metadata.
 	//
 	// For guidance and examples, see [Fetch data](https://docs.pinecone.io/guides/data/fetch-data).
 	Fetch(context.Context, *FetchRequest) (*FetchResponse, error)
 	// List vector IDs
 	//
-	// The `list` operation lists the IDs of vectors in a single namespace of a serverless index. An optional prefix can be passed to limit the results to IDs with a common prefix.
+	// List the IDs of vectors in a single namespace of a serverless index. An optional prefix can be passed to limit the results to IDs with a common prefix.
 	//
-	// `list` returns up to 100 IDs at a time by default in sorted order (bitwise/"C" collation). If the `limit` parameter is set, `list` returns up to that number of IDs instead. Whenever there are additional IDs to return, the response also includes a `pagination_token` that you can use to get the next batch of IDs. When the response does not include a `pagination_token`, there are no more IDs to return.
+	// This returns up to 100 IDs at a time by default in sorted order (bitwise/"C" collation). If the `limit` parameter is set, `list` returns up to that number of IDs instead. Whenever there are additional IDs to return, the response also includes a `pagination_token` that you can use to get the next batch of IDs. When the response does not include a `pagination_token`, there are no more IDs to return.
 	//
 	// For guidance and examples, see [List record IDs](https://docs.pinecone.io/guides/data/list-record-ids).
 	//
-	// **Note:** `list` is supported only for serverless indexes.
+	// **Note:** This is supported only for serverless indexes.
 	List(context.Context, *ListRequest) (*ListResponse, error)
 	// Query vectors
 	//
-	// The `query` operation searches a namespace, using a query vector. It retrieves the ids of the most similar items in a namespace, along with their similarity scores.
+	// Searches a namespace, using a query vector. It retrieves the ids of the most similar items in a namespace, along with their similarity scores.
 	//
 	// For guidance and examples, see [Query data](https://docs.pinecone.io/guides/data/query-data).
 	Query(context.Context, *QueryRequest) (*QueryResponse, error)
 	// Update a vector
 	//
-	// The `update` operation updates a vector in a namespace. If a value is included, it will overwrite the previous value. If a `set_metadata` is included, the values of the fields specified in it will be added or overwrite the previous value.
+	// Update a vector in a namespace. If a value is included, it will overwrite the previous value. If a `set_metadata` is included, the values of the fields specified in it will be added or overwrite the previous value.
 	//
 	// For guidance and examples, see [Update data](https://docs.pinecone.io/guides/data/update-data).
 	Update(context.Context, *UpdateRequest) (*UpdateResponse, error)
 	// Get index stats
 	//
-	// The `describe_index_stats` operation returns statistics about the contents of an index, including the vector count per namespace, the number of dimensions, and the index fullness.
+	// Return statistics about the contents of an index, including the vector count per namespace, the number of dimensions, and the index fullness.
 	//
 	// Serverless indexes scale automatically as needed, so index fullness is relevant only for pod-based indexes.
 	DescribeIndexStats(context.Context, *DescribeIndexStatsRequest) (*DescribeIndexStatsResponse, error)

--- a/internal/gen/db_data/rest/db_data_2025-01.oas.go
+++ b/internal/gen/db_data/rest/db_data_2025-01.oas.go
@@ -434,7 +434,7 @@ type Vector struct {
 	SparseValues *SparseValues `json:"sparseValues,omitempty"`
 
 	// Values This is the vector data included in the request.
-	Values []float32 `json:"values"`
+	Values *[]float32 `json:"values,omitempty"`
 }
 
 // VectorValues This is the vector data included in the request.

--- a/internal/gen/db_data/rest/db_data_2025-01.oas.go
+++ b/internal/gen/db_data/rest/db_data_2025-01.oas.go
@@ -295,7 +295,9 @@ type SearchRecordsRequest struct {
 		// Query The query to rerank documents against. If a specific rerank query is specified,  it overwrites the query input that was provided at the top level.
 		Query *string `json:"query,omitempty"`
 
-		// RankFields The fields to use for reranking.
+		// RankFields The field(s) to consider for reranking. If not provided, the default is `["text"]`.
+		//
+		// The number of fields supported is [model-specific](https://docs.pinecone.io/guides/inference/understanding-inference#reranking-models).
 		RankFields []string `json:"rank_fields"`
 
 		// TopN The number of top results to return after reranking. Defaults to top_k.
@@ -395,7 +397,7 @@ type UpdateResponse = map[string]interface{}
 
 // UpsertRecord The request for the `upsert` operation.
 type UpsertRecord struct {
-	// Id The unique ID of the record to upsert.
+	// Id The unique ID of the record to upsert. Note that `id` can be used as an alias for `_id`.
 	Id string `json:"_id"`
 }
 

--- a/internal/gen/inference/inference_2025-01.oas.go
+++ b/internal/gen/inference/inference_2025-01.oas.go
@@ -142,7 +142,9 @@ type RerankRequest struct {
 	// Query The query to rerank documents against.
 	Query string `json:"query"`
 
-	// RankFields The fields to rank the documents by. If not provided, the default is `"text"`.
+	// RankFields The field(s) to consider for reranking. If not provided, the default is `["text"]`.
+	//
+	// The number of fields supported is [model-specific](https://docs.pinecone.io/guides/inference/understanding-inference#reranking-models).
 	RankFields *[]string `json:"rank_fields,omitempty"`
 
 	// ReturnDocuments Whether to return the documents in the response.

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -541,7 +541,7 @@ func (req CreatePodIndexRequest) TotalCount() int {
 //		}
 func (c *Client) CreatePodIndex(ctx context.Context, in *CreatePodIndexRequest) (*Index, error) {
 	if in.Name == "" || in.Dimension <= 0 || in.Metric == "" || in.Environment == "" || in.PodType == "" {
-		return nil, fmt.Errorf("fields Name, Dimension, Metric, Environment, and Podtype must be included in CreatePodIndexRequest")
+		return nil, fmt.Errorf("fields Name, positive Dimension, Metric, Environment, and Podtype must be included in CreatePodIndexRequest")
 	}
 
 	deletionProtection := pointerOrNil(db_control.DeletionProtection(in.DeletionProtection))

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -1566,7 +1566,7 @@ func toIndex(idx *db_control.IndexModel) *Index {
 
 	return &Index{
 		Name:               idx.Name,
-		Dimension:          *idx.Dimension,
+		Dimension:          idx.Dimension,
 		Host:               idx.Host,
 		Metric:             IndexMetric(idx.Metric),
 		DeletionProtection: DeletionProtection(deletionProtection),

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -1044,7 +1044,7 @@ func TestToIndexUnit(t *testing.T) {
 			},
 			expectedOutput: &Index{
 				Name:               "testIndex",
-				Dimension:          128,
+				Dimension:          &dimension,
 				Host:               "test-host",
 				Metric:             "cosine",
 				DeletionProtection: "disabled",
@@ -1092,7 +1092,7 @@ func TestToIndexUnit(t *testing.T) {
 			},
 			expectedOutput: &Index{
 				Name:               "testIndex",
-				Dimension:          128,
+				Dimension:          &dimension,
 				Host:               "test-host",
 				Metric:             "cosine",
 				DeletionProtection: "enabled",

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -810,7 +810,7 @@ func TestCreatePodIndexMissingReqdFieldsUnit(t *testing.T) {
 	client := &Client{}
 	_, err := client.CreatePodIndex(context.Background(), &CreatePodIndexRequest{})
 	require.Error(t, err)
-	require.ErrorContainsf(t, err, "fields Name, Dimension, Metric, Environment, and Podtype must be included in CreatePodIndexRequest", err.Error())
+	require.ErrorContainsf(t, err, "fields Name, positive Dimension, Metric, Environment, and Podtype must be included in CreatePodIndexRequest", err.Error())
 }
 
 func TestCreateServerlessIndexMissingReqdFieldsUnit(t *testing.T) {
@@ -874,7 +874,7 @@ func TestCreatePodIndexInvalidDimensionUnit(t *testing.T) {
 		PodType:     "p1.x1",
 	})
 	require.Error(t, err)
-	require.ErrorContains(t, err, "fields Name, Dimension, Metric, Environment, and Podtype must be included in CreatePodIndexRequest")
+	require.ErrorContains(t, err, "fields Name, positive Dimension, Metric, Environment, and Podtype must be included in CreatePodIndexRequest")
 }
 
 func TestCreateCollectionMissingReqdFieldsUnit(t *testing.T) {

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -820,11 +820,48 @@ func TestCreateServerlessIndexMissingReqdFieldsUnit(t *testing.T) {
 	require.ErrorContainsf(t, err, "fields Name, Metric, Cloud, and Region must be included in CreateServerlessIndexRequest", err.Error())
 }
 
-func TestCreateCollectionMissingReqdFieldsUnit(t *testing.T) {
+func TestCreateServerlessIndexInvalidSparseDimensionUnit(t *testing.T) {
+	vectorType := "sparse"
+	dimension := int32(1)
 	client := &Client{}
-	_, err := client.CreateCollection(context.Background(), &CreateCollectionRequest{})
+	_, err := client.CreateServerlessIndex(context.Background(), &CreateServerlessIndexRequest{
+		Name:       "test-invalid-dimension",
+		Metric:     Dotproduct,
+		Cloud:      "aws",
+		Region:     "us-east-1",
+		Dimension:  &dimension,
+		VectorType: &vectorType,
+	})
 	require.Error(t, err)
-	require.ErrorContains(t, err, "fields Name and Source must be included in CreateCollectionRequest")
+	require.ErrorContains(t, err, "dimension should not be specified when VectorType is 'sparse'")
+}
+
+func TestCreateServerlessIndexInvalidSparseMetricUnit(t *testing.T) {
+	vectorType := "sparse"
+	client := &Client{}
+	_, err := client.CreateServerlessIndex(context.Background(), &CreateServerlessIndexRequest{
+		Name:       "test-invalid-dimension",
+		Metric:     Cosine,
+		Cloud:      "aws",
+		Region:     "us-east-1",
+		VectorType: &vectorType,
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "metric should be 'dotproduct' when VectorType is 'sparse'")
+}
+
+func TestCreateServerlessIndexInvalidDenseDimensionUnit(t *testing.T) {
+	vectorType := "dense"
+	client := &Client{}
+	_, err := client.CreateServerlessIndex(context.Background(), &CreateServerlessIndexRequest{
+		Name:       "test-invalid-dimension",
+		Metric:     Cosine,
+		Cloud:      "aws",
+		Region:     "us-east-1",
+		VectorType: &vectorType,
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "dimension should be specified when VectorType is 'dense'")
 }
 
 func TestCreatePodIndexInvalidDimensionUnit(t *testing.T) {
@@ -838,6 +875,13 @@ func TestCreatePodIndexInvalidDimensionUnit(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.ErrorContains(t, err, "fields Name, Dimension, Metric, Environment, and Podtype must be included in CreatePodIndexRequest")
+}
+
+func TestCreateCollectionMissingReqdFieldsUnit(t *testing.T) {
+	client := &Client{}
+	_, err := client.CreateCollection(context.Background(), &CreateCollectionRequest{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "fields Name and Source must be included in CreateCollectionRequest")
 }
 
 func TestHandleErrorResponseBodyUnit(t *testing.T) {

--- a/pinecone/index_connection.go
+++ b/pinecone/index_connection.go
@@ -1333,9 +1333,14 @@ func toVector(vector *db_data_grpc.Vector) *Vector {
 	if vector == nil {
 		return nil
 	}
+	var vectorValues *[]float32
+	if vector.Values != nil {
+		vectorValues = &vector.Values
+	}
+
 	return &Vector{
 		Id:           vector.Id,
-		Values:       vector.Values,
+		Values:       vectorValues,
 		Metadata:     vector.Metadata,
 		SparseValues: toSparseValues(vector.SparseValues),
 	}
@@ -1435,9 +1440,14 @@ func vecToGrpc(v *Vector) *db_data_grpc.Vector {
 	if v == nil {
 		return nil
 	}
+	var vecValues []float32
+	if v.Values != nil {
+		vecValues = *v.Values
+	}
+
 	return &db_data_grpc.Vector{
 		Id:           v.Id,
-		Values:       v.Values,
+		Values:       vecValues,
 		Metadata:     v.Metadata,
 		SparseValues: sparseValToGrpc(v.SparseValues),
 	}

--- a/pinecone/index_connection_test.go
+++ b/pinecone/index_connection_test.go
@@ -363,6 +363,9 @@ func TestNewIndexConnectionNamespace(t *testing.T) {
 }
 
 func TestMarshalFetchVectorsResponseUnit(t *testing.T) {
+	vec1Values := []float32{0.01, 0.01, 0.01}
+	vec2Values := []float32{0.02, 0.02, 0.02}
+
 	tests := []struct {
 		name  string
 		input FetchVectorsResponse
@@ -372,8 +375,8 @@ func TestMarshalFetchVectorsResponseUnit(t *testing.T) {
 			name: "All fields present",
 			input: FetchVectorsResponse{
 				Vectors: map[string]*Vector{
-					"vec-1": {Id: "vec-1", Values: []float32{0.01, 0.01, 0.01}},
-					"vec-2": {Id: "vec-2", Values: []float32{0.02, 0.02, 0.02}},
+					"vec-1": {Id: "vec-1", Values: &vec1Values},
+					"vec-2": {Id: "vec-2", Values: &vec2Values},
 				},
 				Usage:     &Usage{ReadUnits: 5},
 				Namespace: "test-namespace",
@@ -461,6 +464,8 @@ func TestMarshalListVectorsResponseUnit(t *testing.T) {
 }
 
 func TestMarshalQueryVectorsResponseUnit(t *testing.T) {
+	vec1Values := []float32{0.01, 0.01, 0.01}
+	vec2Values := []float32{0.02, 0.02, 0.02}
 	tests := []struct {
 		name  string
 		input QueryVectorsResponse
@@ -470,8 +475,8 @@ func TestMarshalQueryVectorsResponseUnit(t *testing.T) {
 			name: "All fields present",
 			input: QueryVectorsResponse{
 				Matches: []*ScoredVector{
-					{Vector: &Vector{Id: "vec-1", Values: []float32{0.01, 0.01, 0.01}}, Score: 0.1},
-					{Vector: &Vector{Id: "vec-2", Values: []float32{0.02, 0.02, 0.02}}, Score: 0.2},
+					{Vector: &Vector{Id: "vec-1", Values: &vec1Values}, Score: 0.1},
+					{Vector: &Vector{Id: "vec-2", Values: &vec2Values}, Score: 0.2},
 				},
 				Usage:     &Usage{ReadUnits: 5},
 				Namespace: "test-namespace",
@@ -554,6 +559,8 @@ func TestMarshalDescribeIndexStatsResponseUnit(t *testing.T) {
 }
 
 func TestToVectorUnit(t *testing.T) {
+	vecValues := []float32{0.01, 0.02, 0.03}
+
 	tests := []struct {
 		name     string
 		vector   *db_data_grpc.Vector
@@ -572,7 +579,7 @@ func TestToVectorUnit(t *testing.T) {
 			},
 			expected: &Vector{
 				Id:     "dense-1",
-				Values: []float32{0.01, 0.02, 0.03},
+				Values: &vecValues,
 			},
 		},
 		{
@@ -607,7 +614,7 @@ func TestToVectorUnit(t *testing.T) {
 
 			expected: &Vector{
 				Id:     "hybrid-1",
-				Values: []float32{0.01, 0.02, 0.03},
+				Values: &vecValues,
 				SparseValues: &SparseValues{
 					Indices: []uint32{0, 2},
 					Values:  []float32{0.01, 0.03},
@@ -630,7 +637,7 @@ func TestToVectorUnit(t *testing.T) {
 			},
 			expected: &Vector{
 				Id:     "hybrid-metadata-1",
-				Values: []float32{0.01, 0.02, 0.03},
+				Values: &vecValues,
 				SparseValues: &SparseValues{
 					Indices: []uint32{0, 2},
 					Values:  []float32{0.01, 0.03},
@@ -683,6 +690,8 @@ func TestToSparseValuesUnit(t *testing.T) {
 }
 
 func TestToScoredVectorUnit(t *testing.T) {
+	vecValues := []float32{0.01, 0.02, 0.03}
+
 	tests := []struct {
 		name         string
 		scoredVector *db_data_grpc.ScoredVector
@@ -697,13 +706,13 @@ func TestToScoredVectorUnit(t *testing.T) {
 			name: "Pass scored dense vector",
 			scoredVector: &db_data_grpc.ScoredVector{
 				Id:     "dense-1",
-				Values: []float32{0.01, 0.01, 0.01},
+				Values: []float32{0.01, 0.02, 0.03},
 				Score:  0.1,
 			},
 			expected: &ScoredVector{
 				Vector: &Vector{
 					Id:     "dense-1",
-					Values: []float32{0.01, 0.01, 0.01},
+					Values: &vecValues,
 				},
 				Score: 0.1,
 			},
@@ -743,7 +752,7 @@ func TestToScoredVectorUnit(t *testing.T) {
 			expected: &ScoredVector{
 				Vector: &Vector{
 					Id:     "hybrid-1",
-					Values: []float32{0.01, 0.02, 0.03},
+					Values: &vecValues,
 					SparseValues: &SparseValues{
 						Indices: []uint32{0, 2},
 						Values:  []float32{0.01, 0.03},
@@ -771,7 +780,7 @@ func TestToScoredVectorUnit(t *testing.T) {
 			expected: &ScoredVector{
 				Vector: &Vector{
 					Id:     "hybrid-metadata-1",
-					Values: []float32{0.01, 0.02, 0.03},
+					Values: &vecValues,
 					SparseValues: &SparseValues{
 						Indices: []uint32{0, 2},
 						Values:  []float32{0.01, 0.03},
@@ -795,6 +804,8 @@ func TestToScoredVectorUnit(t *testing.T) {
 }
 
 func TestVecToGrpcUnit(t *testing.T) {
+	vecValues := []float32{0.01, 0.02, 0.03}
+
 	tests := []struct {
 		name     string
 		vector   *Vector
@@ -809,7 +820,7 @@ func TestVecToGrpcUnit(t *testing.T) {
 			name: "Pass dense vector",
 			vector: &Vector{
 				Id:     "dense-1",
-				Values: []float32{0.01, 0.02, 0.03},
+				Values: &vecValues,
 			},
 			expected: &db_data_grpc.Vector{
 				Id:     "dense-1",
@@ -838,7 +849,7 @@ func TestVecToGrpcUnit(t *testing.T) {
 			name: "Pass hybrid vector",
 			vector: &Vector{
 				Id:     "hybrid-1",
-				Values: []float32{0.01, 0.02, 0.03},
+				Values: &vecValues,
 				SparseValues: &SparseValues{
 					Indices: []uint32{0, 2},
 					Values:  []float32{0.01, 0.03},
@@ -857,7 +868,7 @@ func TestVecToGrpcUnit(t *testing.T) {
 			name: "Pass hybrid vector with metadata",
 			vector: &Vector{
 				Id:     "hybrid-metadata-1",
-				Values: []float32{0.01, 0.02, 0.03},
+				Values: &vecValues,
 				SparseValues: &SparseValues{
 					Indices: []uint32{0, 2},
 					Values:  []float32{0.01, 0.03},

--- a/pinecone/index_connection_test.go
+++ b/pinecone/index_connection_test.go
@@ -27,7 +27,7 @@ func (ts *IntegrationTests) TestFetchVectors() {
 }
 
 func (ts *IntegrationTests) TestQueryByVector() {
-	vec := make([]float32, ts.dimension)
+	vec := make([]float32, derefOrDefault(ts.dimension, 0))
 	for i := range vec {
 		vec[i] = 0.01
 	}
@@ -61,7 +61,7 @@ func (ts *IntegrationTests) TestDeleteVectorsById() {
 	assert.NoError(ts.T(), err)
 	ts.vectorIds = []string{}
 
-	vectors := GenerateVectors(5, ts.dimension, true, nil)
+	vectors := GenerateVectors(5, derefOrDefault(ts.dimension, 0), true, nil)
 
 	_, err = ts.idxConn.UpsertVectors(ctx, vectors)
 	if err != nil {
@@ -95,7 +95,7 @@ func (ts *IntegrationTests) TestDeleteVectorsByFilter() {
 	}
 	ts.vectorIds = []string{}
 
-	vectors := GenerateVectors(5, ts.dimension, true, nil)
+	vectors := GenerateVectors(5, derefOrDefault(ts.dimension, 0), true, nil)
 
 	_, err = ts.idxConn.UpsertVectors(ctx, vectors)
 	if err != nil {
@@ -116,7 +116,7 @@ func (ts *IntegrationTests) TestDeleteAllVectorsInNamespace() {
 	assert.NoError(ts.T(), err)
 	ts.vectorIds = []string{}
 
-	vectors := GenerateVectors(5, ts.dimension, true, nil)
+	vectors := GenerateVectors(5, derefOrDefault(ts.dimension, 0), true, nil)
 
 	_, err = ts.idxConn.UpsertVectors(ctx, vectors)
 	if err != nil {
@@ -244,9 +244,9 @@ func (ts *IntegrationTests) TestUpdateVectorMetadata() {
 func (ts *IntegrationTests) TestUpdateVectorSparseValues() {
 	ctx := context.Background()
 
-	dims := int(ts.dimension)
-	indices := generateUint32Array(dims)
-	vals := generateFloat32Array(dims)
+	dims := int32(derefOrDefault(ts.dimension, 0))
+	indices := generateUint32Array(int(dims))
+	vals := generateFloat32Array(int(dims))
 	expectedSparseValues := SparseValues{
 		Indices: indices,
 		Values:  vals,

--- a/pinecone/index_connection_test.go
+++ b/pinecone/index_connection_test.go
@@ -206,7 +206,9 @@ func (ts *IntegrationTests) TestUpdateVectorValues() {
 	}
 	actualVals := vector.Vectors[ts.vectorIds[0]].Values
 
-	assert.ElementsMatch(ts.T(), expectedVals, actualVals, "Values do not match")
+	if actualVals != nil {
+		assert.ElementsMatch(ts.T(), expectedVals, *actualVals, "Values do not match")
+	}
 }
 
 func (ts *IntegrationTests) TestUpdateVectorMetadata() {
@@ -228,17 +230,20 @@ func (ts *IntegrationTests) TestUpdateVectorMetadata() {
 
 	time.Sleep(10 * time.Second)
 
-	vector, err := ts.idxConn.FetchVectors(ctx, []string{ts.vectorIds[0]})
+	vectors, err := ts.idxConn.FetchVectors(ctx, []string{ts.vectorIds[0]})
 	if err != nil {
 		ts.FailNow(fmt.Sprintf("Failed to fetch vector: %v", err))
 	}
+	vector := vectors.Vectors[ts.vectorIds[0]]
 
-	assert.NotNil(ts.T(), vector.Vectors[ts.vectorIds[0]].Metadata, "Metadata is nil after update")
+	if vector != nil {
+		assert.NotNil(ts.T(), vector.Metadata, "Metadata is nil after update")
 
-	expectedGenre := expectedMetadataMap.Fields["genre"].GetStringValue()
-	actualGenre := vector.Vectors[ts.vectorIds[0]].Metadata.Fields["genre"].GetStringValue()
+		expectedGenre := expectedMetadataMap.Fields["genre"].GetStringValue()
+		actualGenre := vector.Metadata.Fields["genre"].GetStringValue()
 
-	assert.Equal(ts.T(), expectedGenre, actualGenre, "Metadata does not match")
+		assert.Equal(ts.T(), expectedGenre, actualGenre, "Metadata does not match")
+	}
 }
 
 func (ts *IntegrationTests) TestUpdateVectorSparseValues() {
@@ -263,13 +268,17 @@ func (ts *IntegrationTests) TestUpdateVectorSparseValues() {
 	time.Sleep(5 * time.Second)
 
 	// Fetch updated vector and verify sparse values
-	vector, err := ts.idxConn.FetchVectors(ctx, []string{ts.vectorIds[0]})
+	vectors, err := ts.idxConn.FetchVectors(ctx, []string{ts.vectorIds[0]})
 	if err != nil {
 		ts.FailNow(fmt.Sprintf("Failed to fetch vector: %v", err))
 	}
-	actualSparseValues := vector.Vectors[ts.vectorIds[0]].SparseValues.Values
+	vector := vectors.Vectors[ts.vectorIds[0]]
 
-	assert.ElementsMatch(ts.T(), expectedSparseValues.Values, actualSparseValues, "Sparse values do not match")
+	if vector != nil {
+		actualSparseValues := vector.SparseValues.Values
+
+		assert.ElementsMatch(ts.T(), expectedSparseValues.Values, actualSparseValues, "Sparse values do not match")
+	}
 }
 
 func (ts *IntegrationTests) TestImportFlowHappyPath() {

--- a/pinecone/local_test.go
+++ b/pinecone/local_test.go
@@ -185,7 +185,7 @@ func (ts *LocalIntegrationTests) TestQueryVectors() {
 		assert.Equal(ts.T(), queryVectorId, queryVectorsByIdResponse.Matches[0].Vector.Id, "Top QueryByVectorId result's vector id should match queryVectorId")
 
 		queryByVectorValuesResponse, err := idxConn.QueryByVectorValues(context.Background(), &QueryByVectorValuesRequest{
-			Vector:          queryVectorsByIdResponse.Matches[0].Vector.Values,
+			Vector:          *queryVectorsByIdResponse.Matches[0].Vector.Values,
 			TopK:            uint32(topK),
 			MetadataFilter:  ts.metadata,
 			IncludeValues:   true,
@@ -210,7 +210,7 @@ func (ts *LocalIntegrationTests) TestUpdateVectors() {
 	newValues := generateVectorValues(ts.dimension)
 
 	for _, idxConn := range ts.idxConns {
-		err := idxConn.UpdateVector(context.Background(), &UpdateVectorRequest{Id: updateVectorId, Values: newValues})
+		err := idxConn.UpdateVector(context.Background(), &UpdateVectorRequest{Id: updateVectorId, Values: *newValues})
 		require.NoError(ts.T(), err)
 
 		fetchVectorsResponse, err := idxConn.FetchVectors(context.Background(), []string{updateVectorId})

--- a/pinecone/models.go
+++ b/pinecone/models.go
@@ -154,7 +154,7 @@ type ServerlessSpec struct {
 // [dense or sparse vector object]: https://docs.pinecone.io/guides/get-started/key-concepts#dense-vector
 type Vector struct {
 	Id           string        `json:"id"`
-	Values       []float32     `json:"values,omitempty"`
+	Values       *[]float32    `json:"values,omitempty"`
 	SparseValues *SparseValues `json:"sparse_values,omitempty"`
 	Metadata     *Metadata     `json:"metadata,omitempty"`
 }

--- a/pinecone/models.go
+++ b/pinecone/models.go
@@ -65,19 +65,32 @@ type IndexSpec struct {
 	Serverless *ServerlessSpec `json:"serverless,omitempty"`
 }
 
+// [IndexEmbed] is the embedding model configured for an index, including document fields mapped to embedding inputs.
+type IndexEmbed struct {
+	Model           string                  `json:"model"`
+	Dimension       *int32                  `json:"dimension,omitempty"`
+	Metric          *IndexMetric            `json:"metric,omitempty"`
+	VectorType      *string                 `json:"vector_type,omitempty"`
+	FieldMap        *map[string]interface{} `json:"field_map,omitempty"`
+	ReadParameters  *map[string]interface{} `json:"read_parameters,omitempty"`
+	WriteParameters *map[string]interface{} `json:"write_parameters,omitempty"`
+}
+
 // [IndexTags] is a set of key-value pairs that can be attached to a Pinecone [Index].
 type IndexTags map[string]string
 
 // [Index] is a Pinecone [Index] object. Can be either a pod-based or a serverless [Index], depending on the [IndexSpec].
 type Index struct {
 	Name               string             `json:"name"`
-	Dimension          int32              `json:"dimension"`
 	Host               string             `json:"host"`
 	Metric             IndexMetric        `json:"metric"`
+	VectorType         string             `json:"vector_type"`
 	DeletionProtection DeletionProtection `json:"deletion_protection,omitempty"`
+	Dimension          *int32             `json:"dimension"`
 	Spec               *IndexSpec         `json:"spec,omitempty"`
 	Status             *IndexStatus       `json:"status,omitempty"`
 	Tags               *IndexTags         `json:"tags,omitempty"`
+	Embed              *IndexEmbed        `json:"embed,omitempty"`
 }
 
 // [Collection] is a Pinecone [collection entity]. Only available for pod-based Indexes.

--- a/pinecone/models.go
+++ b/pinecone/models.go
@@ -65,7 +65,20 @@ type IndexSpec struct {
 	Serverless *ServerlessSpec `json:"serverless,omitempty"`
 }
 
-// [IndexEmbed] is the embedding model configured for an index, including document fields mapped to embedding inputs.
+// [IndexEmbed] represents the embedding model configured for an index,
+// including document fields mapped to embedding inputs.
+//
+// Fields:
+//   - Model: The name of the embedding model used to create the index (e.g., "multilingual-e5-large").
+//   - Dimension: The dimension of the embedding model, specifying the size of the output vector.
+//   - Metric: The distance metric used by the embedding model. If the 'vector_type' is 'sparse',
+//     the metric must be 'dotproduct'. If the `vector_type` is `dense`, the metric
+//     defaults to 'cosine'.
+//   - VectorType:  The index vector type associated with the model. If 'dense', the vector dimension must be specified.
+//     If 'sparse', the vector dimension will be nil.
+//   - FieldMap: Identifies the name of the text field from your document model that is embedded.
+//   - ReadParameters: The read parameters for the embedding model.
+//   - WriteParameters: The write parameters for the embedding model.
 type IndexEmbed struct {
 	Model           string                  `json:"model"`
 	Dimension       *int32                  `json:"dimension,omitempty"`

--- a/pinecone/models_test.go
+++ b/pinecone/models_test.go
@@ -353,6 +353,7 @@ func TestMarshalVectorUnit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create metadata: %v", err)
 	}
+	vecValues := []float32{0.1, 0.2, 0.3}
 
 	tests := []struct {
 		name  string
@@ -363,7 +364,7 @@ func TestMarshalVectorUnit(t *testing.T) {
 			name: "All fields present",
 			input: Vector{
 				Id:       "vector-1",
-				Values:   []float32{0.1, 0.2, 0.3},
+				Values:   &vecValues,
 				Metadata: metadata,
 				SparseValues: &SparseValues{
 					Indices: []uint32{1, 2, 3},
@@ -403,6 +404,7 @@ func TestMarshalScoredVectorUnit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create metadata: %v", err)
 	}
+	vecValues := []float32{0.1, 0.2, 0.3}
 
 	tests := []struct {
 		name  string
@@ -414,7 +416,7 @@ func TestMarshalScoredVectorUnit(t *testing.T) {
 			input: ScoredVector{
 				Vector: &Vector{
 					Id:       "vector-1",
-					Values:   []float32{0.1, 0.2, 0.3},
+					Values:   &vecValues,
 					Metadata: metadata,
 					SparseValues: &SparseValues{
 						Indices: []uint32{1, 2, 3},

--- a/pinecone/models_test.go
+++ b/pinecone/models_test.go
@@ -7,7 +7,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func TestMarshalIndexStatus(t *testing.T) {
+func TestMarshalIndexStatusUnit(t *testing.T) {
 	tests := []struct {
 		name  string
 		input IndexStatus
@@ -44,7 +44,7 @@ func TestMarshalIndexStatus(t *testing.T) {
 	}
 }
 
-func TestMarshalServerlessSpec(t *testing.T) {
+func TestMarshalServerlessSpecUnit(t *testing.T) {
 	tests := []struct {
 		name  string
 		input ServerlessSpec
@@ -82,7 +82,7 @@ func TestMarshalServerlessSpec(t *testing.T) {
 	}
 }
 
-func TestMarshalPodSpec(t *testing.T) {
+func TestMarshalPodSpecUnit(t *testing.T) {
 	sourceCollection := "source-collection"
 	tests := []struct {
 		name  string
@@ -138,7 +138,7 @@ func TestMarshalPodSpec(t *testing.T) {
 	}
 }
 
-func TestMarshalIndexSpec(t *testing.T) {
+func TestMarshalIndexSpecUnit(t *testing.T) {
 	sourceCollection := "source-collection"
 	tests := []struct {
 		name  string
@@ -191,7 +191,9 @@ func TestMarshalIndexSpec(t *testing.T) {
 	}
 }
 
-func TestMarshalIndex(t *testing.T) {
+func TestMarshalIndexUnit(t *testing.T) {
+	dimension := int32(128)
+
 	tests := []struct {
 		name  string
 		input Index
@@ -200,10 +202,15 @@ func TestMarshalIndex(t *testing.T) {
 		{
 			name: "All fields present",
 			input: Index{
-				Name:      "test-index",
-				Dimension: 128,
-				Host:      "index-host-1.io",
-				Metric:    "cosine",
+				Name:               "test-index",
+				Dimension:          &dimension,
+				Host:               "index-host-1.io",
+				Metric:             "cosine",
+				VectorType:         "sparse",
+				DeletionProtection: "enabled",
+				Embed: &IndexEmbed{
+					Model: "multilingual-e5-large",
+				},
 				Spec: &IndexSpec{
 					Serverless: &ServerlessSpec{
 						Cloud:  "aws",
@@ -214,25 +221,28 @@ func TestMarshalIndex(t *testing.T) {
 					Ready: true,
 					State: "Ready",
 				},
+				Tags: &IndexTags{
+					"test1": "test-tag-1",
+				},
 			},
-			want: `{"name":"test-index","dimension":128,"host":"index-host-1.io","metric":"cosine","spec":{"serverless":{"cloud":"aws","region":"us-west-2"}},"status":{"ready":true,"state":"Ready"}}`,
+			want: `{"name":"test-index","host":"index-host-1.io","metric":"cosine","vector_type":"sparse","deletion_protection":"enabled","dimension":128,"spec":{"serverless":{"cloud":"aws","region":"us-west-2"}},"status":{"ready":true,"state":"Ready"},"tags":{"test1":"test-tag-1"},"embed":{"model":"multilingual-e5-large"}}`,
 		},
 		{
 			name:  "Fields omitted",
 			input: Index{},
-			want:  `{"name":"","dimension":0,"host":"","metric":""}`,
+			want:  `{"name":"","host":"","metric":"","vector_type":"","dimension":null}`,
 		},
 		{
 			name: "Fields empty",
 			input: Index{
 				Name:      "",
-				Dimension: 0,
+				Dimension: nil,
 				Host:      "",
 				Metric:    "",
 				Spec:      nil,
 				Status:    nil,
 			},
-			want: `{"name":"","dimension":0,"host":"","metric":""}`,
+			want: `{"name":"","host":"","metric":"","vector_type":"","dimension":null}`,
 		},
 	}
 
@@ -250,7 +260,7 @@ func TestMarshalIndex(t *testing.T) {
 	}
 }
 
-func TestMarshalCollection(t *testing.T) {
+func TestMarshalCollectionUnit(t *testing.T) {
 	tests := []struct {
 		name  string
 		input Collection
@@ -301,7 +311,7 @@ func TestMarshalCollection(t *testing.T) {
 	}
 }
 
-func TestMarshalPodSpecMetadataConfig(t *testing.T) {
+func TestMarshalPodSpecMetadataConfigUnit(t *testing.T) {
 	tests := []struct {
 		name  string
 		input PodSpecMetadataConfig
@@ -338,7 +348,7 @@ func TestMarshalPodSpecMetadataConfig(t *testing.T) {
 	}
 }
 
-func TestMarshalVector(t *testing.T) {
+func TestMarshalVectorUnit(t *testing.T) {
 	metadata, err := structpb.NewStruct(map[string]interface{}{"genre": "rock"})
 	if err != nil {
 		t.Fatalf("Failed to create metadata: %v", err)
@@ -388,7 +398,7 @@ func TestMarshalVector(t *testing.T) {
 	}
 }
 
-func TestMarshalScoredVector(t *testing.T) {
+func TestMarshalScoredVectorUnit(t *testing.T) {
 	metadata, err := structpb.NewStruct(map[string]interface{}{"genre": "rock"})
 	if err != nil {
 		t.Fatalf("Failed to create metadata: %v", err)
@@ -441,7 +451,7 @@ func TestMarshalScoredVector(t *testing.T) {
 	}
 }
 
-func TestMarshalSparseValues(t *testing.T) {
+func TestMarshalSparseValuesUnit(t *testing.T) {
 	tests := []struct {
 		name  string
 		input SparseValues
@@ -481,7 +491,7 @@ func TestMarshalSparseValues(t *testing.T) {
 	}
 }
 
-func TestMarshalNamespaceSummary(t *testing.T) {
+func TestMarshalNamespaceSummaryUnit(t *testing.T) {
 	tests := []struct {
 		name  string
 		input NamespaceSummary

--- a/pinecone/models_test.go
+++ b/pinecone/models_test.go
@@ -528,7 +528,7 @@ func TestMarshalNamespaceSummaryUnit(t *testing.T) {
 	}
 }
 
-func TestMarshalUsage(t *testing.T) {
+func TestMarshalUsageUnit(t *testing.T) {
 	tests := []struct {
 		name  string
 		input Usage
@@ -563,5 +563,69 @@ func TestMarshalUsage(t *testing.T) {
 			}
 		})
 	}
+}
 
+func TestMarshalIndexEmbedUnit(t *testing.T) {
+	dimension := int32(128)
+	metric := IndexMetric("cosine")
+	vectorType := "sparse"
+	fieldMap := map[string]interface{}{
+		"text-field": "my-text-field",
+	}
+	readParameters := map[string]interface{}{
+		"readParam": "readParamValue",
+	}
+	writeParameters := map[string]interface{}{
+		"writeParam": "writeParamValue",
+	}
+
+	tests := []struct {
+		name  string
+		input IndexEmbed
+		want  string
+	}{
+		{
+			name: "All fields present",
+			input: IndexEmbed{
+				Model:           "multilingual-e5-large",
+				Dimension:       &dimension,
+				Metric:          &metric,
+				VectorType:      &vectorType,
+				FieldMap:        &fieldMap,
+				ReadParameters:  &readParameters,
+				WriteParameters: &writeParameters,
+			},
+			want: `{"model":"multilingual-e5-large","dimension":128,"metric":"cosine","vector_type":"sparse","field_map":{"text-field":"my-text-field"},"read_parameters":{"readParam":"readParamValue"},"write_parameters":{"writeParam":"writeParamValue"}}`,
+		},
+		{
+			name:  "Fields omitted",
+			input: IndexEmbed{},
+			want:  `{"model":""}`,
+		},
+		{
+			name: "Fields empty",
+			input: IndexEmbed{
+				Model:           "",
+				Dimension:       nil,
+				Metric:          nil,
+				VectorType:      nil,
+				FieldMap:        nil,
+				ReadParameters:  nil,
+				WriteParameters: nil,
+			},
+			want: `{"model":""}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(c *testing.T) {
+			got, err := json.Marshal(tt.input)
+			if err != nil {
+				c.Errorf("Failed to marshal IndexEmbed: %v", err)
+			}
+			if string(got) != tt.want {
+				c.Errorf("Marshal IndexEmbed got = %s, want = %s", string(got), tt.want)
+			}
+		})
+	}
 }

--- a/pinecone/test_suite.go
+++ b/pinecone/test_suite.go
@@ -17,7 +17,7 @@ type IntegrationTests struct {
 	apiKey         string
 	client         *Client
 	host           string
-	dimension      int32
+	dimension      *int32
 	indexType      string
 	vectorIds      []string
 	idxName        string
@@ -44,9 +44,13 @@ func (ts *IntegrationTests) SetupSuite() {
 	require.NotNil(ts.T(), idxConn, "Failed to create idxConn")
 
 	ts.idxConn = idxConn
+	dim := int32(0)
+	if ts.dimension != nil {
+		dim = *ts.dimension
+	}
 
 	// Deterministically create vectors
-	vectors := GenerateVectors(10, ts.dimension, false, nil)
+	vectors := GenerateVectors(10, dim, false, nil)
 
 	// Add vector ids to the suite
 	vectorIds := make([]string, len(vectors))

--- a/pinecone/test_suite.go
+++ b/pinecone/test_suite.go
@@ -188,7 +188,8 @@ func GenerateVectors(numOfVectors int, dimension int32, isSparse bool, metadata 
 			for j := 0; j < int(dimension); j++ {
 				sparseValues.Indices = append(sparseValues.Indices, uint32(j))
 			}
-			sparseValues.Values = generateVectorValues(dimension)
+			values := generateVectorValues(dimension)
+			sparseValues.Values = *values
 			vectors[i].SparseValues = &sparseValues
 		}
 
@@ -200,7 +201,7 @@ func GenerateVectors(numOfVectors int, dimension int32, isSparse bool, metadata 
 	return vectors
 }
 
-func generateVectorValues(dimension int32) []float32 {
+func generateVectorValues(dimension int32) *[]float32 {
 	maxInt := 1000000 // A large integer to normalize the float values
 	values := make([]float32, dimension)
 
@@ -209,7 +210,7 @@ func generateVectorValues(dimension int32) []float32 {
 		values[i] = float32(rand.Intn(maxInt)) / float32(maxInt)
 	}
 
-	return values
+	return &values
 }
 
 func BuildServerlessTestIndex(in *Client, idxName string, tags IndexTags) *Index {

--- a/pinecone/test_suite.go
+++ b/pinecone/test_suite.go
@@ -214,11 +214,12 @@ func generateVectorValues(dimension int32) []float32 {
 
 func BuildServerlessTestIndex(in *Client, idxName string, tags IndexTags) *Index {
 	ctx := context.Background()
+	dimension := int32(setDimensionsForTestIndexes())
 
 	fmt.Printf("Creating Serverless index: %s\n", idxName)
 	serverlessIdx, err := in.CreateServerlessIndex(ctx, &CreateServerlessIndexRequest{
 		Name:      idxName,
-		Dimension: int32(setDimensionsForTestIndexes()),
+		Dimension: &dimension,
 		Metric:    Cosine,
 		Region:    "us-east-1",
 		Cloud:     "aws",


### PR DESCRIPTION
## Problem
`2025-01` includes changes to support sparse indexes. We need to adjust several types and functions to support working with these kinds of indexes.

## Solution

- Update `CreateServerlessIndexRequest` to allow creating `sparse` or `dense` serverless indexes.
- Update `Index` struct to support `VectorType` and `IndexEmbed`. Add new `IndexEmbed` type.
- Add new unit tests / update existing unit & integration tests.

```go
package main

import (
	"context"
	"fmt"
	"github.com/pinecone-io/go-pinecone/v2/pinecone"
	"log"
	"os"
)

func main() {
	ctx := context.Background()

	clientParams := pinecone.NewClientParams{
		ApiKey: os.Getenv("PINECONE_API_KEY"),
	}

	pc, err := pinecone.NewClient(clientParams)
	if err != nil {
		log.Fatalf("Failed to create Client: %v", err)
	} else {
		fmt.Println("Successfully created a new Client object!")
	}

	indexName := "my-serverless-index"
	vectorType := "sparse"

	idx, err := pc.CreateServerlessIndex(ctx, &pinecone.CreateServerlessIndexRequest{
		Name:       indexName,
		Metric:     pinecone.Dotproduct,
		VectorType: &vectorType,
		Cloud:      pinecone.Aws,
		Region:     "us-east-1",
		Tags:       &pinecone.IndexTags{"environment": "development"},
	})

	if err != nil {
		log.Fatalf("Failed to create serverless index: %v", err)
	} else {
		fmt.Printf("Successfully created serverless index: %s", idx.Name)
	}
}
```

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
CI / CD (unit / integration tests)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208897809680488
  - https://app.asana.com/0/0/1208897809680503