### PR TITLE
Implement Inference Models and Namespaces APIs

### DIFF
--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -1765,7 +1765,7 @@ func (i *InferenceService) Rerank(ctx context.Context, in *RerankRequest) (*Rera
 	return decodeRerankResponse(res.Body)
 }
 
-// [InferenceService.GetModel] gets a description of a model hosted by Pinecone.
+// [InferenceService.DescribeModel] gets a description of a model hosted by Pinecone.
 //
 // Parameters:
 //   - ctx: A context.Context object controls the request's lifetime, allowing for the request
@@ -1794,7 +1794,7 @@ func (i *InferenceService) Rerank(ctx context.Context, in *RerankRequest) (*Rera
 //		 }
 //
 //	     fmt.Printf("Model (multilingual-e5-large): %+v\n", model)
-func (i *InferenceService) GetModel(ctx context.Context, modelName string) (*ModelInfo, error) {
+func (i *InferenceService) DescribeModel(ctx context.Context, modelName string) (*ModelInfo, error) {
 	res, err := i.client.GetModel(ctx, modelName)
 	if err != nil {
 		return nil, err

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -1770,7 +1770,7 @@ func (i *InferenceService) Rerank(ctx context.Context, in *RerankRequest) (*Rera
 	return decodeRerankResponse(res.Body)
 }
 
-func (i *InferenceService) GetModel(ctx context.Context, modelName string) (*inference.ModelInfo, error) {
+func (i *InferenceService) GetModel(ctx context.Context, modelName string) (*ModelInfo, error) {
 	res, err := i.client.GetModel(ctx, modelName)
 	if err != nil {
 		return nil, err
@@ -1779,12 +1779,42 @@ func (i *InferenceService) GetModel(ctx context.Context, modelName string) (*inf
 	if res.StatusCode != http.StatusOK {
 		return nil, handleErrorResponseBody(res, "failed to get model: ")
 	}
-	var modelInfo inference.ModelInfo
+	var modelInfo ModelInfo
 	err = json.NewDecoder(res.Body).Decode(&modelInfo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode model info response: %w", err)
 	}
 	return &modelInfo, nil
+}
+
+type ListModelsParams struct {
+	Type       *string
+	VectorType *string
+}
+
+func (i *InferenceService) ListModels(ctx context.Context, in *ListModelsParams) (*ModelInfoList, error) {
+	var params *inference.ListModelsParams
+	if in != nil {
+		params = &inference.ListModelsParams{
+			Type:       in.Type,
+			VectorType: in.VectorType,
+		}
+	}
+
+	res, err := i.client.ListModels(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return nil, handleErrorResponseBody(res, "failed to list models: ")
+	}
+	var modelInfoList ModelInfoList
+	err = json.NewDecoder(res.Body).Decode(&modelInfoList)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode model info list response: %w", err)
+	}
+	return &modelInfoList, nil
 }
 
 func (c *Client) extractAuthHeader() map[string]string {

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -123,7 +123,7 @@ type NewClientBaseParams struct {
 // See [Client.Index] for code example.
 type NewIndexConnParams struct {
 	Host               string            // required - obtained through DescribeIndex or ListIndexes
-	Namespace          string            // optional - if not provided the default namespace of "" will be used
+	Namespace          string            // optional - if not provided the default namespace of "__default__" will be used
 	AdditionalMetadata map[string]string // optional
 }
 
@@ -287,6 +287,10 @@ func NewClientBase(in NewClientBaseParams) (*Client, error) {
 func (c *Client) Index(in NewIndexConnParams, dialOpts ...grpc.DialOption) (*IndexConnection, error) {
 	if in.AdditionalMetadata == nil {
 		in.AdditionalMetadata = make(map[string]string)
+	}
+
+	if in.Namespace == "" {
+		in.Namespace = "__default__"
 	}
 
 	if in.Host == "" {

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -1792,7 +1792,7 @@ func (i *InferenceService) Rerank(ctx context.Context, in *RerankRequest) (*Rera
 //			    log.Fatalf("Failed to create Client: %v", err)
 //		 }
 //
-//	     model, err := pc.Inference.GetModel(ctx, "multilingual-e5-large")
+//	     model, err := pc.Inference.DescribeModel(ctx, "multilingual-e5-large")
 //		 if err != nil {
 //			    log.Fatalf("Failed to get model: %v", err)
 //		 }

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -320,7 +320,8 @@ func (ts *IntegrationTests) TestGenerateEmbeddings() {
 	require.NotNil(ts.T(), embeddings, "Expected embedding to be non-nil")
 	require.Equal(ts.T(), embeddingModel, embeddings.Model, "Expected model to be '%s', but got '%s'", embeddingModel, embeddings.Model)
 	require.Equal(ts.T(), 2, len(embeddings.Data), "Expected 2 embeddings")
-	require.Equal(ts.T(), 1024, len(*embeddings.Data[0].Values), "Expected embeddings to have length 1024")
+	require.NotNil(ts.T(), embeddings.Data[0].DenseEmbedding, "Expected DenseEmbedding to be non-nil")
+	require.Equal(ts.T(), 1024, len(embeddings.Data[0].DenseEmbedding.Values), "Expected embeddings to have length 1024")
 }
 
 func (ts *IntegrationTests) TestGenerateEmbeddingsInvalidInputs() {

--- a/pinecone/index_connection_test.go
+++ b/pinecone/index_connection_test.go
@@ -181,7 +181,7 @@ func (ts *IntegrationTests) TestMetadataAppliedToRequests() {
 	apiKeyHeader, ok := idxConn.additionalMetadata["api-key"]
 	require.True(ts.T(), ok, "Expected client to have an 'api-key' header")
 	require.Equal(ts.T(), apiKey, apiKeyHeader, "Expected 'api-key' header to equal %s", apiKey)
-	require.Equal(ts.T(), namespace, idxConn.Namespace, "Expected idxConn to have namespace '%s', but got '%s'", namespace, idxConn.Namespace)
+	require.Equal(ts.T(), namespace, idxConn.namespace, "Expected idxConn to have namespace '%s', but got '%s'", namespace, idxConn.namespace)
 	require.NotNil(ts.T(), idxConn.grpcClient, "Expected idxConn to have non-nil dataClient")
 	require.NotNil(ts.T(), idxConn.grpcConn, "Expected idxConn to have non-nil grpcConn")
 
@@ -207,7 +207,7 @@ func (ts *IntegrationTests) TestUpdateVectorValues() {
 	retryAssertionsWithDefaults(ts.T(), func() error {
 		vector, err := ts.idxConn.FetchVectors(ctx, []string{ts.vectorIds[0]})
 		if err != nil {
-			return fmt.Errorf(fmt.Sprintf("Failed to fetch vector: %v", err))
+			return fmt.Errorf("Failed to fetch vector: %v", err)
 		}
 
 		if len(vector.Vectors) > 0 {
@@ -450,6 +450,70 @@ func (ts *IntegrationTests) TestIntegratedInference() {
 	})
 }
 
+func (ts *IntegrationTests) TestDescribeNamespace() {
+	if ts.indexType != "serverless" {
+		ts.T().Skip("Namespace operations are only supported in serverless indexes")
+	}
+
+	ctx := context.Background()
+	namespace := ts.namespaces[0]
+
+	namespaceDesc, err := ts.idxConn.DescribeNamespace(ctx, namespace)
+	require.NoError(ts.T(), err)
+	require.NotNil(ts.T(), namespaceDesc, "Namespace description should not be nil")
+	require.Equal(ts.T(), namespace, namespaceDesc.Name, "Namespace name should match the requested namespace")
+}
+
+func (ts *IntegrationTests) TestListNamespaces() {
+	if ts.indexType != "serverless" {
+		ts.T().Skip("Namespace operations are only supported in serverless indexes")
+	}
+
+	// List one namespace with limit
+	limit := uint32(1)
+	ctx := context.Background()
+	namespaces, err := ts.idxConn.ListNamespaces(ctx, &ListNamespacesParams{
+		Limit: &limit,
+	})
+	require.NoError(ts.T(), err)
+	require.NotNil(ts.T(), namespaces, "ListNamespaces response should not be nil")
+	require.Equal(ts.T(), limit, uint32(len(namespaces.Namespaces)))
+
+	// List remaining
+	remainingLength := len(ts.namespaces) - int(limit)
+	namespaces, err = ts.idxConn.ListNamespaces(ctx, &ListNamespacesParams{
+		PaginationToken: &namespaces.Pagination.Next,
+	})
+	require.NoError(ts.T(), err)
+	require.NotNil(ts.T(), namespaces, "ListNamespaces response should not be nil")
+	require.Equal(ts.T(), remainingLength, len(namespaces.Namespaces), "ListNamespaces should return the remaining namespaces")
+}
+
+func (ts *IntegrationTests) TestDeleteNamespace() {
+	if ts.indexType != "serverless" {
+		ts.T().Skip("Namespace operations are only supported in serverless indexes")
+	}
+
+	deletedNamespace := ts.namespaces[len(ts.namespaces)-1]
+	ctx := context.Background()
+	err := ts.idxConn.DeleteNamespace(ctx, deletedNamespace)
+	require.NoError(ts.T(), err, "DeleteNamespace should not return an error")
+
+	// Verify the namespace is deleted, which may take some time
+	retryAssertionsWithDefaults(ts.T(), func() error {
+		namespaces, err := ts.idxConn.ListNamespaces(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("ListNamespaces failed: %v", err)
+		}
+		for _, ns := range namespaces.Namespaces {
+			if ns.Name == deletedNamespace {
+				return fmt.Errorf("Namespace %s was not deleted", deletedNamespace)
+			}
+		}
+		return nil // Namespace successfully deleted
+	})
+}
+
 // Unit tests:
 func TestUpdateVectorMissingReqdFieldsUnit(t *testing.T) {
 	ctx := context.Background()
@@ -475,7 +539,7 @@ func TestNewIndexConnection(t *testing.T) {
 	apiKeyHeader, ok := idxConn.additionalMetadata["api-key"]
 	require.True(t, ok, "Expected client to have an 'api-key' header")
 	require.Equal(t, apiKey, apiKeyHeader, "Expected 'api-key' header to equal %s", apiKey)
-	require.Empty(t, idxConn.Namespace, "Expected idxConn to have empty namespace, but got '%s'", idxConn.Namespace)
+	require.Empty(t, idxConn.namespace, "Expected idxConn to have empty namespace, but got '%s'", idxConn.namespace)
 	require.NotNil(t, idxConn.grpcClient, "Expected idxConn to have non-nil dataClient")
 	require.NotNil(t, idxConn.grpcConn, "Expected idxConn to have non-nil grpcConn")
 }
@@ -496,7 +560,7 @@ func TestNewIndexConnectionNamespace(t *testing.T) {
 	apiKeyHeader, ok := idxConn.additionalMetadata["api-key"]
 	require.True(t, ok, "Expected client to have an 'api-key' header")
 	require.Equal(t, apiKey, apiKeyHeader, "Expected 'api-key' header to equal %s", apiKey)
-	require.Equal(t, namespace, idxConn.Namespace, "Expected idxConn to have namespace '%s', but got '%s'", namespace, idxConn.Namespace)
+	require.Equal(t, namespace, idxConn.namespace, "Expected idxConn to have namespace '%s', but got '%s'", namespace, idxConn.namespace)
 	require.NotNil(t, idxConn.grpcClient, "Expected idxConn to have non-nil dataClient")
 	require.NotNil(t, idxConn.grpcConn, "Expected idxConn to have non-nil grpcConn")
 }

--- a/pinecone/index_connection_test.go
+++ b/pinecone/index_connection_test.go
@@ -480,13 +480,14 @@ func (ts *IntegrationTests) TestListNamespaces() {
 	require.Equal(ts.T(), limit, uint32(len(namespaces.Namespaces)))
 
 	// List remaining
-	remainingLength := len(ts.namespaces) - int(limit)
+	remainingLength := uint32(len(ts.namespaces) - int(limit))
 	namespaces, err = ts.idxConn.ListNamespaces(ctx, &ListNamespacesParams{
 		PaginationToken: &namespaces.Pagination.Next,
+		Limit:           &remainingLength,
 	})
 	require.NoError(ts.T(), err)
 	require.NotNil(ts.T(), namespaces, "ListNamespaces response should not be nil")
-	require.Equal(ts.T(), remainingLength, len(namespaces.Namespaces), "ListNamespaces should return the remaining namespaces")
+	require.Equal(ts.T(), limit, uint32(len(namespaces.Namespaces)), "ListNamespaces should return the remaining namespaces")
 }
 
 func (ts *IntegrationTests) TestDeleteNamespace() {

--- a/pinecone/local_test.go
+++ b/pinecone/local_test.go
@@ -46,7 +46,7 @@ func (ts *LocalIntegrationTests) SetupSuite() {
 	for _, idxConn := range ts.idxConns {
 		upsertedVectors, err := idxConn.UpsertVectors(ctx, vectors)
 		require.NoError(ts.T(), err)
-		fmt.Printf("Upserted vectors: %v into host: %s in namespace: %s \n", upsertedVectors, ts.host, idxConn.Namespace)
+		fmt.Printf("Upserted vectors: %v into host: %s in namespace: %s \n", upsertedVectors, ts.host, idxConn.namespace)
 	}
 
 	ts.vectorIds = append(ts.vectorIds, vectorIds...)

--- a/pinecone/models.go
+++ b/pinecone/models.go
@@ -168,7 +168,7 @@ type ScoredVector struct {
 	Score  float32 `json:"score"`
 }
 
-// [SparseValues] is a sparse vector objects, most commonly used for [hybrid search].
+// [SparseValues] is a sparse vector object, most commonly used for [hybrid search].
 //
 // [hybrid search]: https://docs.pinecone.io/guides/data/understanding-hybrid-search#hybrid-search-in-pinecone
 type SparseValues struct {
@@ -179,6 +179,8 @@ type SparseValues struct {
 // [NamespaceSummary] is a summary of stats for a Pinecone [namespace].
 //
 // [namespace]: https://docs.pinecone.io/guides/indexes/use-namespaces
+// Fields:
+//   - VectorCount: The number of vectors in the namespace.
 type NamespaceSummary struct {
 	VectorCount uint32 `json:"vector_count"`
 }
@@ -186,6 +188,9 @@ type NamespaceSummary struct {
 // [NamespaceDescription] is a description of a Pinecone [namespace].
 //
 // [namespace]: https://docs.pinecone.io/guides/indexes/use-namespaces
+// Fields:
+//   - Name: The name of the namespace.
+//   - RecordCount: The number of records in the namespace.
 type NamespaceDescription struct {
 	Name        string `json:"name"`
 	RecordCount uint64 `json:"record_count"`
@@ -218,26 +223,42 @@ type MetadataFilter = structpb.Struct
 type Metadata = structpb.Struct
 
 // [Embedding] represents the embedding of a single input which is returned after [generating embeddings].
-// Each embedding can have either a [SparseEmbedding] or a [DenseEmbedding].
+// [Embedding] is a tagged union which can have either a [SparseEmbedding] or a [DenseEmbedding].
 //
 // [generating embeddings]: https://docs.pinecone.io/guides/inference/generate-embeddings#3-generate-embeddings
+// Fields:
+//   - SparseEmbedding: The [SparseEmbedding] representation of the input.
+//   - DenseEmbedding: The [DenseEmbedding] representation of the input.
 type Embedding struct {
 	SparseEmbedding *SparseEmbedding `json:"sparse_embedding,omitempty"`
 	DenseEmbedding  *DenseEmbedding  `json:"dense_embedding,omitempty"`
 }
 
+// [DenseEmbedding] represents a dense numerical embedding of the input.
+//
+// Fields:
+//   - VectorType: A string indicating the type of vector embedding ("dense").
+//   - Values: A slice of float32 values representing the dense embedding.
 type DenseEmbedding struct {
 	VectorType string    `json:"vector_type"`
 	Values     []float32 `json:"values"`
 }
 
+// [SparseEmbedding] represents a sparse embedding of the input, where only selected dimensions are populated.
+//
+// Fields:
+//   - VectorType: A string indicating the type of vector embedding ("sparse").
+//   - SparseValues: A slice of float32 values representing the sparse embedding value.
+//   - SparseIndices: A slice of int64 values representing the embedding indices.
+//   - SparseTokens: The normalized tokens used to create the sparse embedding, if requested.
 type SparseEmbedding struct {
 	VectorType    string    `json:"vector_type"`
-	SparseValues  []float32 `json:"sparse_values,omitempty"`
-	SparseIndices []int64   `json:"sparse_indices,omitempty"`
+	SparseValues  []float32 `json:"sparse_values"`
+	SparseIndices []int64   `json:"sparse_indices"`
 	SparseTokens  *[]string `json:"sparse_tokens,omitempty"`
 }
 
+// [Pagination] represents the pagination information for a list of resources.
 type Pagination struct {
 	Next string `json:"next"`
 }

--- a/pinecone/models.go
+++ b/pinecone/models.go
@@ -2,6 +2,7 @@ package pinecone
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"google.golang.org/protobuf/types/known/structpb"
@@ -374,46 +375,66 @@ type SearchUsage struct {
 	RerankUnits      *int32 `json:"rerank_units,omitempty"`
 }
 
-type ModelInfo struct {
-	DefaultDimension    *int32                         `json:"default_dimension,omitempty"`
-	MaxBatchSize        *int32                         `json:"max_batch_size,omitempty"`
-	MaxSequenceLength   *int32                         `json:"max_sequence_length,omitempty"`
-	Modality            *string                        `json:"modality,omitempty"`
-	Model               string                         `json:"model"`
-	ProviderName        *string                        `json:"provider_name,omitempty"`
-	ShortDescription    string                         `json:"short_description"`
-	SupportedDimensions *[]int32                       `json:"supported_dimensions,omitempty"`
-	SupportedMetrics    *[]IndexMetric                 `json:"supported_metrics,omitempty"`
-	SupportedParameters *[]ModelInfoSupportedParameter `json:"supported_parameters,omitempty"`
-	Type                string                         `json:"type"`
-	VectorType          *string                        `json:"vector_type,omitempty"`
-}
-
-type ModelInfoSupportedParameter struct {
-	AllowedValues *[]ModelInfoSupportedParameterAllowedValue `json:"allowed_values,omitempty"`
-	Default       *ModelInfoSupportedParameterDefault        `json:"default,omitempty"`
-	Max           *float32                                   `json:"max,omitempty"`
-	Min           *float32                                   `json:"min,omitempty"`
-	Parameter     string                                     `json:"parameter"`
-	Required      bool                                       `json:"required"`
-	Type          string                                     `json:"type"`
-	ValueType     string                                     `json:"value_type"`
-}
-
-type ModelInfoSupportedParameterString = string
-type ModelInfoSupportedParameterInt = int
-type ModelInfoSupportedParameterAllowedValue struct {
-	union json.RawMessage
-}
-
-type ModelInfoSupportedParameterDefaultString = string
-type ModelInfoSupportedParameterDefaultInt = int32
-type ModelInfoSupportedParameterDefaultFloat = float32
-type ModelInfoSupportedParameterDefaultBool = bool
-type ModelInfoSupportedParameterDefault struct {
-	union json.RawMessage
-}
-
 type ModelInfoList struct {
 	Models *[]ModelInfo `json:"models,omitempty"`
+}
+
+type ModelInfo struct {
+	DefaultDimension    *int32                `json:"default_dimension,omitempty"`
+	MaxBatchSize        *int32                `json:"max_batch_size,omitempty"`
+	MaxSequenceLength   *int32                `json:"max_sequence_length,omitempty"`
+	Modality            *string               `json:"modality,omitempty"`
+	Model               string                `json:"model"`
+	ProviderName        *string               `json:"provider_name,omitempty"`
+	ShortDescription    string                `json:"short_description"`
+	SupportedDimensions *[]int32              `json:"supported_dimensions,omitempty"`
+	SupportedMetrics    *[]IndexMetric        `json:"supported_metrics,omitempty"`
+	SupportedParameters *[]SupportedParameter `json:"supported_parameters,omitempty"`
+	Type                string                `json:"type"`
+	VectorType          *string               `json:"vector_type,omitempty"`
+}
+
+type SupportedParameter struct {
+	AllowedValues *[]SupportedParameterValue `json:"allowed_values,omitempty"`
+	Default       *SupportedParameterValue   `json:"default,omitempty"`
+	Max           *float32                   `json:"max,omitempty"`
+	Min           *float32                   `json:"min,omitempty"`
+	Parameter     string                     `json:"parameter"`
+	Required      bool                       `json:"required"`
+	Type          string                     `json:"type"`
+	ValueType     string                     `json:"value_type"`
+}
+
+type SupportedParameterValue struct {
+	StringValue *string
+	IntValue    *int32
+	FloatValue  *float32
+	BoolValue   *bool
+}
+
+func (spv *SupportedParameterValue) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		spv.StringValue = &s
+		return nil
+	}
+
+	var i int32
+	if err := json.Unmarshal(data, &i); err == nil {
+		spv.IntValue = &i
+		return nil
+	}
+
+	var f float32
+	if err := json.Unmarshal(data, &f); err == nil {
+		spv.FloatValue = &f
+		return nil
+	}
+
+	var b bool
+	if err := json.Unmarshal(data, &b); err == nil {
+		spv.BoolValue = &b
+		return nil
+	}
+	return fmt.Errorf("unsupported type for SupportedParameterValue: %s", data)
 }

--- a/pinecone/models.go
+++ b/pinecone/models.go
@@ -1,6 +1,7 @@
 package pinecone
 
 import (
+	"encoding/json"
 	"time"
 
 	"google.golang.org/protobuf/types/known/structpb"
@@ -211,7 +212,20 @@ type Metadata = structpb.Struct
 //
 // [generating embeddings]: https://docs.pinecone.io/guides/inference/generate-embeddings#3-generate-embeddings
 type Embedding struct {
-	Values *[]float32 `json:"values,omitempty"`
+	SparseEmbedding *SparseEmbedding `json:"sparse_embedding,omitempty"`
+	DenseEmbedding  *DenseEmbedding  `json:"dense_embedding,omitempty"`
+}
+
+type DenseEmbedding struct {
+	VectorType string    `json:"vector_type"`
+	Values     []float32 `json:"values"`
+}
+
+type SparseEmbedding struct {
+	VectorType    string    `json:"vector_type"`
+	SparseValues  []float32 `json:"sparse_values,omitempty"`
+	SparseIndices []int32   `json:"sparse_indices,omitempty"`
+	SparseTokens  *[]string `json:"sparse_tokens,omitempty"`
 }
 
 // [ImportStatus] represents the status of an [Import] operation.
@@ -358,4 +372,48 @@ type SearchUsage struct {
 	ReadUnits        int32  `json:"read_units"`
 	EmbedTotalTokens *int32 `json:"embed_total_tokens,omitempty"`
 	RerankUnits      *int32 `json:"rerank_units,omitempty"`
+}
+
+type ModelInfo struct {
+	DefaultDimension    *int32                         `json:"default_dimension,omitempty"`
+	MaxBatchSize        *int32                         `json:"max_batch_size,omitempty"`
+	MaxSequenceLength   *int32                         `json:"max_sequence_length,omitempty"`
+	Modality            *string                        `json:"modality,omitempty"`
+	Model               string                         `json:"model"`
+	ProviderName        *string                        `json:"provider_name,omitempty"`
+	ShortDescription    string                         `json:"short_description"`
+	SupportedDimensions *[]int32                       `json:"supported_dimensions,omitempty"`
+	SupportedMetrics    *[]IndexMetric                 `json:"supported_metrics,omitempty"`
+	SupportedParameters *[]ModelInfoSupportedParameter `json:"supported_parameters,omitempty"`
+	Type                string                         `json:"type"`
+	VectorType          *string                        `json:"vector_type,omitempty"`
+}
+
+type ModelInfoSupportedParameter struct {
+	AllowedValues *[]ModelInfoSupportedParameterAllowedValue `json:"allowed_values,omitempty"`
+	Default       *ModelInfoSupportedParameterDefault        `json:"default,omitempty"`
+	Max           *float32                                   `json:"max,omitempty"`
+	Min           *float32                                   `json:"min,omitempty"`
+	Parameter     string                                     `json:"parameter"`
+	Required      bool                                       `json:"required"`
+	Type          string                                     `json:"type"`
+	ValueType     string                                     `json:"value_type"`
+}
+
+type ModelInfoSupportedParameterString = string
+type ModelInfoSupportedParameterInt = int
+type ModelInfoSupportedParameterAllowedValue struct {
+	union json.RawMessage
+}
+
+type ModelInfoSupportedParameterDefaultString = string
+type ModelInfoSupportedParameterDefaultInt = int32
+type ModelInfoSupportedParameterDefaultFloat = float32
+type ModelInfoSupportedParameterDefaultBool = bool
+type ModelInfoSupportedParameterDefault struct {
+	union json.RawMessage
+}
+
+type ModelInfoList struct {
+	Models *[]ModelInfo `json:"models,omitempty"`
 }

--- a/pinecone/models.go
+++ b/pinecone/models.go
@@ -183,6 +183,14 @@ type NamespaceSummary struct {
 	VectorCount uint32 `json:"vector_count"`
 }
 
+// [NamespaceDescription] is a description of a Pinecone [namespace].
+//
+// [namespace]: https://docs.pinecone.io/guides/indexes/use-namespaces
+type NamespaceDescription struct {
+	Name        string `json:"name"`
+	RecordCount uint64 `json:"record_count"`
+}
+
 // [Usage] is the usage stats ([Read Units]) for a Pinecone [Index].
 //
 // [Read Units]: https://docs.pinecone.io/guides/organizations/manage-cost/understanding-cost#serverless-indexes
@@ -210,6 +218,7 @@ type MetadataFilter = structpb.Struct
 type Metadata = structpb.Struct
 
 // [Embedding] represents the embedding of a single input which is returned after [generating embeddings].
+// Each embedding can have either a [SparseEmbedding] or a [DenseEmbedding].
 //
 // [generating embeddings]: https://docs.pinecone.io/guides/inference/generate-embeddings#3-generate-embeddings
 type Embedding struct {
@@ -227,6 +236,10 @@ type SparseEmbedding struct {
 	SparseValues  []float32 `json:"sparse_values,omitempty"`
 	SparseIndices []int64   `json:"sparse_indices,omitempty"`
 	SparseTokens  *[]string `json:"sparse_tokens,omitempty"`
+}
+
+type Pagination struct {
+	Next string `json:"next"`
 }
 
 // [ImportStatus] represents the status of an [Import] operation.

--- a/pinecone/models.go
+++ b/pinecone/models.go
@@ -247,7 +247,7 @@ const (
 	Pending    ImportStatus = "Pending"
 )
 
-// ImportErrorMode specifies how errors are handled during an [Import].
+// [ImportErrorMode] specifies how errors are handled during an [Import].
 //
 // Values:
 //   - Abort: The [Import] process will abort upon encountering an error.
@@ -283,7 +283,7 @@ type Import struct {
 
 type IntegratedRecord map[string]interface{}
 
-// SearchRecordsRequest represents a search request for records in a specific namespace.
+// [SearchRecordsRequest] represents a search request for records in a specific namespace.
 //
 // Fields:
 //   - Query: The query inputs to search with.
@@ -295,7 +295,7 @@ type SearchRecordsRequest struct {
 	Rerank *SearchRecordsRerank `json:"rerank,omitempty"`
 }
 
-// SearchRecordsQuery represents the query parameters for searching records.
+// [SearchRecordsQuery] represents the query parameters for searching records.
 //
 // Fields:
 //   - TopK: The number of results to return for each search.
@@ -311,7 +311,7 @@ type SearchRecordsQuery struct {
 	Vector *SearchRecordsVector    `json:"vector,omitempty"`
 }
 
-// SearchRecordsRerank represents the parameters for reranking search results.
+// [SearchRecordsRerank] represents the parameters for reranking search results.
 //
 // Fields:
 //   - Model: The name of the [reranking model](https://docs.pinecone.io/guides/inference/understanding-inference#reranking-models) to use.
@@ -327,7 +327,7 @@ type SearchRecordsRerank struct {
 	TopN       *int32                  `json:"top_n,omitempty"`
 }
 
-// Hit represents a record whose vector values are similar to the provided search query.
+// [Hit] represents a record whose vector values are similar to the provided search query.
 //
 // Fields:
 //   - Id: The record ID of the search hit.
@@ -339,7 +339,7 @@ type Hit struct {
 	Fields map[string]interface{} `json:"fields"`
 }
 
-// SearchRecordsResponse represents the response of a records search.
+// [SearchRecordsResponse] represents the response of a records search.
 //
 // Fields:
 //   - Result: The result object containing the [Hit] responses for the search.
@@ -351,7 +351,7 @@ type SearchRecordsResponse struct {
 	Usage SearchUsage `json:"usage"`
 }
 
-// SearchRecordsVector represents the vector data used in a search request.
+// [SearchRecordsVector] represents the vector data used in a search request.
 //
 // Fields:
 //   - SparseIndices: The sparse embedding indices.
@@ -363,7 +363,7 @@ type SearchRecordsVector struct {
 	Values        *[]float32 `json:"values,omitempty"`
 }
 
-// SearchUsage represents the resource usage details of a search operation.
+// [SearchUsage] represents the resource usage details of a search operation.
 //
 // Fields:
 //   - ReadUnits: The number of read units consumed by this operation.
@@ -375,10 +375,29 @@ type SearchUsage struct {
 	RerankUnits      *int32 `json:"rerank_units,omitempty"`
 }
 
+// [ModelInfoList] represents a list of [ModelInfo] objects describing the models hosted by Pinecone.
+//
+// Fields:
+//   - Models: A slice of [ModelInfo] objects.
 type ModelInfoList struct {
 	Models *[]ModelInfo `json:"models,omitempty"`
 }
 
+// [ModelInfo] represents the model configuration include model type, supported parameters, and other model details.
+//
+// Fields:
+//   - DefaultDimension: The default embedding model dimension (applies to dense embedding models only).
+//   - MaxBatchSize: The maximum batch size (number of sequences) supported by the model.
+//   - MaxSequenceLength: The maximum tokens per sequence supported by the model.
+//   - Modality: The modality of the model (e.g. "text").
+//   - Model: The name of the model.
+//   - ProviderName: The name of the provider of the model. (e.g. "Pinecone", "NVIDIA").
+//   - ShortDescription: A summary of the model.
+//   - SupportedDimensions: The list of supported dimensions for the model (applies to dense embedding models only).
+//   - SupportedMetrics: The distance metrics supported by the model for similarity search (e.g. "cosine", "dotproduct", "euclidean").
+//   - SupportedParameters: A list of parameters supported by the model, including parameter value constraints.
+//   - Type: The type of model (e.g. "embed" or "rerank").
+//   - VectorType: Whether the embedding model produces "dense" or "sparse" embeddings.
 type ModelInfo struct {
 	DefaultDimension    *int32                `json:"default_dimension,omitempty"`
 	MaxBatchSize        *int32                `json:"max_batch_size,omitempty"`
@@ -394,6 +413,20 @@ type ModelInfo struct {
 	VectorType          *string               `json:"vector_type,omitempty"`
 }
 
+// [SupportedParameter] describes a parameter supported by the model, including parameter value constraints.
+//
+// Fields:
+//   - AllowedValues: The allowed parameter values when the type is "one_of".
+//   - Default: The default value for the parameter when a parameter is optional.
+//   - Max: The maximum allowed value (inclusive) when the type is "numeric_range".
+//   - Min: The minimum allowed value (inclusive) when the type is "numeric_range".
+//   - Parameter: The name of the parameter.
+//   - Required: Indicates whether this parameter is required or optional.
+//   - Type: The parameter type e.g. "one_of", "numeric_range", or "any". If the type is "one_of", then "allowed_values" will be set,
+//     and the value specified must be one of the allowed values. "one_of" is only compatible with ValueType "string" or "integer".
+//     If "numeric_range", then "min" and "max" will be set, then the value specified must adhere to the ValueType and must fall within
+//     the `[Min, Max]` range. If "any" then any value is allowed, as long as it adheres to the ValueType.
+//   - ValueType: The type of value the parameter accepts, e.g. "string", "integer", "float", or "boolean".
 type SupportedParameter struct {
 	AllowedValues *[]SupportedParameterValue `json:"allowed_values,omitempty"`
 	Default       *SupportedParameterValue   `json:"default,omitempty"`
@@ -405,6 +438,13 @@ type SupportedParameter struct {
 	ValueType     string                     `json:"value_type"`
 }
 
+// [SupportedParameterValue] is a tagged union type representing the value of a [SupportedParameter].
+//
+// Fields:
+//   - StringValue: A string-based value, if the parameter accepts strings.
+//   - IntValue: An integer-based value, if the parameter accepts integers.
+//   - FloatValue: A float-based value, if the parameter accepts floating point numbers.
+//   - BoolValue: A boolean value, if the parameter accepts true/false input.
 type SupportedParameterValue struct {
 	StringValue *string
 	IntValue    *int32

--- a/pinecone/models.go
+++ b/pinecone/models.go
@@ -224,7 +224,7 @@ type DenseEmbedding struct {
 type SparseEmbedding struct {
 	VectorType    string    `json:"vector_type"`
 	SparseValues  []float32 `json:"sparse_values,omitempty"`
-	SparseIndices []int32   `json:"sparse_indices,omitempty"`
+	SparseIndices []int64   `json:"sparse_indices,omitempty"`
 	SparseTokens  *[]string `json:"sparse_tokens,omitempty"`
 }
 


### PR DESCRIPTION
## Problem
Inference Models and Namespaces are new API resources available in `2025-04`. They need to be implemented in the Go client. 

Additionally, there are a few client bugs which need to be fixed: 
- The `Embed` method and it's return type `EmbedResponse` need to be refactored to support both sparse and dense embedding responses, rather than just dense. Currently, embedding with a model that returns sparse values will cause errors.
- The `IndexConnection` struct is not safe to reuse for performing operations across namespaces while reusing the existing gRPC connection for the index. This is because `IndexConnection.Namespace` is publicly exposed, and could be updated at any point.

## Solution
Implement new namespaces and models API operations:
- Namespace operations have been implemented on `IndexConnection`. They're exposed as methods which you can call via `IndexConnection.ListNamespaces`, `IndexConnection.DescribeNamespace`, or `IndexConnection.DeleteNamespace`.
- Hosted model operations can be performed using the `Client.Inference` namespace (`InferenceService` struct) by calling `client.Inference.DescribeModel` or `client.Inference.ListModels`.

The `InferenceService.Embed` method now returns a different `Embedding` inside of `EmbedResponse`. `Embedding` has been refactored into a tagged union type which is basically just a struct that wraps either a `SparseEmbedding` or `DenseEmbedding` pointers. This seemed to be the best way to manage this type of thing in Go given the lack of explicit union types. I'm open to suggestions if anyone has something that may be a bit more ergonomic.

`IndexConnection` has been refactored to no longer expose `IndexConnection.Namespace` directly. Instead, `Namespace` is now a method which allows checking the currently targeted namespace. Users can now call `IndexConnection.WithNamespace` which will return a copy of the `IndexConnection` targeting the new namespace, but sharing the underlying gRPC connection. Again, I think this is a reasonable way of approaching this and allowing safely targeting multiple namespaces within an index, but I'm open to feedback.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - Breaking change for `EmbedResponse` on `InferenceService.Embed` 
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
CI - unit tests & integration tests

If you'd like to test the new APIs out yourself you can check the integration tests or README for more detailed examples:

Models:
```go
	ctx := context.Background()

	pc, err := pinecone.NewClient(pinecone.NewClientParams{
		ApiKey:    "YOUR_API_KEY",
	})
	if err != nil {
		log.Fatalf("Failed to create Client: %v", err)
	}

	embed := "embed"
	rerank := "rerank"

	embedModels, err := pc.Inference.ListModels(ctx, &pinecone.ListModelsParams{
		Type: &embed,
	})
	if err != nil {
		log.Fatalf("Failed to list embedding models: %v", err)
	}

	rerankModels, err := pc.Inference.ListModels(ctx, &pinecone.ListModelsParams{
		Type: &rerank,
	})
	if err != nil {
		log.Fatalf("Failed to list reranking models: %v", err)
        }

       multilingualModel, := pc.Inference.DescribeModel(ctx, "multilingual-e5-large")
	if err != nil {
		log.Fatalf("Failed to describe models: %v", err)
        }
```
Namespaces:
```go
	ctx := context.Background()

	pc, err := pinecone.NewClient(pinecone.NewClientParams{
		ApiKey:    "YOUR_API_KEY",
	})
	if err != nil {
		log.Fatalf("Failed to create Client: %v", err)
	}

	idx, err := pc.DescribeIndex(ctx, "example-index")
	if err != nil {
		log.Fatalf("Failed to describe index \"%v\": %v", idx.Name, err)
	}

	idxConnection, err := pc.Index(pinecone.NewIndexConnParams{Host: idx.Host})
	if err != nil {
		log.Fatalf("Failed to create IndexConnection for Host: %v: %v", idx.Host, err)
	}

	// list namespaces
	limit := uint32(10)
	namespaces, err := idxConnection.ListNamespaces(ctx, &pinecone.ListNamespacesParams{
		Limit: &limit,
	})
	if err != nil {
		log.Fatalf("Failed to list namespaces for Host: %v: %v", idx.Host, err)
	}

	// describe a namespace
	namespace1, err := idxConnection.DescribeNamespace(ctx, "my-namespace-1")
	if err != nil {
		log.Fatalf("Failed to describe namespace: %v: %v", "my-namespace-1", err)
	}

	// delete a namespace
	err := idxConnection.DeleteNamespace("my-namespace-1")
	if err != nil {
		log.Fatalf("Failed to delete namespace: %v: %v", "my-namespace-1", err)
	}
```


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210238631289243
  - https://app.asana.com/0/0/1209828518477630