### PR TITLE
Implement Backups/Restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -1679,8 +1679,8 @@ A backup is a static copy of a serverless index that only consumes storage. It i
 
 	// create a new serverless index from the backup
 	restoredIndexName := indexName + "-from-backup"
-	restoredIndexTags := IndexTags{"restored_on": time.Now().Format("2006-01-02 15:04")}
-	createIndexFromBackupResp, err := pc.CreateIndexFromBackup(context.Background(), &CreateIndexFromBackupParams{
+	restoredIndexTags := pinecone.IndexTags{"restored_on": time.Now().Format("2006-01-02 15:04")}
+	createIndexFromBackupResp, err := pc.CreateIndexFromBackup(context.Background(), &pinecone.CreateIndexFromBackupParams{
 		BackupId: ts.backupId,
 		Name:     restoredIndexName,
 		Tags:     &restoredIndexTags,

--- a/README.md
+++ b/README.md
@@ -1630,6 +1630,69 @@ func main() {
 }
 ```
 
+## Backups
+
+A backup is a static copy of a serverless index that only consumes storage. It is a non-queryable representation of a set of records. You can create a backup of a serverless index, and you can create a new serverless index from a backup. You can optionally apply new `Tags` and `DeletionProtection` configurations for the index when calling `CreateIndexFromBackup`. You can read more about [backups here](https://docs.pinecone.io/guides/manage-data/backups-overview).
+
+```go
+	ctx := context.Background()
+
+	clientParams := pinecone.NewClientParams{
+		ApiKey: os.Getenv("PINECONE_API_KEY"),
+	}
+
+	pc, err := pinecone.NewClient(clientParams)
+	if err != nil {
+		log.Fatalf("Failed to create Client: %w", err)
+	}
+
+	indexName := "my-index"
+	backupName := fmt.Sprintf("backup-%s", )
+	backupDesc := fmt.Sprintf("Backup created for index %s", indexName)
+	fmt.Printf("Creating backup: %s for index: %s\n", backupName, indexName)
+
+	backup, err := pc.CreateBackup(ctx, &pinecone.CreateBackupParams{
+		IndexName:   indexName,
+		Name:        &backupName,
+		Description: &backupDesc,
+	})
+	if err != nil {
+		log.Fatalf("Failed to create backup: %w", err)
+	}
+
+	backup, err = pc.DescribeBackup(ctx, backup.BackupId)
+	if err != nil {
+		log.Fatalf("Failed to describe backup: %w", err)
+	}
+
+	// wait for backup to be "Complete" before triggering a restore job
+	log.Printf("Backup status: %v", backup.Status)
+
+	limit := 10
+	backups, err := pc.ListBackups(ctx, &pinecone.ListBackupsParams{
+		Limit: &limit,
+		IndexName: &indexName,
+	})
+	if err != nil {
+		log.Fatalf("Failed to list backups: %w", err)
+	}
+
+	// create a new serverless index from the backup
+	restoredIndexName := indexName + "-from-backup"
+	restoredIndexTags := IndexTags{"restored_on": time.Now().Format("2006-01-02 15:04")}
+	createIndexFromBackupResp, err := pc.CreateIndexFromBackup(context.Background(), &CreateIndexFromBackupParams{
+		BackupId: ts.backupId,
+		Name:     restoredIndexName,
+		Tags:     &restoredIndexTags,
+	})
+
+	// check the status of the index restoration
+	restoreJob, err := pc.DescribeRestoreJob(ctx, restoreJob.RestoreJobId)
+	if err != nil {
+		log.Fatalf("Failed to describe restore job: %w", err)
+	}
+```
+
 ## Inference
 
 The `Client` object has an `Inference` namespace which exposes an `InferenceService` pointer which allows interacting with Pinecone's [Inference API](https://docs.pinecone.io/guides/inference/generate-embeddings).

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -811,7 +811,7 @@ func (ts *IntegrationTests) TestCreateIndexFromBackupViaRestore() {
 	require.NoError(ts.T(), err)
 	require.NotNil(ts.T(), index, "Expected restored index to be non-nil")
 	require.Equal(ts.T(), restoredIndexName, index.Name, "Expected restored index name to match")
-	require.Equal(ts.T(), restoredIndexTags, index.Tags, "Expected restored index tags to match")
+	require.Equal(ts.T(), restoredIndexTags, *index.Tags, "Expected restored index tags to match")
 }
 
 // Unit tests:

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -777,9 +777,11 @@ func (ts *IntegrationTests) TestCreateIndexFromBackup() {
 	}
 	limit := 5
 	restoredIndexName := ts.idxName + "-from-backup"
+	restoredIndexTags := IndexTags{"status": "integration-test", "type": "backup-restore"}
 	createIndexFromBackupResp, err := ts.client.CreateIndexFromBackup(context.Background(), &CreateIndexFromBackupParams{
 		BackupId: ts.backupId,
 		Name:     restoredIndexName,
+		Tags:     &restoredIndexTags,
 	})
 	require.NoError(ts.T(), err)
 	require.NotNil(ts.T(), createIndexFromBackupResp, "Expected CreateIndexFromBackup response to be non-nil")
@@ -809,6 +811,7 @@ func (ts *IntegrationTests) TestCreateIndexFromBackup() {
 	require.NoError(ts.T(), err)
 	require.NotNil(ts.T(), index, "Expected restored index to be non-nil")
 	require.Equal(ts.T(), restoredIndexName, index.Name, "Expected restored index name to match")
+	require.Equal(ts.T(), restoredIndexTags, index.Tags, "Expected restored index tags to match")
 }
 
 // Unit tests:

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -771,7 +771,7 @@ func (ts *IntegrationTests) TestListAndDescribeIndexBackups() {
 	}
 }
 
-func (ts *IntegrationTests) TestCreateIndexFromBackup() {
+func (ts *IntegrationTests) TestCreateIndexFromBackupViaRestore() {
 	if ts.indexType != "serverless" {
 		ts.T().Skip("Skipping backup tests for non-serverless indexes")
 	}

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -800,7 +800,7 @@ func (ts *IntegrationTests) TestCreateIndexFromBackupViaRestore() {
 	// wait until restore job completes
 	maxRetries := 5
 	for restoreJob.CompletedAt != nil || maxRetries > 0 {
-		time.Sleep(5 * time.Second)
+		time.Sleep(2 * time.Second)
 		restoreJob, err = ts.client.DescribeRestoreJob(context.Background(), createIndexFromBackupResp.RestoreJobId)
 		require.NoError(ts.T(), err)
 		maxRetries--
@@ -808,6 +808,11 @@ func (ts *IntegrationTests) TestCreateIndexFromBackupViaRestore() {
 
 	// validate describing the restored index
 	index, err := ts.client.DescribeIndex(context.Background(), restoredIndexName)
+	defer func(ts *IntegrationTests, name string) {
+		err := ts.client.DeleteIndex(context.Background(), name)
+		require.NoError(ts.T(), err)
+	}(ts, restoredIndexName)
+
 	require.NoError(ts.T(), err)
 	require.NotNil(ts.T(), index, "Expected restored index to be non-nil")
 	require.Equal(ts.T(), restoredIndexName, index.Name, "Expected restored index name to match")

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -747,6 +747,70 @@ func (ts *IntegrationTests) TestIndexTags() {
 	ts.indexTags = &updatedTags
 }
 
+func (ts *IntegrationTests) TestListAndDescribeIndexBackups() {
+	if ts.indexType != "serverless" {
+		ts.T().Skip("Skipping backup tests for non-serverless indexes")
+	}
+	// CreateBackup and DeleteBackup are tested as a part of IntegrationTests.SetupSuite(), so not explicitly tested here
+	limit := 5
+
+	// list project backups
+	backups, err := ts.client.ListBackups(context.Background(), &ListBackupsParams{Limit: &limit})
+	require.NoError(ts.T(), err)
+	require.NotNil(ts.T(), backups, "Expected backups to be non-nil")
+
+	// list index backups
+	indexBackups, err := ts.client.ListBackups(context.Background(), &ListBackupsParams{
+		IndexName: &ts.idxName,
+		Limit:     &limit,
+	})
+	require.NoError(ts.T(), err)
+	require.NotNil(ts.T(), indexBackups, "Expected index backups to be non-nil")
+	if len(indexBackups.Data) > 0 {
+		require.Equal(ts.T(), ts.idxName, indexBackups.Data[0].SourceIndexName, "Expected index backup to match index name")
+	}
+}
+
+func (ts *IntegrationTests) TestCreateIndexFromBackup() {
+	if ts.indexType != "serverless" {
+		ts.T().Skip("Skipping backup tests for non-serverless indexes")
+	}
+	limit := 5
+	restoredIndexName := ts.idxName + "-from-backup"
+	createIndexFromBackupResp, err := ts.client.CreateIndexFromBackup(context.Background(), &CreateIndexFromBackupParams{
+		BackupId: ts.backupId,
+		Name:     restoredIndexName,
+	})
+	require.NoError(ts.T(), err)
+	require.NotNil(ts.T(), createIndexFromBackupResp, "Expected CreateIndexFromBackup response to be non-nil")
+
+	// validate describing restore job
+	restoreJob, err := ts.client.DescribeRestoreJob(context.Background(), createIndexFromBackupResp.RestoreJobId)
+	require.NoError(ts.T(), err)
+	require.Equal(ts.T(), createIndexFromBackupResp.RestoreJobId, restoreJob.RestoreJobId, "Expected restore job ID to match")
+	require.Equal(ts.T(), restoredIndexName, restoreJob.TargetIndexName)
+
+	// validate listing restore jobs
+	restoreJobs, err := ts.client.ListRestoreJobs(context.Background(), &ListRestoreJobsParams{Limit: &limit})
+	require.NoError(ts.T(), err)
+	require.NotNil(ts.T(), restoreJobs, "Expected restore jobs to be non-nil")
+
+	// wait until restore job completes
+	maxRetries := 10
+	for restoreJob.CompletedAt != nil || maxRetries > 0 {
+		time.Sleep(10 * time.Second)
+		restoreJob, err = ts.client.DescribeRestoreJob(context.Background(), createIndexFromBackupResp.RestoreJobId)
+		require.NoError(ts.T(), err)
+		maxRetries--
+	}
+
+	// validate describing the restored index
+	index, err := ts.client.DescribeIndex(context.Background(), restoredIndexName)
+	require.NoError(ts.T(), err)
+	require.NotNil(ts.T(), index, "Expected restored index to be non-nil")
+	require.Equal(ts.T(), restoredIndexName, index.Name, "Expected restored index name to match")
+}
+
 // Unit tests:
 func TestExtractAuthHeaderUnit(t *testing.T) {
 	globalApiKey := os.Getenv("PINECONE_API_KEY")

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -798,9 +798,9 @@ func (ts *IntegrationTests) TestCreateIndexFromBackupViaRestore() {
 	require.NotNil(ts.T(), restoreJobs, "Expected restore jobs to be non-nil")
 
 	// wait until restore job completes
-	maxRetries := 10
+	maxRetries := 5
 	for restoreJob.CompletedAt != nil || maxRetries > 0 {
-		time.Sleep(10 * time.Second)
+		time.Sleep(5 * time.Second)
 		restoreJob, err = ts.client.DescribeRestoreJob(context.Background(), createIndexFromBackupResp.RestoreJobId)
 		require.NoError(ts.T(), err)
 		maxRetries--

--- a/pinecone/index_connection_test.go
+++ b/pinecone/index_connection_test.go
@@ -244,35 +244,32 @@ func (ts *IntegrationTests) TestUpdateVectorMetadata() {
 	})
 	assert.NoError(ts.T(), err)
 
-	// TODO: re-enable once serverless freshness is more stable
-	if ts.indexType != "serverless" {
-		retryAssertionsWithDefaults(ts.T(), func() error {
-			vectors, err := ts.idxConn.FetchVectors(ctx, []string{ts.vectorIds[0]})
-			if err != nil {
-				return fmt.Errorf("Failed to fetch vector: %v", err)
+	retryAssertionsWithDefaults(ts.T(), func() error {
+		vectors, err := ts.idxConn.FetchVectors(ctx, []string{ts.vectorIds[0]})
+		if err != nil {
+			return fmt.Errorf("Failed to fetch vector: %v", err)
+		}
+
+		if vectors != nil && len(vectors.Vectors) > 0 {
+			vector := vectors.Vectors[ts.vectorIds[0]]
+			if vector == nil {
+				return fmt.Errorf("Fetched vector is nil after UpdateVector->FetchVector")
+			}
+			if vector.Metadata == nil {
+				return fmt.Errorf("Metadata is nil after update")
 			}
 
-			if vectors != nil && len(vectors.Vectors) > 0 {
-				vector := vectors.Vectors[ts.vectorIds[0]]
-				if vector == nil {
-					return fmt.Errorf("Fetched vector is nil after UpdateVector->FetchVector")
-				}
-				if vector.Metadata == nil {
-					return fmt.Errorf("Metadata is nil after update")
-				}
+			expectedGenre := expectedMetadataMap.Fields["genre"].GetStringValue()
+			actualGenre := vector.Metadata.Fields["genre"].GetStringValue()
 
-				expectedGenre := expectedMetadataMap.Fields["genre"].GetStringValue()
-				actualGenre := vector.Metadata.Fields["genre"].GetStringValue()
-
-				if expectedGenre != actualGenre {
-					return fmt.Errorf("Metadata does not match")
-				}
-			} else {
-				return fmt.Errorf("No vectors found after update")
+			if expectedGenre != actualGenre {
+				return fmt.Errorf("Metadata does not match")
 			}
-			return nil // Test passed
-		})
-	}
+		} else {
+			return fmt.Errorf("No vectors found after update")
+		}
+		return nil // Test passed
+	})
 }
 
 func (ts *IntegrationTests) TestUpdateVectorSparseValues() {
@@ -293,31 +290,28 @@ func (ts *IntegrationTests) TestUpdateVectorSparseValues() {
 	})
 	require.NoError(ts.T(), err)
 
-	// TODO: re-enable once serverless freshness is more stable
-	if ts.indexType != "serverless" {
-		// Fetch updated vector and verify sparse values
-		retryAssertionsWithDefaults(ts.T(), func() error {
-			vectors, err := ts.idxConn.FetchVectors(ctx, []string{ts.vectorIds[0]})
-			if err != nil {
-				return fmt.Errorf("Failed to fetch vector: %v", err)
-			}
+	// Fetch updated vector and verify sparse values
+	retryAssertionsWithDefaults(ts.T(), func() error {
+		vectors, err := ts.idxConn.FetchVectors(ctx, []string{ts.vectorIds[0]})
+		if err != nil {
+			return fmt.Errorf("Failed to fetch vector: %v", err)
+		}
 
-			vector := vectors.Vectors[ts.vectorIds[0]]
+		vector := vectors.Vectors[ts.vectorIds[0]]
 
-			if vector == nil {
-				return fmt.Errorf("Fetched vector is nil after UpdateVector->FetchVector")
-			}
-			if vector.SparseValues == nil {
-				return fmt.Errorf("Sparse values are nil after UpdateVector->FetchVector")
-			}
-			actualSparseValues := vector.SparseValues.Values
+		if vector == nil {
+			return fmt.Errorf("Fetched vector is nil after UpdateVector->FetchVector")
+		}
+		if vector.SparseValues == nil {
+			return fmt.Errorf("Sparse values are nil after UpdateVector->FetchVector")
+		}
+		actualSparseValues := vector.SparseValues.Values
 
-			if !slicesEqual[float32](expectedSparseValues.Values, actualSparseValues) {
-				return fmt.Errorf("Sparse values do not match")
-			}
-			return nil // Test passed
-		})
-	}
+		if !slicesEqual[float32](expectedSparseValues.Values, actualSparseValues) {
+			return fmt.Errorf("Sparse values do not match")
+		}
+		return nil // Test passed
+	})
 }
 
 func (ts *IntegrationTests) TestImportFlowHappyPath() {

--- a/pinecone/models.go
+++ b/pinecone/models.go
@@ -512,3 +512,81 @@ func (spv *SupportedParameterValue) UnmarshalJSON(data []byte) error {
 	}
 	return fmt.Errorf("unsupported type for SupportedParameterValue: %s", data)
 }
+
+// [Backup] describes the configuration and status of a Pinecone backup.
+//
+// Fields:
+//   - BackupId: Unique identifier for the backup.
+//   - Cloud: Cloud provider where the backup is stored.
+//   - CreatedAt: Timestamp when the backup was created.
+//   - Description: Optional description providing context for the backup.
+//   - Dimension: The dimensions of the vectors to be inserted in the index.
+//   - Metric: The distance metric to be used for similarity search. You can use 'euclidean', 'cosine', or 'dotproduct'. If the 'vector_type' is 'sparse', the metric must be 'dotproduct'. If the `vector_type` is `dense`, the metric defaults to 'cosine'.
+//   - Name: Optional user-defined name for the backup.
+//   - NamespaceCount: Number of namespaces in the backup.
+//   - RecordCount: Total number of records in the backup.
+//   - Region: Cloud region where the backup is stored.
+//   - SizeBytes: Size of the backup in bytes.
+//   - SourceIndexId: ID of the index.
+//   - SourceIndexName: Name of the index from which the backup was taken.
+//   - Status: Current status of the backup (e.g., Initializing, Ready, Failed).
+//   - Tags: Custom user tags added to an index. Keys must be 80 characters or less. Values must be 120 characters or less. Keys must be alphanumeric, '_', or '-'. Values must be alphanumeric, ';', '@', '_', '-', '.', '+', or ' '. To unset a key, set the value to an empty string.
+type Backup struct {
+	BackupId        string       `json:"backup_id"`
+	Cloud           string       `json:"cloud"`
+	CreatedAt       *string      `json:"created_at,omitempty"`
+	Description     *string      `json:"description,omitempty"`
+	Dimension       *int32       `json:"dimension,omitempty"`
+	Metric          *IndexMetric `json:"metric,omitempty"`
+	Name            *string      `json:"name,omitempty"`
+	NamespaceCount  *int         `json:"namespace_count,omitempty"`
+	RecordCount     *int         `json:"record_count,omitempty"`
+	Region          string       `json:"region"`
+	SizeBytes       *int         `json:"size_bytes,omitempty"`
+	SourceIndexId   string       `json:"source_index_id"`
+	SourceIndexName string       `json:"source_index_name"`
+	Status          string       `json:"status"`
+	Tags            *IndexTags   `json:"tags,omitempty"`
+}
+
+// [BackupList] contains a paginated list of backups.
+//
+// Fields:
+//   - Data: A list of [Backup] records.
+//   - Pagination: Pagination token for fetching the next page of results.
+type BackupList struct {
+	Data       []*Backup   `json:"data"`
+	Pagination *Pagination `json:"pagination,omitempty"`
+}
+
+// [RestoreJob] describes the status of a restore job.
+//
+// Fields:
+//   - BackupId: Backup used for the restore.
+//   - CompletedAt: Timestamp when the restore job finished.
+//   - CreatedAt: Timestamp when the restore job started.
+//   - PercentComplete: The progress made by the restore job out of 100.
+//   - RestoreJobId: Unique identifier for the restore job.
+//   - Status: Status of the restore job.
+//   - TargetIndexId: ID of the index.
+//   - TargetIndexName: Name of the index into which data is being restored.
+type RestoreJob struct {
+	BackupId        string     `json:"backup_id"`
+	CompletedAt     *time.Time `json:"completed_at,omitempty"`
+	CreatedAt       time.Time  `json:"created_at"`
+	PercentComplete *float32   `json:"percent_complete,omitempty"`
+	RestoreJobId    string     `json:"restore_job_id"`
+	Status          string     `json:"status"`
+	TargetIndexId   string     `json:"target_index_id"`
+	TargetIndexName string     `json:"target_index_name"`
+}
+
+// [RestoreJobList] contains a paginated list of restore jobs.
+//
+// Fields:
+//   - Data: A list of [RestoreJob] records.
+//   - Pagination: Pagination token for fetching the next page of results.
+type RestoreJobList struct {
+	Data       []*RestoreJob `json:"data"`
+	Pagination *Pagination   `json:"pagination,omitempty"`
+}

--- a/pinecone/test_suite.go
+++ b/pinecone/test_suite.go
@@ -174,15 +174,18 @@ func createCollection(ts *IntegrationTests, ctx context.Context) {
 
 func createBackup(ts *IntegrationTests, ctx context.Context) {
 	backupName := fmt.Sprintf("backup-%s", uuid.New().String())
+	backupDesc := fmt.Sprintf("Backup created for index %s for Pinecone integration tests", ts.idxName)
 	fmt.Printf("Creating backup: %s for index: %s\n", backupName, ts.idxName)
 
 	backup, err := ts.client.CreateBackup(ctx, &CreateBackupParams{
-		IndexName: ts.idxName,
-		Name:      &backupName,
+		IndexName:   ts.idxName,
+		Name:        &backupName,
+		Description: &backupDesc,
 	})
 
 	require.NoError(ts.T(), err)
 	require.Equal(ts.T(), backupName, *backup.Name)
+	require.Equal(ts.T(), backupDesc, *backup.Description)
 	ts.backupId = backup.BackupId
 
 	fmt.Printf("Successfully created backup with ID: %s\n", ts.backupId)

--- a/pinecone/test_suite.go
+++ b/pinecone/test_suite.go
@@ -22,6 +22,7 @@ type IntegrationTests struct {
 	indexType      string
 	vectorIds      []string
 	idxName        string
+	backupId       string
 	idxConn        *IndexConnection
 	collectionName string
 	sourceTag      string
@@ -83,6 +84,10 @@ func (ts *IntegrationTests) SetupSuite() {
 	if ts.indexType == "pods" {
 		createCollection(ts, ctx)
 	}
+	// Create backup for serverless index suite
+	if ts.indexType == "serverless" {
+		createBackup(ts, ctx)
+	}
 
 	fmt.Printf("\n %s set up suite completed successfully\n", ts.indexType)
 }
@@ -118,6 +123,12 @@ func (ts *IntegrationTests) TearDownSuite() {
 
 	if err != nil {
 		fmt.Printf("Failed to delete index \"%s\" after 4 retries: %v\n", ts.idxName, err)
+	}
+
+	// Delete backup
+	err = ts.client.DeleteBackup(ctx, ts.backupId)
+	if err != nil {
+		fmt.Printf("Failed to delete backup \"%s\": %v\n", ts.backupId, err)
 	}
 
 	fmt.Printf("\n %s setup suite torn down successfully\n", ts.indexType)
@@ -159,6 +170,37 @@ func createCollection(ts *IntegrationTests, ctx context.Context) {
 
 	require.NoError(ts.T(), err)
 	require.Equal(ts.T(), name, collection.Name)
+}
+
+func createBackup(ts *IntegrationTests, ctx context.Context) {
+	backupName := fmt.Sprintf("backup-%s", uuid.New().String())
+	fmt.Printf("Creating backup: %s for index: %s\n", backupName, ts.idxName)
+
+	backup, err := ts.client.CreateBackup(ctx, &CreateBackupParams{
+		IndexName: ts.idxName,
+		Name:      &backupName,
+	})
+
+	require.NoError(ts.T(), err)
+	require.Equal(ts.T(), backupName, *backup.Name)
+	ts.backupId = backup.BackupId
+
+	fmt.Printf("Successfully created backup with ID: %s\n", ts.backupId)
+	fmt.Printf("Waiting for backup to complete...\n")
+	retries := 5
+	for retries > 0 {
+		time.Sleep(5 * time.Second)
+		backupDesc, err := ts.client.DescribeBackup(ctx, ts.backupId)
+		require.NoError(ts.T(), err)
+
+		if backupDesc.Status == "Ready" || backupDesc.Status == "Failed" {
+			fmt.Printf("Backup \"%s\" is ready with status: %s\n", ts.backupId, backupDesc.Status)
+			return
+		}
+
+		fmt.Printf("Backup \"%s\" not ready yet, retrying... (%d retries left)\n", ts.backupId, retries-1)
+		retries--
+	}
 }
 
 func waitUntilIndexReady(ts *IntegrationTests, ctx context.Context) (bool, error) {

--- a/pinecone/test_suite.go
+++ b/pinecone/test_suite.go
@@ -112,7 +112,7 @@ func (ts *IntegrationTests) TearDownSuite() {
 	err = ts.client.DeleteIndex(ctx, ts.idxName)
 
 	// If the index failed to delete, wait a bit and retry cleaning up
-	// Somtimes indexes are stuck upgrading, or have pending collections
+	// Sometimes indexes are stuck upgrading, or have pending collections
 	retry := 4
 	for err != nil && retry > 0 {
 		time.Sleep(5 * time.Second)
@@ -126,9 +126,11 @@ func (ts *IntegrationTests) TearDownSuite() {
 	}
 
 	// Delete backup
-	err = ts.client.DeleteBackup(ctx, ts.backupId)
-	if err != nil {
-		fmt.Printf("Failed to delete backup \"%s\": %v\n", ts.backupId, err)
+	if ts.backupId != "" {
+		err = ts.client.DeleteBackup(ctx, ts.backupId)
+		if err != nil {
+			fmt.Printf("Failed to delete backup \"%s\": %v\n", ts.backupId, err)
+		}
 	}
 
 	fmt.Printf("\n %s setup suite torn down successfully\n", ts.indexType)
@@ -192,7 +194,7 @@ func createBackup(ts *IntegrationTests, ctx context.Context) {
 	fmt.Printf("Waiting for backup to complete...\n")
 	retries := 5
 	for retries > 0 {
-		time.Sleep(5 * time.Second)
+		time.Sleep(2 * time.Second)
 		backupDesc, err := ts.client.DescribeBackup(ctx, ts.backupId)
 		require.NoError(ts.T(), err)
 


### PR DESCRIPTION
## Problem
Backups/Restore are a part of the `2025-04` spec and need to be implemented in the Go client.

## Solution
Add new types for working with `Backups` and `RestoreJob` methods on `Client`:
- `Backup`
- `BackupList`
- `RestoreJob`
- `RestoreJobList`
- `CreateBackupParams`
- `CreateIndexFromBackupParams`
- `CreateIndexFromBackupResponse`
- `ListBackupsParams`
- `ListRestoreJobsParams`

Add new methods for working with backups as a part of `Client`:
- `CreateBackup`
- `CreateIndexFromBackup`
- `DescribeBackup`
- `DeleteBackup`
- `DescribeRestoreJob`
- `ListBackups`
- `ListRestoreJobs`

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
CI - unit & integration tests

New integration tests have been added to validate the create backup -> list/describe backups -> create index from backup -> list/describe restore jobs flow.

You can also test using the `README` or the integration tests themselves as example code:

```go
package main

import (
	"context"
	"fmt"
	"log"
	"os"
	"time"

	"github.com/pinecone-io/go-pinecone/v3/pinecone"
)
ctx := context.Background()

clientParams := pinecone.NewClientParams{
ApiKey: os.Getenv("PINECONE_API_KEY"),
}

pc, err := pinecone.NewClient(clientParams)
if err != nil {
log.Fatalf("Failed to create Client: %w", err)
}

indexName := "my-index"
backupName := fmt.Sprintf("backup-%s", )
backupDesc := fmt.Sprintf("Backup created for index %s", indexName)
fmt.Printf("Creating backup: %s for index: %s\n", backupName, indexName)

backup, err := pc.CreateBackup(ctx, &pinecone.CreateBackupParams{
    IndexName:   indexName,
    Name:        &backupName,
    Description: &backupDesc,
})
if err != nil {
    log.Fatalf("Failed to create backup: %w", err)
}

backup, err = pc.DescribeBackup(ctx, backup.BackupId)
if err != nil {
    log.Fatalf("Failed to describe backup: %w", err)
}

// wait for backup to be "Complete" before triggering a restore job
log.Printf("Backup status: %v", backup.Status)

limit := 10
backups, err := pc.ListBackups(ctx, &pinecone.ListBackupsParams{
    Limit: &limit,
    IndexName: &indexName,
})
if err != nil {
    log.Fatalf("Failed to list backups: %w", err)
}

// create a new serverless index from the backup
restoredIndexName := indexName + "-from-backup"
restoredIndexTags := IndexTags{"restored_on": time.Now().Format("2006-01-02 15:04")}
createIndexFromBackupResp, err := pc.CreateIndexFromBackup(context.Background(), &CreateIndexFromBackupParams{
    BackupId: ts.backupId,
    Name:     restoredIndexName,
    Tags:     &restoredIndexTags,
})

// check the status of the index restoration
restoreJob, err := pc.DescribeRestoreJob(ctx, restoreJob.RestoreJobId)
if err != nil {
    log.Fatalf("Failed to describe restore job: %w", err)
}
```


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209571416750587