### PR TITLE
Add `PrivateHost` to `Index`

### DIFF
--- a/internal/gen/db_control/db_control_2025-04.oas.go
+++ b/internal/gen/db_control/db_control_2025-04.oas.go
@@ -413,7 +413,10 @@ type IndexModel struct {
 
 	// Name The name of the index. Resource name must be 1-45 characters long, start and end with an alphanumeric character, and consist only of lower case alphanumeric characters or '-'.
 	Name string `json:"name"`
-	Spec struct {
+
+	// PrivateHost The private endpoint URL of an index.
+	PrivateHost *string `json:"private_host,omitempty"`
+	Spec        struct {
 		// Byoc Configuration needed to deploy an index in a BYOC environment.
 		Byoc *ByocSpec `json:"byoc,omitempty"`
 

--- a/internal/gen/db_data/grpc/db_data_2025-04.pb.go
+++ b/internal/gen/db_data/grpc/db_data_2025-04.pb.go
@@ -339,7 +339,7 @@ type UpsertRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// An array containing the vectors to upsert. Recommended batch limit is 100 vectors.
+	// An array containing the vectors to upsert. Recommended batch limit is up to 1000 vectors.
 	Vectors []*Vector `protobuf:"bytes,1,rep,name=vectors,proto3" json:"vectors,omitempty"`
 	// The namespace where you upsert vectors.
 	Namespace string `protobuf:"bytes,2,opt,name=namespace,proto3" json:"namespace,omitempty"`
@@ -454,8 +454,7 @@ type DeleteRequest struct {
 	Namespace string `protobuf:"bytes,3,opt,name=namespace,proto3" json:"namespace,omitempty"`
 	// If specified, the metadata filter here will be used to select the vectors to delete. This is mutually exclusive
 	// with specifying ids to delete in the ids param or using `delete_all=True`.
-	// For guidance and examples, see [Understanding metadata](https://docs.pinecone.io/guides/index-data/indexing-overview#metadata).
-	// Serverless indexes do not support delete by metadata. Instead, you can use the `list` operation to fetch the vector IDs based on their common ID prefix and then delete the records by ID.
+	// For guidance and examples, see [Delete data](https://docs.pinecone.io/guides/manage-data/delete-data#delete-records-by-metadata).
 	Filter *structpb.Struct `protobuf:"bytes,4,opt,name=filter,proto3" json:"filter,omitempty"`
 }
 
@@ -1022,7 +1021,7 @@ type QueryRequest struct {
 	Namespace string `protobuf:"bytes,1,opt,name=namespace,proto3" json:"namespace,omitempty"`
 	// The number of results to return for each query.
 	TopK uint32 `protobuf:"varint,2,opt,name=top_k,json=topK,proto3" json:"top_k,omitempty"`
-	// The filter to apply. You can use vector metadata to limit your search. See [Understanding metadata](https://docs.pinecone.io/guides/index-data/indexing-overview#metadata). You can use vector metadata to limit your search. See [Understanding metadata](https://docs.pinecone.io/guides/index-data/indexing-overview#metadata).
+	// The filter to apply. You can use vector metadata to limit your search. See [Understanding metadata](https://docs.pinecone.io/guides/index-data/indexing-overview#metadata).
 	Filter *structpb.Struct `protobuf:"bytes,3,opt,name=filter,proto3" json:"filter,omitempty"`
 	// Indicates whether vector values are included in the response.
 	IncludeValues bool `protobuf:"varint,4,opt,name=include_values,json=includeValues,proto3" json:"include_values,omitempty"`

--- a/internal/gen/db_data/grpc/db_data_2025-04_grpc.pb.go
+++ b/internal/gen/db_data/grpc/db_data_2025-04_grpc.pb.go
@@ -39,7 +39,7 @@ type VectorServiceClient interface {
 	//
 	// Upsert vectors into a namespace. If a new value is upserted for an existing vector ID, it will overwrite the previous value.
 	//
-	// For guidance and examples, see [Upsert data](https://docs.pinecone.io/guides/index-data/upsert-data#upsert-vectors).
+	// For guidance, examples, and limits, see [Upsert data](https://docs.pinecone.io/guides/index-data/upsert-data).
 	Upsert(ctx context.Context, in *UpsertRequest, opts ...grpc.CallOption) (*UpsertResponse, error)
 	// Delete vectors
 	//
@@ -67,7 +67,7 @@ type VectorServiceClient interface {
 	//
 	// Search a namespace with a query vector or record ID and return the IDs of the most similar records, along with their similarity scores.
 	//
-	// For guidance and examples, see [Search](https://docs.pinecone.io/guides/search/semantic-search).
+	// For guidance, examples, and limits, see [Search](https://docs.pinecone.io/guides/search/search-overview).
 	Query(ctx context.Context, in *QueryRequest, opts ...grpc.CallOption) (*QueryResponse, error)
 	// Update a vector
 	//
@@ -81,13 +81,15 @@ type VectorServiceClient interface {
 	//
 	// Serverless indexes scale automatically as needed, so index fullness is relevant only for pod-based indexes.
 	DescribeIndexStats(ctx context.Context, in *DescribeIndexStatsRequest, opts ...grpc.CallOption) (*DescribeIndexStatsResponse, error)
-	// Get list of all namespaces
+	// List namespaces
 	//
-	// Get a list of all namespaces within an index.
+	// Get a list of all [namespaces](https://docs.pinecone.io/guides/index-data/indexing-overview#namespaces) in a serverless index.
+	//
+	// Up to 100 namespaces are returned at a time by default, in sorted order (bitwise “C” collation). If the `limit` parameter is set, up to that number of namespaces are returned instead. Whenever there are additional namespaces to return, the response also includes a `pagination_token` that you can use to get the next batch of namespaces. When the response does not include a `pagination_token`, there are no more namespaces to return.
 	ListNamespaces(ctx context.Context, in *ListNamespacesRequest, opts ...grpc.CallOption) (*ListNamespacesResponse, error)
 	// Describe a namespace
 	//
-	// Describe a namespace within an index, showing the vector count within the namespace.
+	// Describe a [namespace](https://docs.pinecone.io/guides/index-data/indexing-overview#namespaces) in a serverless index, including the total number of vectors in the namespace.
 	DescribeNamespace(ctx context.Context, in *DescribeNamespaceRequest, opts ...grpc.CallOption) (*NamespaceDescription, error)
 	// Delete a namespace
 	//
@@ -201,7 +203,7 @@ type VectorServiceServer interface {
 	//
 	// Upsert vectors into a namespace. If a new value is upserted for an existing vector ID, it will overwrite the previous value.
 	//
-	// For guidance and examples, see [Upsert data](https://docs.pinecone.io/guides/index-data/upsert-data#upsert-vectors).
+	// For guidance, examples, and limits, see [Upsert data](https://docs.pinecone.io/guides/index-data/upsert-data).
 	Upsert(context.Context, *UpsertRequest) (*UpsertResponse, error)
 	// Delete vectors
 	//
@@ -229,7 +231,7 @@ type VectorServiceServer interface {
 	//
 	// Search a namespace with a query vector or record ID and return the IDs of the most similar records, along with their similarity scores.
 	//
-	// For guidance and examples, see [Search](https://docs.pinecone.io/guides/search/semantic-search).
+	// For guidance, examples, and limits, see [Search](https://docs.pinecone.io/guides/search/search-overview).
 	Query(context.Context, *QueryRequest) (*QueryResponse, error)
 	// Update a vector
 	//
@@ -243,13 +245,15 @@ type VectorServiceServer interface {
 	//
 	// Serverless indexes scale automatically as needed, so index fullness is relevant only for pod-based indexes.
 	DescribeIndexStats(context.Context, *DescribeIndexStatsRequest) (*DescribeIndexStatsResponse, error)
-	// Get list of all namespaces
+	// List namespaces
 	//
-	// Get a list of all namespaces within an index.
+	// Get a list of all [namespaces](https://docs.pinecone.io/guides/index-data/indexing-overview#namespaces) in a serverless index.
+	//
+	// Up to 100 namespaces are returned at a time by default, in sorted order (bitwise “C” collation). If the `limit` parameter is set, up to that number of namespaces are returned instead. Whenever there are additional namespaces to return, the response also includes a `pagination_token` that you can use to get the next batch of namespaces. When the response does not include a `pagination_token`, there are no more namespaces to return.
 	ListNamespaces(context.Context, *ListNamespacesRequest) (*ListNamespacesResponse, error)
 	// Describe a namespace
 	//
-	// Describe a namespace within an index, showing the vector count within the namespace.
+	// Describe a [namespace](https://docs.pinecone.io/guides/index-data/indexing-overview#namespaces) in a serverless index, including the total number of vectors in the namespace.
 	DescribeNamespace(context.Context, *DescribeNamespaceRequest) (*NamespaceDescription, error)
 	// Delete a namespace
 	//

--- a/internal/gen/db_data/rest/db_data_2025-04.oas.go
+++ b/internal/gen/db_data/rest/db_data_2025-04.oas.go
@@ -44,8 +44,7 @@ type DeleteRequest struct {
 	// DeleteAll This indicates that all vectors in the index namespace should be deleted.
 	DeleteAll *bool `json:"deleteAll,omitempty"`
 
-	// Filter If specified, the metadata filter here will be used to select the vectors to delete. This is mutually exclusive with specifying ids to delete in the ids param or using delete_all=True. See [Understanding metadata](https://docs.pinecone.io/guides/index-data/indexing-overview#metadata).
-	// Serverless indexes do not support delete by metadata. Instead, you can use the `list` operation to fetch the vector IDs based on their common ID prefix and then delete the records by ID.
+	// Filter If specified, the metadata filter here will be used to select the vectors to delete. This is mutually exclusive with specifying ids to delete in the ids param or using delete_all=True. See [Delete data](https://docs.pinecone.io/guides/manage-data/delete-data#delete-records-by-metadata).
 	Filter *map[string]interface{} `json:"filter,omitempty"`
 
 	// Ids Vectors to delete.
@@ -202,7 +201,7 @@ type Pagination struct {
 
 // QueryRequest The request for the `query` operation.
 type QueryRequest struct {
-	// Filter The filter to apply. You can use vector metadata to limit your search. See [Understanding metadata](https://docs.pinecone.io/guides/index-data/indexing-overview#metadata). You can use vector metadata to limit your search. See [Understanding metadata](https://docs.pinecone.io/guides/index-data/indexing-overview#metadata).
+	// Filter The filter to apply. You can use vector metadata to limit your search. See [Understanding metadata](https://docs.pinecone.io/guides/index-data/indexing-overview#metadata).
 	Filter *map[string]interface{} `json:"filter,omitempty"`
 
 	// Id The unique ID of the vector to be used as a query vector. Each request  can contain either the `vector` or `id` parameter.
@@ -422,7 +421,7 @@ type UpsertRequest struct {
 	// Namespace The namespace where you upsert vectors.
 	Namespace *string `json:"namespace,omitempty"`
 
-	// Vectors An array containing the vectors to upsert. Recommended batch limit is 100 vectors.
+	// Vectors An array containing the vectors to upsert. Recommended batch limit is up to 1000 vectors.
 	Vectors []Vector `json:"vectors"`
 }
 

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -2406,6 +2406,7 @@ func toIndex(idx *db_control.IndexModel) *Index {
 	return &Index{
 		Name:               idx.Name,
 		Host:               idx.Host,
+		PrivateHost:        idx.PrivateHost,
 		Metric:             IndexMetric(idx.Metric),
 		VectorType:         idx.VectorType,
 		DeletionProtection: DeletionProtection(deletionProtection),

--- a/pinecone/models.go
+++ b/pinecone/models.go
@@ -114,8 +114,8 @@ type Index struct {
 	Metric             IndexMetric        `json:"metric"`
 	VectorType         string             `json:"vector_type"`
 	DeletionProtection DeletionProtection `json:"deletion_protection,omitempty"`
-	PrivateHost        *string            `json:"private_host"`
-	Dimension          *int32             `json:"dimension"`
+	PrivateHost        *string            `json:"private_host,omitempty"`
+	Dimension          *int32             `json:"dimension,omitempty"`
 	Spec               *IndexSpec         `json:"spec,omitempty"`
 	Status             *IndexStatus       `json:"status,omitempty"`
 	Tags               *IndexTags         `json:"tags,omitempty"`

--- a/pinecone/models.go
+++ b/pinecone/models.go
@@ -95,12 +95,26 @@ type IndexEmbed struct {
 type IndexTags map[string]string
 
 // [Index] is a Pinecone [Index] object. Can be either a pod-based or a serverless [Index], depending on the [IndexSpec].
+//
+// Fields:
+//   - Name: The name of the index.
+//   - Host: The URL address where the index is hosted.
+//   - Metric: The distance metric used for similarity search. One of 'euclidean', 'cosine', or 'dotproduct'.
+//   - VectorType: The index vector type. One of 'sparse' or 'dense'.
+//   - DeletionProtection: Whether deletion protection is configured for the index. Can be 'enabled' or 'disabled'.
+//   - PrivateHost: The private endpoint URL of an index.
+//   - Dimension: The dimensions of vectors stored in the index. Required for dense indexes.
+//   - Spec: The infrastructure configuration for the index. Contains either [PodSpec] or [ServerlessSpec].
+//   - Status: The [IndexStatus] of the index, which includes index state information.
+//   - Tags: Custom [IndexTags] added to an index.
+//   - Embed: The [IndexEmbed] model configured for the index, if applicable.
 type Index struct {
 	Name               string             `json:"name"`
 	Host               string             `json:"host"`
 	Metric             IndexMetric        `json:"metric"`
 	VectorType         string             `json:"vector_type"`
 	DeletionProtection DeletionProtection `json:"deletion_protection,omitempty"`
+	PrivateHost        *string            `json:"private_host"`
 	Dimension          *int32             `json:"dimension"`
 	Spec               *IndexSpec         `json:"spec,omitempty"`
 	Status             *IndexStatus       `json:"status,omitempty"`
@@ -109,6 +123,14 @@ type Index struct {
 }
 
 // [Collection] is a Pinecone [collection entity]. Only available for pod-based Indexes.
+//
+// Fields:
+//   - Name: The name of the collection.
+//   - Size: The total size of the collection in bytes.
+//   - Status: The [CollectionStatus] of the collection.
+//   - Dimension: The dimensionality of the each vectors for each record stored in the collection.
+//   - VectorCount: The number of records (vectors) stored in the collection.
+//   - Environment: The environment where the collection is hosted.
 //
 // [collection entity]: https://docs.pinecone.io/guides/indexes/understanding-collections
 type Collection struct {
@@ -135,6 +157,17 @@ type PodSpecMetadataConfig struct {
 }
 
 // [PodSpec] is the infrastructure specification of a pod-based Pinecone [Index]. Only available for pod-based Indexes.
+//
+// Fields:
+//   - Environment: The environment where the index is hosted.
+//   - PodType: The pod type used for the index. Must be one of "s1", "p1", or "p2"
+//     followed by ".x1", ".x2", ".x4", or ".x8".
+//   - PodCount: The number of pods used for the index. Should equal `shards` × `replicas`.
+//   - Replicas: The number of replicas. Replicas duplicate the index. They provide higher availability and throughput.
+//   - ShardCount: The number of shards. Shards split your data across multiple pods so you can fit more data into an index.
+//   - SourceCollection: The name of the [Collection] used as a source for the index.
+//   - MetadataConfig: Configuration for the behavior of Pinecone's internal metadata index. By default, all metadata is indexed;
+//     when `metadata_config` is present, only specified metadata fields are indexed.
 type PodSpec struct {
 	Environment      string                 `json:"environment"`
 	PodType          string                 `json:"pod_type"`
@@ -146,6 +179,10 @@ type PodSpec struct {
 }
 
 // [ServerlessSpec] is the infrastructure specification of a serverless Pinecone [Index]. Only available for serverless Indexes.
+//
+// Fields:
+//   - Cloud: The public cloud provider where the index is hosted.
+//   - Region: The region where the index is hosted.
 type ServerlessSpec struct {
 	Cloud  Cloud  `json:"cloud"`
 	Region string `json:"region"`

--- a/pinecone/models_test.go
+++ b/pinecone/models_test.go
@@ -230,7 +230,7 @@ func TestMarshalIndexUnit(t *testing.T) {
 		{
 			name:  "Fields omitted",
 			input: Index{},
-			want:  `{"name":"","host":"","metric":"","vector_type":"","dimension":null}`,
+			want:  `{"name":"","host":"","metric":"","vector_type":""}`,
 		},
 		{
 			name: "Fields empty",
@@ -242,7 +242,7 @@ func TestMarshalIndexUnit(t *testing.T) {
 				Spec:      nil,
 				Status:    nil,
 			},
-			want: `{"name":"","host":"","metric":"","vector_type":"","dimension":null}`,
+			want: `{"name":"","host":"","metric":"","vector_type":""}`,
 		},
 	}
 


### PR DESCRIPTION
## Problem
`PrivateHost` is available in the `2025-04` API, but was not included as a part of the previous generation cycles, and we want to expose it on the `Index` struct.


## Solution

- Regenerate 2025-04 core, add PrivateHost to Index and decode as a part of unmarshalling the API response.
- Update doc comments that are missing some detail.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
CI - unit & integration tests
