### PR TITLE
Add `SourceCollection` to `CreateServerlessIndexRequest`

### DIFF
--- a/internal/gen/db_control/db_control_2025-04.oas.go
+++ b/internal/gen/db_control/db_control_2025-04.oas.go
@@ -573,6 +573,9 @@ type ServerlessSpec struct {
 
 	// Region The region where you would like your index to be created.
 	Region string `json:"region"`
+
+	// SourceCollection The name of the collection to be used as the source for the index.
+	SourceCollection *string `json:"source_collection,omitempty"`
 }
 
 // ServerlessSpecCloud The public cloud where you would like your index hosted.

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -631,6 +631,8 @@ func (c *Client) CreatePodIndex(ctx context.Context, in *CreatePodIndexRequest) 
 //   - VectorType: (Optional) The index vector type. You can use `dense` or `sparse`. If `dense`, the vector dimension must be specified.
 //     If `sparse`, the vector dimension should not be specified, and the Metric must be set to `dotproduct`. Defaults to `dense`.
 //   - Tags: (Optional) A map of tags to associate with the Index.
+//   - SourceCollection: (Optional) The name of the [Collection] to use as the source for the index. NOTE: Collections can only be created
+//     from pods-based indexes.
 //
 // To create a new Serverless Index, use the [Client.CreateServerlessIndex] method.
 //
@@ -681,6 +683,7 @@ type CreateServerlessIndexRequest struct {
 	Dimension          *int32
 	VectorType         *string
 	Tags               *IndexTags
+	SourceCollection   *string
 }
 
 // [Client.CreateServerlessIndex] creates and initializes a new serverless Index via the specified [Client].
@@ -772,8 +775,9 @@ func (c *Client) CreateServerlessIndex(ctx context.Context, in *CreateServerless
 		VectorType:         vectorType,
 		Spec: db_control.IndexSpec{
 			Serverless: &db_control.ServerlessSpec{
-				Cloud:  db_control.ServerlessSpecCloud(in.Cloud),
-				Region: in.Region,
+				Cloud:            db_control.ServerlessSpecCloud(in.Cloud),
+				Region:           in.Region,
+				SourceCollection: in.SourceCollection,
 			},
 		},
 		Tags: tags,

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -2377,8 +2377,9 @@ func toIndex(idx *db_control.IndexModel) *Index {
 	}
 	if idx.Spec.Serverless != nil {
 		spec.Serverless = &ServerlessSpec{
-			Cloud:  Cloud(idx.Spec.Serverless.Cloud),
-			Region: idx.Spec.Serverless.Region,
+			Cloud:            Cloud(idx.Spec.Serverless.Cloud),
+			Region:           idx.Spec.Serverless.Region,
+			SourceCollection: idx.Spec.Serverless.SourceCollection,
 		}
 	}
 	status := &IndexStatus{

--- a/pinecone/models.go
+++ b/pinecone/models.go
@@ -183,9 +183,11 @@ type PodSpec struct {
 // Fields:
 //   - Cloud: The public cloud provider where the index is hosted.
 //   - Region: The region where the index is hosted.
+//   - SourceCollection: The name of the [Collection] used as a source for the index.
 type ServerlessSpec struct {
-	Cloud  Cloud  `json:"cloud"`
-	Region string `json:"region"`
+	Cloud            Cloud   `json:"cloud"`
+	Region           string  `json:"region"`
+	SourceCollection *string `json:"source_collection,omitempty"`
 }
 
 // [Vector] is a [dense or sparse vector object] with optional metadata.


### PR DESCRIPTION
## Problem
The `2025-04` version of the API supports passing `source_collection` as a part of `ServerlessSpec` as a means of migrating pod indexes. This is currently not supported through the Go SDK.

## Solution
- Regenerate `2025-04` from latest.
- Add `SourceCollection` to `CreateServerlessIndexRequest` and `ServerlessSpec`.
- Update `toIndex` to properly apply `SourceCollection` from API responses when converting types.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
CI - unit & integration tests
