### PR TITLE
Add PercentComplete and RecordsImported fields to Import object construction

### DIFF
--- a/pinecone/index_connection.go
+++ b/pinecone/index_connection.go
@@ -1901,6 +1901,8 @@ func toImport(importModel *db_data_rest.ImportModel) *Import {
 		CreatedAt:  importModel.CreatedAt,
 		FinishedAt: importModel.FinishedAt,
 		Error:      importModel.Error,
+		PercentComplete: derefOrDefault(importModel.PercentComplete, 0),
+		RecordsImported: derefOrDefault(importModel.RecordsImported, 0),
 	}
 }
 


### PR DESCRIPTION
## Problem

`IndexConnection.DescribeImport` returns an `Import` object with `PercentComplete` and `RecordsImported` fields being always 0, because they are not passed to `Import` object construction in `toImport` function.

## Solution

Add `PercentComplete` and `PercentComplete` fields passing to `Import` object construction in `toImport` function.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

- Start a batch import using `IndexConnection.StartImport`
- Continuously call `IndexConnection.DescribeImport`
- Verify that the returned `Import` object's fields have proper values
