### PR TITLE
Update `go.mod` for v3, review feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,13 +149,15 @@ func main() {
 	}
 
 	indexName := "my-serverless-index"
+	metric := pinecone.Cosine
+	dimension := int32(3)
 
 	idx, err := pc.CreateServerlessIndex(ctx, &pinecone.CreateServerlessIndexRequest{
 		Name:      indexName,
-		Dimension: 3,
-		Metric:    pinecone.Cosine,
 		Cloud:     pinecone.Aws,
 		Region:    "us-east-1",
+		Metric:    &metric,
+		Dimension: &dimension,
 		Tags:      &pinecone.IndexTags{"environment": "development"},
 	})
 
@@ -167,7 +169,8 @@ func main() {
 }
 ```
 
-You can also create `sparse` only serverless indexes. These indexes enable direct indexing and retrieval of sparse vectors, supporting traditional methods like BM25 and learned sparse models such as [pinecone-sparse-english-v0](https://docs.pinecone.io/models/pinecone-sparse-english-v0). A `sparse` index must have a distance metric of `dotproduct` and does not require a specified dimension:
+You can also create `sparse` only serverless indexes. These indexes enable direct indexing and retrieval of sparse vectors, supporting traditional methods like BM25 and learned sparse models such as [pinecone-sparse-english-v0](https://docs.pinecone.io/models/pinecone-sparse-english-v0). A `sparse` index must have a distance metric of `dotproduct` and does not require a specified dimension. `dotproduct` will be defaulted for sparse indexes when
+a Metric is not provided:
 
 ```go
 package main
@@ -196,13 +199,14 @@ func main() {
 
 	indexName := "my-serverless-index"
 	vectorType := "sparse"
+	metric := pinecone.Dotproduct
 
 	idx, err := pc.CreateServerlessIndex(ctx, &pinecone.CreateServerlessIndexRequest{
 		Name:       indexName,
-		Metric:     pinecone.Dotproduct,
-		VectorType: &vectorType,
 		Cloud:      pinecone.Aws,
 		Region:     "us-east-1",
+		Metric:     &metric,
+		VectorType: &vectorType,
 		Tags:       &pinecone.IndexTags{"environment": "development"},
 	})
 
@@ -245,6 +249,7 @@ func main() {
 	}
 
 	indexName := "my-pod-index"
+	metric := pinecone.Cosine
 
 	podIndexMetadata := &pinecone.PodSpecMetadataConfig{
 		Indexed: &[]string{"title", "description"},
@@ -253,10 +258,10 @@ func main() {
 	idx, err := pc.CreatePodIndex(ctx, &pinecone.CreatePodIndexRequest{
 		Name:           indexName,
 		Dimension:      3,
-		Metric:         pinecone.Cosine,
 		Environment:    "us-west1-gcp",
 		PodType:        "s1",
 		MetadataConfig: podIndexMetadata,
+		Metric:         &metric,
 		Tags:           &pinecone.IndexTags{"environment": "development"},
 	})
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the official Go SDK for [Pinecone](https://www.pinecone.io).
 To see the latest documentation for `main`, visit https://pkg.go.dev/github.com/pinecone-io/go-pinecone@main/pinecone.
 
 To see the latest versioned-release's documentation,
-visit https://pkg.go.dev/github.com/pinecone-io/go-pinecone/v2/pinecone.
+visit https://pkg.go.dev/github.com/pinecone-io/go-pinecone/v3/pinecone.
 
 ## Features
 
@@ -24,7 +24,7 @@ See the [Pinecone API Docs](https://docs.pinecone.io/reference/) for more inform
 To upgrade the SDK to the latest version, run:
 
 ```shell
-go get -u github.com/pinecone-io/go-pinecone/v2/pinecone@latest
+go get -u github.com/pinecone-io/go-pinecone/v3/pinecone@latest
 ```
 
 ## Prerequisites
@@ -36,7 +36,7 @@ go get -u github.com/pinecone-io/go-pinecone/v2/pinecone@latest
 To install the Pinecone Go SDK, run the following in your terminal:
 
 ```shell
-go get github.com/pinecone-io/go-pinecone/v2/pinecone
+go get github.com/pinecone-io/go-pinecone/v3/pinecone
 ```
 
 For more information on setting up a Go project, see the [Go documentation](https://golang.org/doc/).
@@ -58,7 +58,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v2/pinecone"
+	"github.com/pinecone-io/go-pinecone/v3/pinecone"
 	"log"
 	"os"
 )
@@ -91,7 +91,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v2/pinecone"
+	"github.com/pinecone-io/go-pinecone/v3/pinecone"
 	"log"
 )
 
@@ -129,7 +129,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v2/pinecone"
+	"github.com/pinecone-io/go-pinecone/v3/pinecone"
 	"log"
 	"os"
 )
@@ -178,7 +178,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v2/pinecone"
+	"github.com/pinecone-io/go-pinecone/v3/pinecone"
 	"log"
 	"os"
 )
@@ -229,7 +229,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v2/pinecone"
+	"github.com/pinecone-io/go-pinecone/v3/pinecone"
 	"log"
 	"os"
 )
@@ -284,7 +284,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v2/pinecone"
+	"github.com/pinecone-io/go-pinecone/v3/pinecone"
 	"log"
 	"os"
 )
