### PR TITLE
Update `EmbedParameters` type to non-pointer

### DIFF
--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -1325,7 +1325,7 @@ type EmbedRequest struct {
 //     InputType string
 //     Truncate  string
 //     }
-type EmbedParameters *map[string]interface{}
+type EmbedParameters map[string]interface{}
 
 // [EmbedResponse] represents holds the embeddings generated for a single input.
 //
@@ -1407,17 +1407,9 @@ func (i *InferenceService) Embed(ctx context.Context, in *EmbedRequest) (*EmbedR
 	}
 
 	// convert embedding parameters to expected type
-	// if in.Parameters.InputType != "" || in.Parameters.Truncate != "" {
-	// 	req.Parameters = &struct {
-	// 		InputType string `json:"input_type,omitempty"`
-	// 		Truncate  string `json:"truncate,omitempty"`
-	// 	}{
-	// 		InputType: in.Parameters.InputType,
-	// 		Truncate:  in.Parameters.Truncate,
-	// 	}
-	// }
 	if &in.Parameters != nil {
-		req.Parameters = in.Parameters
+		params := map[string]interface{}(in.Parameters)
+		req.Parameters = &params
 	}
 
 	res, err := i.client.Embed(ctx, req)

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -310,7 +310,7 @@ func (ts *IntegrationTests) TestGenerateEmbeddings() {
 			"The quick brown fox jumps over the lazy dog",
 			"Lorem ipsum",
 		},
-		Parameters: &map[string]interface{}{
+		Parameters: map[string]interface{}{
 			"input_type": "query",
 			"truncate":   "END",
 		},
@@ -328,7 +328,7 @@ func (ts *IntegrationTests) TestGenerateEmbeddingsInvalidInputs() {
 	embeddingModel := "multilingual-e5-large"
 	_, err := ts.client.Inference.Embed(ctx, &EmbedRequest{
 		Model: embeddingModel,
-		Parameters: &map[string]interface{}{
+		Parameters: map[string]interface{}{
 			"input_type": "query",
 			"truncate":   "END",
 		},


### PR DESCRIPTION
## Problem
While testing for v3 I noticed that we have a type for `EmbedParameters` that classifies it as a pointer. This isn't something we want for the type itself.

## Solution
Clean up `EmbedParameters`.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
CI - unit & integration
