### PR TITLE
Update `go.mod` to support v4.0.0 major version update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pinecone-io/go-pinecone/v3
+module github.com/pinecone-io/go-pinecone/v4
 
 go 1.21
 

--- a/internal/useragent/useragent.go
+++ b/internal/useragent/useragent.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pinecone-io/go-pinecone/v3/internal"
+	"github.com/pinecone-io/go-pinecone/v4/internal"
 )
 
 func getPackageVersion() string {

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -14,12 +14,12 @@ import (
 	"os"
 	"strings"
 
-	"github.com/pinecone-io/go-pinecone/v3/internal/gen"
-	"github.com/pinecone-io/go-pinecone/v3/internal/gen/db_control"
-	db_data_rest "github.com/pinecone-io/go-pinecone/v3/internal/gen/db_data/rest"
-	"github.com/pinecone-io/go-pinecone/v3/internal/gen/inference"
-	"github.com/pinecone-io/go-pinecone/v3/internal/provider"
-	"github.com/pinecone-io/go-pinecone/v3/internal/useragent"
+	"github.com/pinecone-io/go-pinecone/v4/internal/gen"
+	"github.com/pinecone-io/go-pinecone/v4/internal/gen/db_control"
+	db_data_rest "github.com/pinecone-io/go-pinecone/v4/internal/gen/db_data/rest"
+	"github.com/pinecone-io/go-pinecone/v4/internal/gen/inference"
+	"github.com/pinecone-io/go-pinecone/v4/internal/provider"
+	"github.com/pinecone-io/go-pinecone/v4/internal/useragent"
 	"google.golang.org/grpc"
 )
 

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -14,11 +14,10 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
-	"github.com/pinecone-io/go-pinecone/v3/internal/gen"
-	"github.com/pinecone-io/go-pinecone/v3/internal/gen/db_control"
-	"github.com/pinecone-io/go-pinecone/v3/internal/provider"
-
-	"github.com/pinecone-io/go-pinecone/v3/internal/utils"
+	"github.com/pinecone-io/go-pinecone/v4/internal/gen"
+	"github.com/pinecone-io/go-pinecone/v4/internal/gen/db_control"
+	"github.com/pinecone-io/go-pinecone/v4/internal/provider"
+	"github.com/pinecone-io/go-pinecone/v4/internal/utils"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pinecone/index_connection.go
+++ b/pinecone/index_connection.go
@@ -12,9 +12,9 @@ import (
 	"net/url"
 	"strings"
 
-	db_data_grpc "github.com/pinecone-io/go-pinecone/v3/internal/gen/db_data/grpc"
-	db_data_rest "github.com/pinecone-io/go-pinecone/v3/internal/gen/db_data/rest"
-	"github.com/pinecone-io/go-pinecone/v3/internal/useragent"
+	db_data_grpc "github.com/pinecone-io/go-pinecone/v4/internal/gen/db_data/grpc"
+	db_data_rest "github.com/pinecone-io/go-pinecone/v4/internal/gen/db_data/rest"
+	"github.com/pinecone-io/go-pinecone/v4/internal/useragent"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"

--- a/pinecone/index_connection_test.go
+++ b/pinecone/index_connection_test.go
@@ -7,8 +7,8 @@ import (
 	"log"
 	"testing"
 
-	db_data_grpc "github.com/pinecone-io/go-pinecone/v3/internal/gen/db_data/grpc"
-	"github.com/pinecone-io/go-pinecone/v3/internal/utils"
+	db_data_grpc "github.com/pinecone-io/go-pinecone/v4/internal/gen/db_data/grpc"
+	"github.com/pinecone-io/go-pinecone/v4/internal/utils"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/structpb"


### PR DESCRIPTION
## Problem
When releasing a new major version of a Go package, you need to update the `go.mod` file and associated imports. Here are examples of where this was done previously:

- https://github.com/pinecone-io/go-pinecone/pull/91
- https://github.com/pinecone-io/go-pinecone/pull/97

## Solution
Update for `v4`.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
CI - unit + integration