@@ -325,7 +325,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v2/pinecone"
+	"github.com/pinecone-io/go-pinecone/v3/pinecone"
 	"log"
 	"os"
 )
@@ -366,7 +366,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v2/pinecone"
+	"github.com/pinecone-io/go-pinecone/v3/pinecone"
 	"log"
 	"os"
 )
@@ -406,7 +406,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v2/pinecone"
+	"github.com/pinecone-io/go-pinecone/v3/pinecone"
 	"log"
 	"os"
 )
@@ -488,7 +488,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v2/pinecone"
+	"github.com/pinecone-io/go-pinecone/v3/pinecone"
 	"log"
 	"os"
 )
@@ -539,7 +539,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v2/pinecone"
+	"github.com/pinecone-io/go-pinecone/v3/pinecone"
 	"log"
 	"os"
 )
@@ -582,7 +582,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v2/pinecone"
+	"github.com/pinecone-io/go-pinecone/v3/pinecone"
 	"google.golang.org/protobuf/types/known/structpb"
 	"log"
 	"os"
@@ -739,7 +739,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v2/pinecone"
+	"github.com/pinecone-io/go-pinecone/v3/pinecone"
 	"google.golang.org/protobuf/types/known/structpb"
 	"log"
 	"os"
@@ -870,7 +870,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v2/pinecone"
+	"github.com/pinecone-io/go-pinecone/v3/pinecone"
 	"log"
 	"os"
 )
@@ -931,7 +931,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v2/pinecone"
+	"github.com/pinecone-io/go-pinecone/v3/pinecone"
 	"log"
 	"os"
 )
@@ -979,7 +979,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v2/pinecone"
+	"github.com/pinecone-io/go-pinecone/v3/pinecone"
 	"google.golang.org/protobuf/types/known/structpb"
 	"log"
 	"os"
@@ -1034,7 +1034,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v2/pinecone"
+	"github.com/pinecone-io/go-pinecone/v3/pinecone"
 	"log"
 	"os"
 )
@@ -1082,7 +1082,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v2/pinecone"
+	"github.com/pinecone-io/go-pinecone/v3/pinecone"
 	"log"
 	"os"
 )
@@ -1162,7 +1162,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v2/pinecone"
+	"github.com/pinecone-io/go-pinecone/v3/pinecone"
 	"log"
 	"os"
 )
@@ -1218,7 +1218,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v2/pinecone"
+	"github.com/pinecone-io/go-pinecone/v3/pinecone"
 	"log"
 	"os"
 )
@@ -1295,7 +1295,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v2/pinecone"
+	"github.com/pinecone-io/go-pinecone/v3/pinecone"
 	"log"
 	"os"
 )
@@ -1336,7 +1336,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v2/pinecone"
+	"github.com/pinecone-io/go-pinecone/v3/pinecone"
 	"log"
 	"os"
 )
@@ -1381,7 +1381,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v2/pinecone"
+	"github.com/pinecone-io/go-pinecone/v3/pinecone"
 	"log"
 	"os"
 )
@@ -1419,7 +1419,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v2/pinecone"
+	"github.com/pinecone-io/go-pinecone/v3/pinecone"
 	"log"
 	"os"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pinecone-io/go-pinecone/v2
+module github.com/pinecone-io/go-pinecone/v3
 
 go 1.21
 

