### PR TITLE
Update `README` to use v4 instead of v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the official Go SDK for [Pinecone](https://www.pinecone.io).
 To see the latest documentation for `main`, visit https://pkg.go.dev/github.com/pinecone-io/go-pinecone@main/pinecone.
 
 To see the latest versioned-release's documentation,
-visit https://pkg.go.dev/github.com/pinecone-io/go-pinecone/v3/pinecone.
+visit https://pkg.go.dev/github.com/pinecone-io/go-pinecone/v4/pinecone.
 
 ## Features
 
@@ -24,7 +24,7 @@ See the [Pinecone API Docs](https://docs.pinecone.io/reference/) for more inform
 To upgrade the SDK to the latest version, run:
 
 ```shell
-go get -u github.com/pinecone-io/go-pinecone/v3/pinecone@latest
+go get -u github.com/pinecone-io/go-pinecone/v4/pinecone@latest
 ```
 
 ## Prerequisites
@@ -36,7 +36,7 @@ go get -u github.com/pinecone-io/go-pinecone/v3/pinecone@latest
 To install the Pinecone Go SDK, run the following in your terminal:
 
 ```shell
-go get github.com/pinecone-io/go-pinecone/v3/pinecone
+go get github.com/pinecone-io/go-pinecone/v4/pinecone
 ```
 
 For more information on setting up a Go project, see the [Go documentation](https://golang.org/doc/).
@@ -58,7 +58,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v3/pinecone"
+	"github.com/pinecone-io/go-pinecone/v4/pinecone"
 	"log"
 	"os"
 )
@@ -91,7 +91,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v3/pinecone"
+	"github.com/pinecone-io/go-pinecone/v4/pinecone"
 	"log"
 )
 
@@ -129,7 +129,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v3/pinecone"
+	"github.com/pinecone-io/go-pinecone/v4/pinecone"
 	"log"
 	"os"
 )
@@ -178,7 +178,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v3/pinecone"
+	"github.com/pinecone-io/go-pinecone/v4/pinecone"
 	"log"
 	"os"
 )
@@ -228,7 +228,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v3/pinecone"
+	"github.com/pinecone-io/go-pinecone/v4/pinecone"
 	"log"
 	"os"
 )
@@ -276,7 +276,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v3/pinecone"
+	"github.com/pinecone-io/go-pinecone/v4/pinecone"
 	"log"
 	"os"
 )
@@ -331,7 +331,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v3/pinecone"
+	"github.com/pinecone-io/go-pinecone/v4/pinecone"
 	"log"
 	"os"
 )
@@ -372,7 +372,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v3/pinecone"
+	"github.com/pinecone-io/go-pinecone/v4/pinecone"
 	"log"
 	"os"
 )
@@ -413,7 +413,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v3/pinecone"
+	"github.com/pinecone-io/go-pinecone/v4/pinecone"
 	"log"
 	"os"
 )
@@ -453,7 +453,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v3/pinecone"
+	"github.com/pinecone-io/go-pinecone/v4/pinecone"
 	"log"
 	"os"
 )
@@ -546,7 +546,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v3/pinecone"
+	"github.com/pinecone-io/go-pinecone/v4/pinecone"
 	"log"
 	"os"
 )
@@ -599,7 +599,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v3/pinecone"
+	"github.com/pinecone-io/go-pinecone/v4/pinecone"
 	"log"
 	"os"
 )
@@ -688,7 +688,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v3/pinecone"
+	"github.com/pinecone-io/go-pinecone/v4/pinecone"
 	"google.golang.org/protobuf/types/known/structpb"
 	"log"
 	"os"
@@ -763,7 +763,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v3/pinecone"
+	"github.com/pinecone-io/go-pinecone/v4/pinecone"
 	"google.golang.org/protobuf/types/known/structpb"
 	"log"
 	"os"
@@ -920,7 +920,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v3/pinecone"
+	"github.com/pinecone-io/go-pinecone/v4/pinecone"
 	"google.golang.org/protobuf/types/known/structpb"
 	"log"
 	"os"
@@ -1051,7 +1051,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v3/pinecone"
+	"github.com/pinecone-io/go-pinecone/v4/pinecone"
 	"log"
 	"os"
 )
@@ -1112,7 +1112,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v3/pinecone"
+	"github.com/pinecone-io/go-pinecone/v4/pinecone"
 	"log"
 	"os"
 )
@@ -1160,7 +1160,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v3/pinecone"
+	"github.com/pinecone-io/go-pinecone/v4/pinecone"
 	"google.golang.org/protobuf/types/known/structpb"
 	"log"
 	"os"
@@ -1215,7 +1215,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v3/pinecone"
+	"github.com/pinecone-io/go-pinecone/v4/pinecone"
 	"log"
 	"os"
 )
@@ -1263,7 +1263,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v3/pinecone"
+	"github.com/pinecone-io/go-pinecone/v4/pinecone"
 	"log"
 	"os"
 )
@@ -1343,7 +1343,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v3/pinecone"
+	"github.com/pinecone-io/go-pinecone/v4/pinecone"
 	"log"
 	"os"
 )
@@ -1399,7 +1399,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v3/pinecone"
+	"github.com/pinecone-io/go-pinecone/v4/pinecone"
 	"log"
 	"os"
 )
@@ -1476,7 +1476,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v3/pinecone"
+	"github.com/pinecone-io/go-pinecone/v4/pinecone"
 	"log"
 	"os"
 )
@@ -1517,7 +1517,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v3/pinecone"
+	"github.com/pinecone-io/go-pinecone/v4/pinecone"
 	"log"
 	"os"
 )
@@ -1562,7 +1562,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v3/pinecone"
+	"github.com/pinecone-io/go-pinecone/v4/pinecone"
 	"log"
 	"os"
 )
@@ -1600,7 +1600,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pinecone-io/go-pinecone/v3/pinecone"
+	"github.com/pinecone-io/go-pinecone/v4/pinecone"
 	"log"
 	"os"
 )

--- a/justfile
+++ b/justfile
@@ -20,5 +20,5 @@ bootstrap:
 gen:
   ./codegen/build-clients.sh {{api_version}}
 docs:
-  @echo "Serving docs at http://localhost:6060/pkg/github.com/pinecone-io/go-pinecone/v3/pinecone/"
+  @echo "Serving docs at http://localhost:6060/pkg/github.com/pinecone-io/go-pinecone/v4/pinecone/"
   @godoc -http=:6060 >/dev/null


### PR DESCRIPTION
## Problem
The major release for v4.0.0 updated the package route to 

## Solution
Update code examples in the `README` to use `/v4/` instead of `/v3/`. There was also a spot in the justfile where we spin up a local server for serving docs that needed a tweak too.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [X] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
N/A
