### PR TITLE
fix ensure https function

### DIFF
--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -329,9 +329,9 @@ func (c *Client) Index(in NewIndexConnParams, dialOpts ...grpc.DialOption) (*Ind
 }
 
 func ensureHostHasHttps(host string) string {
-	if strings.HasPrefix("http://", host) {
+	if strings.HasPrefix(host, "http://") {
 		return strings.Replace(host, "http://", "https://", 1)
-	} else if !strings.HasPrefix("https://", host) {
+	} else if !strings.HasPrefix(host, "https://") {
 		return "https://" + host
 	}
 

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -1772,6 +1772,37 @@ func TestBuildClientBaseOptionsUnit(t *testing.T) {
 	}
 }
 
+func TestEnsureHostHasHttpsUnit(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		expected string
+	}{
+		{
+			name:     "Host with https prefix should remain unchanged",
+			host:     "https://test-abcd.pinecone.io",
+			expected: "https://test-abcd.pinecone.io",
+		},
+		{
+			name:     "Host with http prefix should be converted to https",
+			host:     "http://test-abcd.pinecone.io",
+			expected: "https://test-abcd.pinecone.io",
+		},
+		{
+			name:     "Host without prefix should get https prefix",
+			host:     "test-abcd.pinecone.io",
+			expected: "https://test-abcd.pinecone.io",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ensureHostHasHttps(tt.host)
+			assert.Equal(t, tt.expected, result, "Expected result to be '%s', but got '%s'", tt.expected, result)
+		})
+	}
+}
+
 // Helper functions:
 func (ts *IntegrationTests) deleteIndex(name string) error {
 	_, err := waitUntilIndexReady(ts, context.Background())


### PR DESCRIPTION
## Problem

Describe the purpose of this change. What problem is being solved and why?
https double concatenated on go client search calls.  the has prefix function input is string followed by the prefix not the other way around.

## Solution

fix the bug on has prefix 
## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.