--- a/internal/useragent/useragent.go
+++ b/internal/useragent/useragent.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pinecone-io/go-pinecone/v2/internal"
+	"github.com/pinecone-io/go-pinecone/v3/internal"
 )
 
 func getPackageVersion() string {

--- a/justfile
+++ b/justfile
@@ -20,5 +20,5 @@ bootstrap:
 gen:
   ./codegen/build-clients.sh {{api_version}}
 docs:
-  @echo "Serving docs at http://localhost:6060/pkg/github.com/pinecone-io/go-pinecone/v2/pinecone/"
+  @echo "Serving docs at http://localhost:6060/pkg/github.com/pinecone-io/go-pinecone/v3/pinecone/"
   @godoc -http=:6060 >/dev/null

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -14,12 +14,12 @@ import (
 	"os"
 	"strings"
 
-	"github.com/pinecone-io/go-pinecone/v2/internal/gen"
-	"github.com/pinecone-io/go-pinecone/v2/internal/gen/db_control"
-	db_data_rest "github.com/pinecone-io/go-pinecone/v2/internal/gen/db_data/rest"
-	"github.com/pinecone-io/go-pinecone/v2/internal/gen/inference"
-	"github.com/pinecone-io/go-pinecone/v2/internal/provider"
-	"github.com/pinecone-io/go-pinecone/v2/internal/useragent"
+	"github.com/pinecone-io/go-pinecone/v3/internal/gen"
+	"github.com/pinecone-io/go-pinecone/v3/internal/gen/db_control"
+	db_data_rest "github.com/pinecone-io/go-pinecone/v3/internal/gen/db_data/rest"
+	"github.com/pinecone-io/go-pinecone/v3/internal/gen/inference"
+	"github.com/pinecone-io/go-pinecone/v3/internal/provider"
+	"github.com/pinecone-io/go-pinecone/v3/internal/useragent"
 	"google.golang.org/grpc"
 )
 

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -184,17 +184,6 @@ func (ts *IntegrationTests) TestDeletionProtection() {
 	err = ts.client.DeleteIndex(context.Background(), ts.idxName)
 	require.ErrorContainsf(ts.T(), err, "failed to delete index: Deletion protection is enabled for this index", err.Error())
 
-	// if testing a pods index, make sure configuring the index without specifying DeletionProtection maintains "enabled" state
-	if ts.indexType == "pods" {
-		index, err := ts.client.ConfigureIndex(context.Background(), ts.idxName, ConfigureIndexParams{PodType: "p1.x2"})
-		require.NoError(ts.T(), err)
-		require.Equal(ts.T(), DeletionProtectionEnabled, index.DeletionProtection, "Expected deletion protection to be 'enabled'")
-
-		// validate we cannot delete the index
-		err = ts.client.DeleteIndex(context.Background(), ts.idxName)
-		require.ErrorContainsf(ts.T(), err, "failed to delete index: Deletion protection is enabled for this index", err.Error())
-	}
-
 	// disable deletion protection so the index can be cleaned up during integration teardown
 	_, err = ts.client.ConfigureIndex(context.Background(), ts.idxName, ConfigureIndexParams{DeletionProtection: "disabled"})
 	require.NoError(ts.T(), err)

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -14,11 +14,11 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
-	"github.com/pinecone-io/go-pinecone/v2/internal/gen"
-	"github.com/pinecone-io/go-pinecone/v2/internal/gen/db_control"
-	"github.com/pinecone-io/go-pinecone/v2/internal/provider"
+	"github.com/pinecone-io/go-pinecone/v3/internal/gen"
+	"github.com/pinecone-io/go-pinecone/v3/internal/gen/db_control"
+	"github.com/pinecone-io/go-pinecone/v3/internal/provider"
 
-	"github.com/pinecone-io/go-pinecone/v2/internal/utils"
+	"github.com/pinecone-io/go-pinecone/v3/internal/utils"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -37,6 +37,7 @@ func (ts *IntegrationTests) TestCreatePodIndexDense() {
 	}
 
 	name := uuid.New().String()
+	metric := Cosine
 
 	defer func(ts *IntegrationTests, name string) {
 		err := ts.deleteIndex(name)
@@ -46,7 +47,7 @@ func (ts *IntegrationTests) TestCreatePodIndexDense() {
 	idx, err := ts.client.CreatePodIndex(context.Background(), &CreatePodIndexRequest{
 		Name:        name,
 		Dimension:   2,
-		Metric:      Cosine,
+		Metric:      &metric,
 		Environment: "us-east1-gcp",
 		PodType:     "p1.x1",
 	})
@@ -63,6 +64,7 @@ func (ts *IntegrationTests) TestCreateServerlessIndexDense() {
 
 	name := uuid.New().String()
 	dimension := int32(10)
+	metric := Cosine
 
 	defer func(ts *IntegrationTests, name string) {
 		err := ts.deleteIndex(name)
@@ -72,7 +74,7 @@ func (ts *IntegrationTests) TestCreateServerlessIndexDense() {
 	idx, err := ts.client.CreateServerlessIndex(context.Background(), &CreateServerlessIndexRequest{
 		Name:      name,
 		Dimension: &dimension,
-		Metric:    Cosine,
+		Metric:    &metric,
 		Cloud:     Aws,
 		Region:    "us-west-2",
 	})
@@ -89,6 +91,7 @@ func (ts *IntegrationTests) TestCreateServerlessIndexSparse() {
 
 	name := uuid.New().String()
 	vectorType := "sparse"
+	metric := Dotproduct
 
 	defer func(ts *IntegrationTests, name string) {
 		err := ts.deleteIndex(name)
@@ -97,7 +100,7 @@ func (ts *IntegrationTests) TestCreateServerlessIndexSparse() {
 
 	idx, err := ts.client.CreateServerlessIndex(context.Background(), &CreateServerlessIndexRequest{
 		Name:       name,
-		Metric:     Dotproduct,
+		Metric:     &metric,
 		Cloud:      Aws,
 		Region:     "us-west-2",
 		VectorType: &vectorType,
@@ -114,11 +117,12 @@ func (ts *IntegrationTests) TestCreateServerlessIndexInvalidDimension() {
 
 	name := uuid.New().String()
 	dimension := int32(-1)
+	metric := Cosine
 
 	_, err := ts.client.CreateServerlessIndex(context.Background(), &CreateServerlessIndexRequest{
 		Name:      name,
 		Dimension: &dimension,
-		Metric:    Cosine,
+		Metric:    &metric,
 		Cloud:     Aws,
 		Region:    "us-west-2",
 	})
@@ -202,6 +206,7 @@ func (ts *IntegrationTests) TestDeletionProtection() {
 
 func (ts *IntegrationTests) TestConfigureIndexIllegalScaleDown() {
 	name := uuid.New().String()
+	metric := Cosine
 
 	defer func(ts *IntegrationTests, name string) {
 		err := ts.deleteIndex(name)
@@ -211,7 +216,7 @@ func (ts *IntegrationTests) TestConfigureIndexIllegalScaleDown() {
 	_, err := ts.client.CreatePodIndex(context.Background(), &CreatePodIndexRequest{
 		Name:        name,
 		Dimension:   2,
-		Metric:      Cosine,
+		Metric:      &metric,
 		Environment: "us-east1-gcp",
 		PodType:     "p1.x2",
 	})
@@ -225,11 +230,12 @@ func (ts *IntegrationTests) TestConfigureIndexIllegalScaleDown() {
 
 func (ts *IntegrationTests) TestConfigureIndexScaleUpNoPods() {
 	name := uuid.New().String()
+	metric := Cosine
 
 	_, err := ts.client.CreatePodIndex(context.Background(), &CreatePodIndexRequest{
 		Name:        name,
 		Dimension:   2,
-		Metric:      Cosine,
+		Metric:      &metric,
 		Environment: "us-east1-gcp",
 		PodType:     "p1.x2",
 	})
@@ -249,11 +255,12 @@ func (ts *IntegrationTests) TestConfigureIndexScaleUpNoPods() {
 
 func (ts *IntegrationTests) TestConfigureIndexScaleUpNoReplicas() {
 	name := uuid.New().String()
+	metric := Cosine
 
 	_, err := ts.client.CreatePodIndex(context.Background(), &CreatePodIndexRequest{
 		Name:        name,
 		Dimension:   2,
-		Metric:      Cosine,
+		Metric:      &metric,
 		Environment: "us-east1-gcp",
 		PodType:     "p1.x2",
 	})
@@ -278,6 +285,7 @@ func (ts *IntegrationTests) TestConfigureIndexIllegalNoPodsOrReplicasOrDeletionP
 
 func (ts *IntegrationTests) TestConfigureIndexHitPodLimit() {
 	name := uuid.New().String()
+	metric := Cosine
 
 	defer func(ts *IntegrationTests, name string) {
 		err := ts.deleteIndex(name)
@@ -287,7 +295,7 @@ func (ts *IntegrationTests) TestConfigureIndexHitPodLimit() {
 	_, err := ts.client.CreatePodIndex(context.Background(), &CreatePodIndexRequest{
 		Name:        name,
 		Dimension:   2,
-		Metric:      Cosine,
+		Metric:      &metric,
 		Environment: "us-east1-gcp",
 		PodType:     "p1.x2",
 	})
@@ -810,71 +818,75 @@ func TestCreatePodIndexMissingReqdFieldsUnit(t *testing.T) {
 	client := &Client{}
 	_, err := client.CreatePodIndex(context.Background(), &CreatePodIndexRequest{})
 	require.Error(t, err)
-	require.ErrorContainsf(t, err, "fields Name, positive Dimension, Metric, Environment, and Podtype must be included in CreatePodIndexRequest", err.Error())
+	require.ErrorContainsf(t, err, "fields Name, positive Dimension, Environment, and Podtype must be included in CreatePodIndexRequest", err.Error())
 }
 
 func TestCreateServerlessIndexMissingReqdFieldsUnit(t *testing.T) {
 	client := &Client{}
 	_, err := client.CreateServerlessIndex(context.Background(), &CreateServerlessIndexRequest{})
 	require.Error(t, err)
-	require.ErrorContainsf(t, err, "fields Name, Metric, Cloud, and Region must be included in CreateServerlessIndexRequest", err.Error())
+	require.ErrorContainsf(t, err, "fields Name, Cloud, and Region must be included in CreateServerlessIndexRequest", err.Error())
 }
 
 func TestCreateServerlessIndexInvalidSparseDimensionUnit(t *testing.T) {
 	vectorType := "sparse"
 	dimension := int32(1)
+	metric := Dotproduct
 	client := &Client{}
 	_, err := client.CreateServerlessIndex(context.Background(), &CreateServerlessIndexRequest{
 		Name:       "test-invalid-dimension",
-		Metric:     Dotproduct,
+		Metric:     &metric,
 		Cloud:      "aws",
 		Region:     "us-east-1",
 		Dimension:  &dimension,
 		VectorType: &vectorType,
 	})
 	require.Error(t, err)
-	require.ErrorContains(t, err, "dimension should not be specified when VectorType is 'sparse'")
+	require.ErrorContains(t, err, "Dimension should not be specified when VectorType is 'sparse'")
 }
 
 func TestCreateServerlessIndexInvalidSparseMetricUnit(t *testing.T) {
 	vectorType := "sparse"
+	metric := Cosine
 	client := &Client{}
 	_, err := client.CreateServerlessIndex(context.Background(), &CreateServerlessIndexRequest{
 		Name:       "test-invalid-dimension",
-		Metric:     Cosine,
+		Metric:     &metric,
 		Cloud:      "aws",
 		Region:     "us-east-1",
 		VectorType: &vectorType,
 	})
 	require.Error(t, err)
-	require.ErrorContains(t, err, "metric should be 'dotproduct' when VectorType is 'sparse'")
+	require.ErrorContains(t, err, "Metric should be 'dotproduct' when VectorType is 'sparse'")
 }
 
 func TestCreateServerlessIndexInvalidDenseDimensionUnit(t *testing.T) {
 	vectorType := "dense"
+	metric := Cosine
 	client := &Client{}
 	_, err := client.CreateServerlessIndex(context.Background(), &CreateServerlessIndexRequest{
 		Name:       "test-invalid-dimension",
-		Metric:     Cosine,
+		Metric:     &metric,
 		Cloud:      "aws",
 		Region:     "us-east-1",
 		VectorType: &vectorType,
 	})
 	require.Error(t, err)
-	require.ErrorContains(t, err, "dimension should be specified when VectorType is 'dense'")
+	require.ErrorContains(t, err, "Dimension should be specified when VectorType is 'dense'")
 }
 
 func TestCreatePodIndexInvalidDimensionUnit(t *testing.T) {
+	metric := Cosine
 	client := &Client{}
 	_, err := client.CreatePodIndex(context.Background(), &CreatePodIndexRequest{
 		Name:        "test-invalid-dimension",
 		Dimension:   -1,
-		Metric:      Cosine,
+		Metric:      &metric,
 		Environment: "us-east1-gcp",
 		PodType:     "p1.x1",
 	})
 	require.Error(t, err)
-	require.ErrorContains(t, err, "fields Name, positive Dimension, Metric, Environment, and Podtype must be included in CreatePodIndexRequest")
+	require.ErrorContains(t, err, "fields Name, positive Dimension, Environment, and Podtype must be included in CreatePodIndexRequest")
 }
 
 func TestCreateCollectionMissingReqdFieldsUnit(t *testing.T) {

--- a/pinecone/index_connection.go
+++ b/pinecone/index_connection.go
@@ -11,9 +11,9 @@ import (
 	"net/url"
 	"strings"
 
-	db_data_grpc "github.com/pinecone-io/go-pinecone/v2/internal/gen/db_data/grpc"
-	db_data_rest "github.com/pinecone-io/go-pinecone/v2/internal/gen/db_data/rest"
-	"github.com/pinecone-io/go-pinecone/v2/internal/useragent"
+	db_data_grpc "github.com/pinecone-io/go-pinecone/v3/internal/gen/db_data/grpc"
+	db_data_rest "github.com/pinecone-io/go-pinecone/v3/internal/gen/db_data/rest"
+	"github.com/pinecone-io/go-pinecone/v3/internal/useragent"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"

--- a/pinecone/index_connection_test.go
+++ b/pinecone/index_connection_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	db_data_grpc "github.com/pinecone-io/go-pinecone/v2/internal/gen/db_data/grpc"
-	"github.com/pinecone-io/go-pinecone/v2/internal/utils"
+	db_data_grpc "github.com/pinecone-io/go-pinecone/v3/internal/gen/db_data/grpc"
+	"github.com/pinecone-io/go-pinecone/v3/internal/utils"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/structpb"

--- a/pinecone/test_suite.go
+++ b/pinecone/test_suite.go
@@ -216,12 +216,13 @@ func generateVectorValues(dimension int32) *[]float32 {
 func BuildServerlessTestIndex(in *Client, idxName string, tags IndexTags) *Index {
 	ctx := context.Background()
 	dimension := int32(setDimensionsForTestIndexes())
+	metric := Cosine
 
 	fmt.Printf("Creating Serverless index: %s\n", idxName)
 	serverlessIdx, err := in.CreateServerlessIndex(ctx, &CreateServerlessIndexRequest{
 		Name:      idxName,
 		Dimension: &dimension,
-		Metric:    Cosine,
+		Metric:    &metric,
 		Region:    "us-east-1",
 		Cloud:     "aws",
 		Tags:      &tags,
@@ -236,12 +237,13 @@ func BuildServerlessTestIndex(in *Client, idxName string, tags IndexTags) *Index
 
 func BuildPodTestIndex(in *Client, name string, tags IndexTags) *Index {
 	ctx := context.Background()
+	metric := Cosine
 
 	fmt.Printf("Creating pod index: %s\n", name)
 	podIdx, err := in.CreatePodIndex(ctx, &CreatePodIndexRequest{
 		Name:        name,
 		Dimension:   int32(setDimensionsForTestIndexes()),
-		Metric:      Cosine,
+		Metric:      &metric,
 		Environment: "us-east-1-aws",
 		PodType:     "p1",
 		Tags:        &tags,

--- a/pinecone/test_suite.go
+++ b/pinecone/test_suite.go
@@ -89,8 +89,6 @@ func (ts *IntegrationTests) TearDownSuite() {
 	}
 
 	// Delete test index
-	_, err = WaitUntilIndexReady(ts, ctx)
-	require.NoError(ts.T(), err)
 	err = ts.client.DeleteIndex(ctx, ts.idxName)
 
 	// If the index failed to delete, wait a bit and retry cleaning up


### PR DESCRIPTION
## Problem
In order to release `v3.0.0` the `go.mod` file and associated imports need to be updated. There was also some feedback from a previous PR that I wanted to implement. 

## Solution
- Update `go.mod` to bump `module` to v3 for the upcoming release. Update relevant imports.
- Make `Metric` and `DeletionProtection` pointers to signify optionality in `CreateServerlessIndexRequest` and `CreatePodIndexRequest`. Update tests, README, etc.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
CI unit + integration
