### PR TITLE
Update `NewAdminClientParams` to support `AccessToken`

### DIFF
--- a/pinecone/admin_client.go
+++ b/pinecone/admin_client.go
@@ -153,7 +153,7 @@ func NewAdminClientWithContext(ctx context.Context, in NewAdminClientParams) (*A
 			return nil, fmt.Errorf("no ClientSecret provided, please pass an ClientSecret for authorization through NewAdminClientParams or set the PINECONE_CLIENT_SECRET environment variable")
 		}
 
-		authToken, err := getAuthTokenFunc(ctx, in.ClientId, in.ClientSecret, clientOptions...)
+		authToken, err := getAuthTokenFunc(ctx, clientId, clientSecret, clientOptions...)
 		if err != nil {
 			return nil, err
 		}

--- a/pinecone/admin_client.go
+++ b/pinecone/admin_client.go
@@ -34,261 +34,84 @@ type AdminClient struct {
 	APIKey APIKeyClient
 }
 
-// [ProjectClient] defines operations for managing Pinecone projects.
+// [ProjectClient] provides an interface for managing Pinecone projects.
 type ProjectClient interface {
-	// Creates a new project.
-	//
-	// Parameters:
-	//   - ctx: The request context.
-	//   - in: A pointer to [CreateProjectParams] containing the new project's configuration.
-	//
-	// Returns a pointer to a [Project] or an error.
-	//
-	// Example:
-	//
-	//	ctx := context.Background()
-	//	project, err := adminClient.Project.Create(ctx, &pinecone.CreateProjectParams{
-	//		Name: "example-project",
-	//	})
-	//	if err != nil {
-	//		log.Fatal(err)
-	//	}
+	// Create a new project.
 	Create(ctx context.Context, in *CreateProjectParams) (*Project, error)
 
-	// Updates an existing project by ID.
-	//
-	// Parameters:
-	//   - ctx: The request context.
-	//   - projectId: The ID of the project to update.
-	//   - in: A pointer to [UpdateProjectParams] containing the updated project configuration.
-	//
-	// Returns the updated [Project] or an error.
-	//
-	// Example:
-	//
-	//	project, err := adminClient.Project.Update(ctx, "project-id", &pinecone.UpdateProjectParams{
-	//		Name: "renamed-project",
-	//	})
-	//	if err != nil {
-	//		log.Fatal(err)
-	//	}
+	// Update an existing project by ID.
 	Update(ctx context.Context, projectId string, in *UpdateProjectParams) (*Project, error)
 
-	// Lists all projects available to the authenticated service account.
-	//
-	// Parameters:
-	//   - ctx: The request context.
-	//
-	// Returns a slice of [Project] objects or an error.
-	//
-	// Example:
-	//
-	//	projects, err := adminClient.Project.List(ctx)
-	//	if err != nil {
-	//		log.Fatal(err)
-	//	}
+	// List all projects available to the authenticated service account.
 	List(ctx context.Context) ([]*Project, error)
 
-	// Describes an existing project by ID.
-	//
-	// Parameters:
-	//   - ctx: The request context.
-	//   - projectId: The ID of the project to describe.
-	//
-	// Returns a pointer to a [Project] or an error.
-	//
-	// Example:
-	//
-	//	project, err := adminClient.Project.Describe(ctx, "project-id")
-	//	if err != nil {
-	//		log.Fatal(err)
-	//	}
+	// Describe an existing project by ID.
 	Describe(ctx context.Context, projectId string) (*Project, error)
 
-	// Deletes a project by ID.
-	//
-	// Parameters:
-	//   - ctx: The request context.
-	//   - projectId: The ID of the project to delete.
-	//
-	// Returns an error if deletion fails.
-	//
-	// Example:
-	//
-	//	err := adminClient.Project.Delete(ctx, "project-id")
-	//	if err != nil {
-	//		log.Fatal(err)
-	//	}
+	// Delete a project by ID.
 	Delete(ctx context.Context, projectId string) error
 }
 
-// [OrganizationClient] defines operations for managing organizations.
+// [OrganizationClient] provides an interface for managing organizations.
 type OrganizationClient interface {
-	// Lists all organizations available to the authenticated service account.
-	//
-	// Parameters:
-	//   - ctx: The request context.
-	//
-	// Returns a slice of [Organization] objects or an error.
-	//
-	// Example:
-	//
-	//	orgs, err := adminClient.Organization.List(ctx)
-	//	if err != nil {
-	//		log.Fatal(err)
-	//	}
+	// List all organizations available to the authenticated service account.
 	List(ctx context.Context) ([]*Organization, error)
 
-	// Describes an organization by ID.
-	//
-	// Parameters:
-	//   - ctx: The request context.
-	//   - organizationId: The ID of the organization to describe.
-	//
-	// Returns a pointer to an [Organization] or an error.
-	//
-	// Example:
-	//
-	//	org, err := adminClient.Organization.Describe(ctx, "organization-id")
-	//	if err != nil {
-	//		log.Fatal(err)
-	//	}
+	// Describe an organization by ID.
 	Describe(ctx context.Context, organizationId string) (*Organization, error)
 
-	// Updates an existing organization by ID.
-	//
-	// Parameters:
-	//   - ctx: The request context.
-	//   - organizationId: The ID of the organization to update.
-	//   - in: A pointer to [UpdateOrganizationParams] containing updated fields.
-	//
-	// Returns the updated [Organization] or an error.
-	//
-	// Example:
-	//
-	//	org, err := adminClient.Organization.Update(ctx, "organization-id", &pinecone.UpdateOrganizationParams{
-	//		Name: "Renamed Org",
-	//	})
-	//	if err != nil {
-	//		log.Fatal(err)
-	//	}
+	// Update an existing organization by ID.
 	Update(ctx context.Context, organizationId string, in *UpdateOrganizationParams) (*Organization, error)
 
-	// Deletes an organization by ID. All projects within the organization must be deleted first.
-	//
-	// Parameters:
-	//   - ctx: The request context.
-	//   - organizationId: The ID of the organization to delete.
-	//
-	// Returns an error if deletion fails.
-	//
-	// Example:
-	//
-	//	err := adminClient.Organization.Delete(ctx, "organization-id")
-	//	if err != nil {
-	//		log.Fatal(err)
-	//	}
+	// Delete an organization by ID. All projects within the organization must be deleted first.
 	Delete(ctx context.Context, organizationId string) error
 }
 
-// [APIKeyClient] defines operations for managing API keys within a project.
+// [APIKeyClient] provides an interface for managing API keys within a project.
 type APIKeyClient interface {
-	// Creates a new API key.
-	//
-	// Parameters:
-	//   - ctx: The request context.
-	//   - projectId: The ID of the project in which to create the API key.
-	//   - in: A pointer to [CreateAPIKeyParams] containing the API key configuration.
-	//
-	// Returns a pointer to an [APIKeyWithSecret] or an error.
-	//
-	// Example:
-	//
-	//	apiKeyWithSecret, err := adminClient.APIKey.Create(ctx, "project-id", &pinecone.CreateAPIKeyParams{
-	//		Name: "my-api-key",
-	//	})
-	//	if err != nil {
-	//		log.Fatal(err)
-	//	}
+	// Create a new API key.
 	Create(ctx context.Context, projectId string, in *CreateAPIKeyParams) (*APIKeyWithSecret, error)
 
-	// Updates an existing API key by ID.
-	//
-	// Parameters:
-	//   - ctx: The request context.
-	//   - apiKeyId: The ID of the API key to update.
-	//   - in: A pointer to [UpdateAPIKeyParams] containing updated fields.
-	//
-	// Returns the updated [APIKey] or an error.
-	//
-	// Example:
-	//
-	//	apiKey, err := adminClient.APIKey.Update(ctx, "api-key-id", &pinecone.UpdateAPIKeyParams{
-	//		Name: "updated-name",
-	//	})
-	//	if err != nil {
-	//		log.Fatal(err)
-	//	}
+	// Update an existing API key by ID.
 	Update(ctx context.Context, apiKeyId string, in *UpdateAPIKeyParams) (*APIKey, error)
 
-	// Lists all API keys within a project.
-	//
-	// Parameters:
-	//   - ctx: The request context.
-	//   - projectId: The ID of the project to list API keys for.
-	//
-	// Returns a slice of [APIKey] objects or an error.
-	//
-	// Example:
-	//
-	//	apiKeys, err := adminClient.APIKey.List(ctx, "project-id")
-	//	if err != nil {
-	//		log.Fatal(err)
-	//	}
+	// List all API keys within a project by project ID.
 	List(ctx context.Context, projectId string) ([]*APIKey, error)
 
-	// Describes an API key by ID.
-	//
-	// Parameters:
-	//   - ctx: The request context.
-	//   - apiKeyId: The ID of the API key to describe.
-	//
-	// Returns a pointer to an [APIKey] or an error.
-	//
-	// Example:
-	//
-	//	apiKey, err := adminClient.APIKey.Describe(ctx, "api-key-id")
-	//	if err != nil {
-	//		log.Fatal(err)
-	//	}
+	// Describe an API key by ID.
 	Describe(ctx context.Context, apiKeyId string) (*APIKey, error)
 
-	// Deletes an API key by ID.
-	//
-	// Parameters:
-	//   - ctx: The request context.
-	//   - apiKeyId: The ID of the API key to delete.
-	//
-	// Returns an error if deletion fails.
-	//
-	// Example:
-	//
-	//	err := adminClient.APIKey.Delete(ctx, "api-key-id")
-	//	if err != nil {
-	//		log.Fatal(err)
-	//	}
+	// Delete an API key by ID.
 	Delete(ctx context.Context, apiKeyId string) error
 }
 
+// [DefaultProjectClient] is the default implementation of [ProjectClient].
+type DefaultProjectClient struct {
+	restClient *admin.Client
+}
+
+// [DefaultOrganizationClient] is the default implementation of [OrganizationClient].
+type DefaultOrganizationClient struct {
+	restClient *admin.Client
+}
+
+// [DefaultApiKeyClient] is the default implementation of [APIKeyClient].
+type DefaultApiKeyClient struct {
+	restClient *admin.Client
+}
+
 // [NewAdminClientParams] contains parameters used to configure the [AdminClient].
-// You must provide a client ID and secret either directly or via environment
-// variables (PINECONE_CLIENT_ID and PINECONE_CLIENT_SECRET).
+// You must provide either a client ID and secret, or an access token, either directly or via environment
+// variables (PINECONE_CLIENT_ID, PINECONE_CLIENT_SECRET, PINECONE_ACCESS_TOKEN).
 type NewAdminClientParams struct {
 	// The OAuth client ID used for authentication.
 	ClientId string
 
 	// The OAuth client secret used for authentication.
 	ClientSecret string
+
+	// The OAuth access token used for authentication.
+	AccessToken string
 
 	// (Optional) Additional headers to include in the request.
 	Headers *map[string]string
@@ -312,45 +135,57 @@ func NewAdminClient(in NewAdminClientParams) (*AdminClient, error) {
 // cancellation of the authentication request. It validates the client ID and secret
 // from the input or environment, authenticates, and constructs an authorized [AdminClient].
 func NewAdminClientWithContext(ctx context.Context, in NewAdminClientParams) (*AdminClient, error) {
-	osClientId := os.Getenv("PINECONE_CLIENT_ID")
-	osClientSecret := os.Getenv("PINECONE_CLIENT_SECRET")
-	hasClientId := valueOrFallback(in.ClientId, osClientId) != ""
-	hasClientSecret := valueOrFallback(in.ClientSecret, osClientSecret) != ""
-
-	if !hasClientId {
-		return nil, fmt.Errorf("no ClientId provided, please pass an ClientId for authorization through NewAdminClientParams or set the PINECONE_CLIENT_ID environment variable")
-	}
-	if !hasClientSecret {
-		return nil, fmt.Errorf("no ClientSecret provided, please pass an ClientSecret for authorization through NewAdminClientParams or set the PINECONE_CLIENT_SECRET environment variable")
-	}
-
+	var authHeader string
 	clientOptions := buildAdminClientOptions(in)
 
-	authToken, err := getAuthToken(ctx, in.ClientId, in.ClientSecret, clientOptions...)
-	if err != nil {
-		return nil, err
+	accessToken := valueOrFallback(in.AccessToken, os.Getenv("PINECONE_ACCESS_TOKEN"))
+	if accessToken != "" {
+		// Use access token directly if provided
+		authHeader = fmt.Sprintf("Bearer %s", accessToken)
+	} else {
+		// Fall back to client ID and secret if access token is not provided
+		clientId := valueOrFallback(in.ClientId, os.Getenv("PINECONE_CLIENT_ID"))
+		clientSecret := valueOrFallback(in.ClientSecret, os.Getenv("PINECONE_CLIENT_SECRET"))
+		if clientId == "" {
+			return nil, fmt.Errorf("no ClientId provided, please pass an ClientId for authorization through NewAdminClientParams or set the PINECONE_CLIENT_ID environment variable")
+		}
+		if clientSecret == "" {
+			return nil, fmt.Errorf("no ClientSecret provided, please pass an ClientSecret for authorization through NewAdminClientParams or set the PINECONE_CLIENT_SECRET environment variable")
+		}
+
+		authToken, err := getAuthTokenFunc(ctx, in.ClientId, in.ClientSecret, clientOptions...)
+		if err != nil {
+			return nil, err
+		}
+		authHeader = fmt.Sprintf("Bearer %s", authToken)
 	}
 
-	authProvider := provider.NewHeaderProvider("Authorization", fmt.Sprintf("Bearer %s", authToken))
+	authProvider := provider.NewHeaderProvider("Authorization", authHeader)
 	clientOptions = append(clientOptions, admin.WithRequestEditorFn(authProvider.Intercept))
 
-	adminClient, err := admin.NewClient("https://api.pinecone.io", clientOptions...)
+	adminClient, err := newAdminClient("https://api.pinecone.io", clientOptions...)
 	if err != nil {
 		return nil, err
 	}
 
 	return &AdminClient{
-		Project: &projectClient{
+		Project: &DefaultProjectClient{
 			restClient: adminClient,
 		},
-		Organization: &organizationClient{
+		Organization: &DefaultOrganizationClient{
 			restClient: adminClient,
 		},
-		APIKey: &apiKeyClient{
+		APIKey: &DefaultApiKeyClient{
 			restClient: adminClient,
 		},
 	}, nil
 }
+
+// testing abstractions
+var (
+	getAuthTokenFunc = getAuthToken
+	newAdminClient   = admin.NewClient
+)
 
 // [CreateProjectParams] contains parameters for creating a new project.
 type CreateProjectParams struct {
@@ -365,7 +200,24 @@ type CreateProjectParams struct {
 	MaxPods *int `json:"max_pods,omitempty"`
 }
 
-func (p *projectClient) Create(ctx context.Context, in *CreateProjectParams) (*Project, error) {
+// Creates a new project.
+//
+// Parameters:
+//   - ctx: The request context.
+//   - in: A pointer to [CreateProjectParams] containing the new project's configuration.
+//
+// Returns a pointer to a [Project] or an error.
+//
+// Example:
+//
+//	ctx := context.Background()
+//	project, err := adminClient.Project.Create(ctx, &pinecone.CreateProjectParams{
+//		Name: "example-project",
+//	})
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+func (p *DefaultProjectClient) Create(ctx context.Context, in *CreateProjectParams) (*Project, error) {
 	if in == nil {
 		return nil, fmt.Errorf("in (*CreateProjectParams) cannot be nil")
 	}
@@ -408,7 +260,24 @@ type UpdateProjectParams struct {
 	MaxPods *int `json:"max_pods,omitempty"`
 }
 
-func (p *projectClient) Update(ctx context.Context, projectId string, in *UpdateProjectParams) (*Project, error) {
+// Updates an existing project by ID.
+//
+// Parameters:
+//   - ctx: The request context.
+//   - projectId: The ID of the project to update.
+//   - in: A pointer to [UpdateProjectParams] containing the updated project configuration.
+//
+// Returns the updated [Project] or an error.
+//
+// Example:
+//
+//	project, err := adminClient.Project.Update(ctx, "project-id", &pinecone.UpdateProjectParams{
+//		Name: "renamed-project",
+//	})
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+func (p *DefaultProjectClient) Update(ctx context.Context, projectId string, in *UpdateProjectParams) (*Project, error) {
 	if in == nil {
 		return nil, fmt.Errorf("in (*UpdateProjectParams) cannot be nil")
 	}
@@ -443,7 +312,20 @@ func (p *projectClient) Update(ctx context.Context, projectId string, in *Update
 	return toProject(adminProject), nil
 }
 
-func (p *projectClient) List(ctx context.Context) ([]*Project, error) {
+// Lists all projects available to the authenticated service account.
+//
+// Parameters:
+//   - ctx: The request context.
+//
+// Returns a slice of [Project] objects or an error.
+//
+// Example:
+//
+//	projects, err := adminClient.Project.List(ctx)
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+func (p *DefaultProjectClient) List(ctx context.Context) ([]*Project, error) {
 	res, err := p.restClient.ListProjects(ctx)
 	if err != nil {
 		return nil, err
@@ -475,7 +357,21 @@ func (p *projectClient) List(ctx context.Context) ([]*Project, error) {
 	return projects, nil
 }
 
-func (p *projectClient) Describe(ctx context.Context, projectId string) (*Project, error) {
+// Describes an existing project by ID.
+//
+// Parameters:
+//   - ctx: The request context.
+//   - projectId: The ID of the project to describe.
+//
+// Returns a pointer to a [Project] or an error.
+//
+// Example:
+//
+//	project, err := adminClient.Project.Describe(ctx, "project-id")
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+func (p *DefaultProjectClient) Describe(ctx context.Context, projectId string) (*Project, error) {
 	projectIdUUID, err := uuid.Parse(projectId)
 	if err != nil {
 		return nil, fmt.Errorf("invalid projectId: %w", err)
@@ -500,7 +396,21 @@ func (p *projectClient) Describe(ctx context.Context, projectId string) (*Projec
 	return toProject(adminProject), nil
 }
 
-func (p *projectClient) Delete(ctx context.Context, projectId string) error {
+// Deletes a project by ID.
+//
+// Parameters:
+//   - ctx: The request context.
+//   - projectId: The ID of the project to delete.
+//
+// Returns an error if deletion fails.
+//
+// Example:
+//
+//	err := adminClient.Project.Delete(ctx, "project-id")
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+func (p *DefaultProjectClient) Delete(ctx context.Context, projectId string) error {
 	projectIdUUID, err := uuid.Parse(projectId)
 	if err != nil {
 		return fmt.Errorf("invalid projectId: %w", err)
@@ -519,7 +429,20 @@ func (p *projectClient) Delete(ctx context.Context, projectId string) error {
 	return nil
 }
 
-func (o *organizationClient) List(ctx context.Context) ([]*Organization, error) {
+// Lists all organizations available to the authenticated service account.
+//
+// Parameters:
+//   - ctx: The request context.
+//
+// Returns a slice of [Organization] objects or an error.
+//
+// Example:
+//
+//	orgs, err := adminClient.Organization.List(ctx)
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+func (o *DefaultOrganizationClient) List(ctx context.Context) ([]*Organization, error) {
 	res, err := o.restClient.ListOrganizations(ctx)
 	if err != nil {
 		return nil, err
@@ -551,7 +474,21 @@ func (o *organizationClient) List(ctx context.Context) ([]*Organization, error) 
 	return organizations, nil
 }
 
-func (o *organizationClient) Describe(ctx context.Context, organizationId string) (*Organization, error) {
+// Describes an organization by ID.
+//
+// Parameters:
+//   - ctx: The request context.
+//   - organizationId: The ID of the organization to describe.
+//
+// Returns a pointer to an [Organization] or an error.
+//
+// Example:
+//
+//	org, err := adminClient.Organization.Describe(ctx, "organization-id")
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+func (o *DefaultOrganizationClient) Describe(ctx context.Context, organizationId string) (*Organization, error) {
 	res, err := o.restClient.FetchOrganization(ctx, organizationId)
 	if err != nil {
 		return nil, err
@@ -577,7 +514,24 @@ type UpdateOrganizationParams struct {
 	Name *string `json:"name"`
 }
 
-func (o *organizationClient) Update(ctx context.Context, organizationId string, in *UpdateOrganizationParams) (*Organization, error) {
+// Updates an existing organization by ID.
+//
+// Parameters:
+//   - ctx: The request context.
+//   - organizationId: The ID of the organization to update.
+//   - in: A pointer to [UpdateOrganizationParams] containing updated fields.
+//
+// Returns the updated [Organization] or an error.
+//
+// Example:
+//
+//	org, err := adminClient.Organization.Update(ctx, "organization-id", &pinecone.UpdateOrganizationParams{
+//		Name: "Renamed Org",
+//	})
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+func (o *DefaultOrganizationClient) Update(ctx context.Context, organizationId string, in *UpdateOrganizationParams) (*Organization, error) {
 	if in == nil {
 		return nil, fmt.Errorf("in (*UpdateOrganizationParams) cannot be nil")
 	}
@@ -605,7 +559,21 @@ func (o *organizationClient) Update(ctx context.Context, organizationId string, 
 	return toOrganization(adminOrganization), nil
 }
 
-func (o *organizationClient) Delete(ctx context.Context, organizationId string) error {
+// Deletes an organization by ID. All projects within the organization must be deleted first.
+//
+// Parameters:
+//   - ctx: The request context.
+//   - organizationId: The ID of the organization to delete.
+//
+// Returns an error if deletion fails.
+//
+// Example:
+//
+//	err := adminClient.Organization.Delete(ctx, "organization-id")
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+func (o *DefaultOrganizationClient) Delete(ctx context.Context, organizationId string) error {
 	res, err := o.restClient.DeleteOrganization(ctx, organizationId)
 	if err != nil {
 		return err
@@ -629,7 +597,24 @@ type CreateAPIKeyParams struct {
 	Roles *[]string `json:"roles,omitempty"`
 }
 
-func (a *apiKeyClient) Create(ctx context.Context, projectId string, in *CreateAPIKeyParams) (*APIKeyWithSecret, error) {
+// Creates a new API key.
+//
+// Parameters:
+//   - ctx: The request context.
+//   - projectId: The ID of the project in which to create the API key.
+//   - in: A pointer to [CreateAPIKeyParams] containing the API key configuration.
+//
+// Returns a pointer to an [APIKeyWithSecret] or an error.
+//
+// Example:
+//
+//	apiKeyWithSecret, err := adminClient.APIKey.Create(ctx, "project-id", &pinecone.CreateAPIKeyParams{
+//		Name: "my-api-key",
+//	})
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+func (a *DefaultApiKeyClient) Create(ctx context.Context, projectId string, in *CreateAPIKeyParams) (*APIKeyWithSecret, error) {
 	if in == nil {
 		return nil, fmt.Errorf("in (*CreateAPIKeyParams) cannot be nil")
 	}
@@ -674,7 +659,24 @@ type UpdateAPIKeyParams struct {
 	Roles *[]string `json:"roles,omitempty"`
 }
 
-func (a *apiKeyClient) Update(ctx context.Context, apiKeyId string, in *UpdateAPIKeyParams) (*APIKey, error) {
+// Updates an existing API key by ID.
+//
+// Parameters:
+//   - ctx: The request context.
+//   - apiKeyId: The ID of the API key to update.
+//   - in: A pointer to [UpdateAPIKeyParams] containing updated fields.
+//
+// Returns the updated [APIKey] or an error.
+//
+// Example:
+//
+//	apiKey, err := adminClient.APIKey.Update(ctx, "api-key-id", &pinecone.UpdateAPIKeyParams{
+//		Name: "updated-name",
+//	})
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+func (a *DefaultApiKeyClient) Update(ctx context.Context, apiKeyId string, in *UpdateAPIKeyParams) (*APIKey, error) {
 	if in == nil {
 		return nil, fmt.Errorf("in (*UpdateAPIKeyParams) cannot be nil")
 	}
@@ -708,7 +710,21 @@ func (a *apiKeyClient) Update(ctx context.Context, apiKeyId string, in *UpdateAP
 	return toAPIKey(adminApiKey), nil
 }
 
-func (a *apiKeyClient) List(ctx context.Context, projectId string) ([]*APIKey, error) {
+// Lists all API keys within a project by project ID.
+//
+// Parameters:
+//   - ctx: The request context.
+//   - projectId: The ID of the project to list API keys for.
+//
+// Returns a slice of [APIKey] objects or an error.
+//
+// Example:
+//
+//	apiKeys, err := adminClient.APIKey.List(ctx, "project-id")
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+func (a *DefaultApiKeyClient) List(ctx context.Context, projectId string) ([]*APIKey, error) {
 	projectIdUUID, err := uuid.Parse(projectId)
 	if err != nil {
 		return nil, fmt.Errorf("invalid projectId: %w", err)
@@ -744,7 +760,21 @@ func (a *apiKeyClient) List(ctx context.Context, projectId string) ([]*APIKey, e
 	return apiKeys, nil
 }
 
-func (a *apiKeyClient) Describe(ctx context.Context, apiKeyId string) (*APIKey, error) {
+// Describes an API key by ID.
+//
+// Parameters:
+//   - ctx: The request context.
+//   - apiKeyId: The ID of the API key to describe.
+//
+// Returns a pointer to an [APIKey] or an error.
+//
+// Example:
+//
+//	apiKey, err := adminClient.APIKey.Describe(ctx, "api-key-id")
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+func (a *DefaultApiKeyClient) Describe(ctx context.Context, apiKeyId string) (*APIKey, error) {
 	apiKeyIdUUID, err := uuid.Parse(apiKeyId)
 	if err != nil {
 		return nil, fmt.Errorf("invalid apiKeyId: %w", err)
@@ -769,7 +799,21 @@ func (a *apiKeyClient) Describe(ctx context.Context, apiKeyId string) (*APIKey, 
 	return toAPIKey(adminApiKey), nil
 }
 
-func (a *apiKeyClient) Delete(ctx context.Context, apiKeyId string) error {
+// Deletes an API key by ID.
+//
+// Parameters:
+//   - ctx: The request context.
+//   - apiKeyId: The ID of the API key to delete.
+//
+// Returns an error if deletion fails.
+//
+// Example:
+//
+//	err := adminClient.APIKey.Delete(ctx, "api-key-id")
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+func (a *DefaultApiKeyClient) Delete(ctx context.Context, apiKeyId string) error {
 	apiKeyIdUUID, err := uuid.Parse(apiKeyId)
 	if err != nil {
 		return fmt.Errorf("invalid apiKeyId: %w", err)
@@ -786,18 +830,6 @@ func (a *apiKeyClient) Delete(ctx context.Context, apiKeyId string) error {
 	}
 
 	return nil
-}
-
-type projectClient struct {
-	restClient *admin.Client
-}
-
-type organizationClient struct {
-	restClient *admin.Client
-}
-
-type apiKeyClient struct {
-	restClient *admin.Client
 }
 
 type authTokenResponse struct {

--- a/pinecone/client_test.go
+++ b/pinecone/client_test.go
@@ -24,13 +24,13 @@ import (
 )
 
 // Integration tests:
-func (ts *IntegrationTests) TestListIndexes() {
+func (ts *integrationTests) TestListIndexes() {
 	indexes, err := ts.client.ListIndexes(context.Background())
 	require.NoError(ts.T(), err)
 	require.Greater(ts.T(), len(indexes), 0, "Expected at least one index to exist")
 }
 
-func (ts *IntegrationTests) TestCreatePodIndexDense() {
+func (ts *integrationTests) TestCreatePodIndexDense() {
 	if ts.indexType == "serverless" {
 		ts.T().Skip("Skipping pod index tests for serverless suite")
 	}
@@ -38,7 +38,7 @@ func (ts *IntegrationTests) TestCreatePodIndexDense() {
 	name := uuid.New().String()
 	metric := Cosine
 
-	defer func(ts *IntegrationTests, name string) {
+	defer func(ts *integrationTests, name string) {
 		err := ts.deleteIndex(name)
 		require.NoError(ts.T(), err)
 	}(ts, name)
@@ -56,7 +56,7 @@ func (ts *IntegrationTests) TestCreatePodIndexDense() {
 	require.Equal(ts.T(), "dense", idx.VectorType, "Index vector type does not match")
 }
 
-func (ts *IntegrationTests) TestCreateServerlessIndexDense() {
+func (ts *integrationTests) TestCreateServerlessIndexDense() {
 	if ts.indexType == "pod" {
 		ts.T().Skip("Skipping serverless index tests for pod suite")
 	}
@@ -65,7 +65,7 @@ func (ts *IntegrationTests) TestCreateServerlessIndexDense() {
 	dimension := int32(10)
 	metric := Cosine
 
-	defer func(ts *IntegrationTests, name string) {
+	defer func(ts *integrationTests, name string) {
 		err := ts.deleteIndex(name)
 		require.NoError(ts.T(), err)
 	}(ts, name)
@@ -83,7 +83,7 @@ func (ts *IntegrationTests) TestCreateServerlessIndexDense() {
 	require.Equal(ts.T(), "dense", idx.VectorType, "Index vector type does not match")
 }
 
-func (ts *IntegrationTests) TestCreateServerlessIndexSparse() {
+func (ts *integrationTests) TestCreateServerlessIndexSparse() {
 	if ts.indexType == "pod" {
 		ts.T().Skip("Skipping serverless index tests for pod suite")
 	}
@@ -92,7 +92,7 @@ func (ts *IntegrationTests) TestCreateServerlessIndexSparse() {
 	vectorType := "sparse"
 	metric := Dotproduct
 
-	defer func(ts *IntegrationTests, name string) {
+	defer func(ts *integrationTests, name string) {
 		err := ts.deleteIndex(name)
 		require.NoError(ts.T(), err)
 	}(ts, name)
@@ -109,7 +109,7 @@ func (ts *IntegrationTests) TestCreateServerlessIndexSparse() {
 	require.Equal(ts.T(), vectorType, idx.VectorType, "Index vector type does not match")
 }
 
-func (ts *IntegrationTests) TestCreateServerlessIndexInvalidDimension() {
+func (ts *integrationTests) TestCreateServerlessIndexInvalidDimension() {
 	if ts.indexType == "pod" {
 		ts.T().Skip("Skipping serverless index tests for pod suite")
 	}
@@ -129,19 +129,19 @@ func (ts *IntegrationTests) TestCreateServerlessIndexInvalidDimension() {
 	require.Equal(ts.T(), reflect.TypeOf(err), reflect.TypeOf(&PineconeError{}), "Expected error to be of type PineconeError")
 }
 
-func (ts *IntegrationTests) TestDescribeIndex() {
+func (ts *integrationTests) TestDescribeIndex() {
 	index, err := ts.client.DescribeIndex(context.Background(), ts.idxName)
 	require.NoError(ts.T(), err)
 	require.Equal(ts.T(), ts.idxName, index.Name, "Index name does not match")
 }
 
-func (ts *IntegrationTests) TestDescribeNonExistentIndex() {
+func (ts *integrationTests) TestDescribeNonExistentIndex() {
 	_, err := ts.client.DescribeIndex(context.Background(), "non-existent-index")
 	require.Error(ts.T(), err)
 	require.Equal(ts.T(), reflect.TypeOf(err), reflect.TypeOf(&PineconeError{}), "Expected error to be of type PineconeError")
 }
 
-func (ts *IntegrationTests) TestListCollections() {
+func (ts *integrationTests) TestListCollections() {
 	if ts.indexType == "serverless" {
 		ts.T().Skip("No pod index to test")
 	}
@@ -162,7 +162,7 @@ func (ts *IntegrationTests) TestListCollections() {
 	require.True(ts.T(), found, "Collection %v not found in list of collections", ts.collectionName)
 }
 
-func (ts *IntegrationTests) TestDescribeCollection() {
+func (ts *integrationTests) TestDescribeCollection() {
 	if ts.indexType == "serverless" {
 		ts.T().Skip("No pod index to test")
 	}
@@ -173,7 +173,7 @@ func (ts *IntegrationTests) TestDescribeCollection() {
 	require.Equal(ts.T(), ts.collectionName, collection.Name, "Collection name does not match")
 }
 
-func (ts *IntegrationTests) TestDeletionProtection() {
+func (ts *integrationTests) TestDeletionProtection() {
 	// configure index to enable deletion protection
 	index, err := ts.client.ConfigureIndex(context.Background(), ts.idxName, ConfigureIndexParams{DeletionProtection: "enabled"})
 	require.NoError(ts.T(), err)
@@ -192,11 +192,11 @@ func (ts *IntegrationTests) TestDeletionProtection() {
 	require.NoError(ts.T(), err)
 }
 
-func (ts *IntegrationTests) TestConfigureIndexIllegalScaleDown() {
+func (ts *integrationTests) TestConfigureIndexIllegalScaleDown() {
 	name := uuid.New().String()
 	metric := Cosine
 
-	defer func(ts *IntegrationTests, name string) {
+	defer func(ts *integrationTests, name string) {
 		err := ts.deleteIndex(name)
 		require.NoError(ts.T(), err)
 	}(ts, name)
@@ -216,7 +216,7 @@ func (ts *IntegrationTests) TestConfigureIndexIllegalScaleDown() {
 	require.ErrorContainsf(ts.T(), err, "Cannot scale down", err.Error())
 }
 
-func (ts *IntegrationTests) TestConfigureIndexScaleUpNoPods() {
+func (ts *integrationTests) TestConfigureIndexScaleUpNoPods() {
 	name := uuid.New().String()
 	metric := Cosine
 
@@ -241,7 +241,7 @@ func (ts *IntegrationTests) TestConfigureIndexScaleUpNoPods() {
 	require.NoError(ts.T(), err)
 }
 
-func (ts *IntegrationTests) TestConfigureIndexScaleUpNoReplicas() {
+func (ts *integrationTests) TestConfigureIndexScaleUpNoReplicas() {
 	name := uuid.New().String()
 	metric := Cosine
 
@@ -266,16 +266,16 @@ func (ts *IntegrationTests) TestConfigureIndexScaleUpNoReplicas() {
 	require.NoError(ts.T(), err)
 }
 
-func (ts *IntegrationTests) TestConfigureIndexIllegalNoPodsOrReplicasOrDeletionProtection() {
+func (ts *integrationTests) TestConfigureIndexIllegalNoPodsOrReplicasOrDeletionProtection() {
 	_, err := ts.client.ConfigureIndex(context.Background(), ts.idxName, ConfigureIndexParams{})
 	require.ErrorContainsf(ts.T(), err, "must specify PodType, Replicas, DeletionProtection, or Tags", err.Error())
 }
 
-func (ts *IntegrationTests) TestConfigureIndexHitPodLimit() {
+func (ts *integrationTests) TestConfigureIndexHitPodLimit() {
 	name := uuid.New().String()
 	metric := Cosine
 
-	defer func(ts *IntegrationTests, name string) {
+	defer func(ts *integrationTests, name string) {
 		err := ts.deleteIndex(name)
 		require.NoError(ts.T(), err)
 	}(ts, name)
@@ -295,7 +295,7 @@ func (ts *IntegrationTests) TestConfigureIndexHitPodLimit() {
 	require.ErrorContainsf(ts.T(), err, "You've reached the max pods allowed", err.Error())
 }
 
-func (ts *IntegrationTests) TestDescribeEmbedModel() {
+func (ts *integrationTests) TestDescribeEmbedModel() {
 	ctx := context.Background()
 	modelName := "multilingual-e5-large"
 	paramQuery := "query"
@@ -341,7 +341,7 @@ func (ts *IntegrationTests) TestDescribeEmbedModel() {
 	require.Equal(ts.T(), supportedParameters, *model.SupportedParameters, "Expected model supported parameters to match")
 }
 
-func (ts *IntegrationTests) TestDescribeRerankModel() {
+func (ts *integrationTests) TestDescribeRerankModel() {
 	ctx := context.Background()
 	modelName := "pinecone-rerank-v0"
 	paramEND := "END"
@@ -376,7 +376,7 @@ func (ts *IntegrationTests) TestDescribeRerankModel() {
 	require.Nil(ts.T(), model.DefaultDimension, "Expected model default dimension to be nil")
 }
 
-func (ts *IntegrationTests) TestListAllModels() {
+func (ts *integrationTests) TestListAllModels() {
 	ctx := context.Background()
 
 	allModels, err := ts.client.Inference.ListModels(ctx, nil)
@@ -407,7 +407,7 @@ func (ts *IntegrationTests) TestListAllModels() {
 	require.True(ts.T(), returnsDense, "Expected at least one dense embed model to be listed")
 }
 
-func (ts *IntegrationTests) TestListRerankModels() {
+func (ts *integrationTests) TestListRerankModels() {
 	ctx := context.Background()
 	rerank := "rerank"
 
@@ -434,7 +434,7 @@ func (ts *IntegrationTests) TestListRerankModels() {
 	require.Equal(ts.T(), false, returnsEmbed, "Expected no embed models to be listed in rerank models")
 }
 
-func (ts *IntegrationTests) TestListEmbeddingModels() {
+func (ts *integrationTests) TestListEmbeddingModels() {
 	ctx := context.Background()
 	embed := "embed"
 	sparse := "sparse"
@@ -484,7 +484,7 @@ func (ts *IntegrationTests) TestListEmbeddingModels() {
 	require.Equal(ts.T(), true, allDenseModels, "Expected all listed models to be of vector type 'dense'")
 }
 
-func (ts *IntegrationTests) TestGenerateEmbeddingsDense() {
+func (ts *integrationTests) TestGenerateEmbeddingsDense() {
 	// Run Embed tests once rather than duplicating across serverless & pods
 	if ts.indexType == "pod" {
 		ts.T().Skip("Skipping Embed tests for pods")
@@ -512,7 +512,7 @@ func (ts *IntegrationTests) TestGenerateEmbeddingsDense() {
 	require.Equal(ts.T(), 1024, len(denseEmbeddings.Data[0].DenseEmbedding.Values), "Expected embeddings to have length 1024")
 }
 
-func (ts *IntegrationTests) TestGenerateEmbeddingsSparse() {
+func (ts *integrationTests) TestGenerateEmbeddingsSparse() {
 	// Run Embed tests once rather than duplicating across serverless & pods
 	if ts.indexType == "pod" {
 		ts.T().Skip("Skipping Embed tests for pods")
@@ -542,7 +542,7 @@ func (ts *IntegrationTests) TestGenerateEmbeddingsSparse() {
 	require.NotNil(ts.T(), sparseEmbeddings.Data[0].SparseEmbedding.SparseValues, "Expected SparseValues to be non-nil")
 }
 
-func (ts *IntegrationTests) TestGenerateEmbeddingsInvalidInputs() {
+func (ts *integrationTests) TestGenerateEmbeddingsInvalidInputs() {
 	ctx := context.Background()
 	embeddingModel := "multilingual-e5-large"
 	_, err := ts.client.Inference.Embed(ctx, &EmbedRequest{
@@ -557,7 +557,7 @@ func (ts *IntegrationTests) TestGenerateEmbeddingsInvalidInputs() {
 	require.Contains(ts.T(), err.Error(), "TextInputs must contain at least one value")
 }
 
-func (ts *IntegrationTests) TestRerankDocumentDefaultField() {
+func (ts *integrationTests) TestRerankDocumentDefaultField() {
 	// Run Rerank tests once rather than duplicating across serverless & pods
 	if ts.indexType == "pod" {
 		ts.T().Skip("Skipping Rerank tests for pods")
@@ -590,7 +590,7 @@ func (ts *IntegrationTests) TestRerankDocumentDefaultField() {
 	require.True(ts.T(), exists, "Expected '%s' to exist in Document map", "id")
 }
 
-func (ts *IntegrationTests) TestRerankDocumentCustomField() {
+func (ts *integrationTests) TestRerankDocumentCustomField() {
 	// Run Rerank tests once rather than duplicating across serverless & pods
 	if ts.indexType == "pod" {
 		ts.T().Skip("Skipping Rerank tests for pods")
@@ -624,7 +624,7 @@ func (ts *IntegrationTests) TestRerankDocumentCustomField() {
 	require.True(ts.T(), exists, "Expected '%s' to exist in Document map", "id")
 }
 
-func (ts *IntegrationTests) TestRerankDocumentAllDefaults() {
+func (ts *integrationTests) TestRerankDocumentAllDefaults() {
 	// Run Rerank tests once rather than duplicating across serverless & pods
 	if ts.indexType == "pod" {
 		ts.T().Skip("Skipping Rerank tests for pods")
@@ -653,7 +653,7 @@ func (ts *IntegrationTests) TestRerankDocumentAllDefaults() {
 	require.True(ts.T(), exists, "Expected '%s' to exist in Document map", "id")
 }
 
-func (ts *IntegrationTests) TestRerankDocumentsMultipleRankFields() {
+func (ts *integrationTests) TestRerankDocumentsMultipleRankFields() {
 	// Run Rerank tests once rather than duplicating across serverless & pods
 	if ts.indexType == "pod" {
 		ts.T().Skip("Skipping Rerank tests for pods")
@@ -692,7 +692,7 @@ func (ts *IntegrationTests) TestRerankDocumentsMultipleRankFields() {
 	require.Contains(ts.T(), err.Error(), "Only one rank field is supported for model")
 }
 
-func (ts *IntegrationTests) TestRerankDocumentFieldError() {
+func (ts *integrationTests) TestRerankDocumentFieldError() {
 	// Run Rerank tests once rather than duplicating across serverless & pods
 	if ts.indexType == "pod" {
 		ts.T().Skip("Skipping Rerank tests for pods")
@@ -715,7 +715,7 @@ func (ts *IntegrationTests) TestRerankDocumentFieldError() {
 	require.Contains(ts.T(), err.Error(), "field 'custom-field' not found in document")
 }
 
-func (ts *IntegrationTests) TestIndexTags() {
+func (ts *integrationTests) TestIndexTags() {
 	// Validate that index tags are set
 	index, err := ts.client.DescribeIndex(context.Background(), ts.idxName)
 	require.NoError(ts.T(), err)
@@ -746,11 +746,11 @@ func (ts *IntegrationTests) TestIndexTags() {
 	ts.indexTags = &updatedTags
 }
 
-func (ts *IntegrationTests) TestListAndDescribeIndexBackups() {
+func (ts *integrationTests) TestListAndDescribeIndexBackups() {
 	if ts.indexType != "serverless" {
 		ts.T().Skip("Skipping backup tests for non-serverless indexes")
 	}
-	// CreateBackup and DeleteBackup are tested as a part of IntegrationTests.SetupSuite(), so not explicitly tested here
+	// CreateBackup and DeleteBackup are tested as a part of integrationTests.SetupSuite(), so not explicitly tested here
 	limit := 5
 
 	// list project backups
@@ -770,7 +770,7 @@ func (ts *IntegrationTests) TestListAndDescribeIndexBackups() {
 	}
 }
 
-func (ts *IntegrationTests) TestCreateIndexFromBackupViaRestore() {
+func (ts *integrationTests) TestCreateIndexFromBackupViaRestore() {
 	if ts.indexType != "serverless" {
 		ts.T().Skip("Skipping backup tests for non-serverless indexes")
 	}
@@ -807,7 +807,7 @@ func (ts *IntegrationTests) TestCreateIndexFromBackupViaRestore() {
 
 	// validate describing the restored index
 	index, err := ts.client.DescribeIndex(context.Background(), restoredIndexName)
-	defer func(ts *IntegrationTests, name string) {
+	defer func(ts *integrationTests, name string) {
 		err := ts.client.DeleteIndex(context.Background(), name)
 		require.NoError(ts.T(), err)
 	}(ts, restoredIndexName)
@@ -1804,7 +1804,7 @@ func TestEnsureHostHasHttpsUnit(t *testing.T) {
 }
 
 // Helper functions:
-func (ts *IntegrationTests) deleteIndex(name string) error {
+func (ts *integrationTests) deleteIndex(name string) error {
 	_, err := waitUntilIndexReady(ts, context.Background())
 	require.NoError(ts.T(), err)
 

--- a/pinecone/index_connection_test.go
+++ b/pinecone/index_connection_test.go
@@ -18,14 +18,14 @@ import (
 )
 
 // Integration tests
-func (ts *IntegrationTests) TestFetchVectors() {
+func (ts *integrationTests) TestFetchVectors() {
 	ctx := context.Background()
 	res, err := ts.idxConn.FetchVectors(ctx, ts.vectorIds)
 	assert.NoError(ts.T(), err)
 	assert.NotNil(ts.T(), res)
 }
 
-func (ts *IntegrationTests) TestQueryByVector() {
+func (ts *integrationTests) TestQueryByVector() {
 	vec := make([]float32, derefOrDefault(ts.dimension, 0))
 	for i := range vec {
 		vec[i] = 0.01
@@ -54,7 +54,7 @@ func (ts *IntegrationTests) TestQueryByVector() {
 	})
 }
 
-func (ts *IntegrationTests) TestQueryById() {
+func (ts *integrationTests) TestQueryById() {
 	req := &QueryByVectorIdRequest{
 		VectorId: ts.vectorIds[0],
 		TopK:     5,
@@ -66,7 +66,7 @@ func (ts *IntegrationTests) TestQueryById() {
 	assert.NotNil(ts.T(), res)
 }
 
-func (ts *IntegrationTests) TestDeleteVectorsById() {
+func (ts *integrationTests) TestDeleteVectorsById() {
 	ctx := context.Background()
 	err := ts.idxConn.DeleteVectorsById(ctx, ts.vectorIds)
 	assert.NoError(ts.T(), err)
@@ -87,7 +87,7 @@ func (ts *IntegrationTests) TestDeleteVectorsById() {
 	ts.vectorIds = append(ts.vectorIds, vectorIds...)
 }
 
-func (ts *IntegrationTests) TestDeleteVectorsByFilter() {
+func (ts *integrationTests) TestDeleteVectorsByFilter() {
 	metadataFilter := map[string]interface{}{
 		"genre": "classical",
 	}
@@ -116,7 +116,7 @@ func (ts *IntegrationTests) TestDeleteVectorsByFilter() {
 	ts.vectorIds = append(ts.vectorIds, vectorIds...)
 }
 
-func (ts *IntegrationTests) TestDeleteAllVectorsInNamespace() {
+func (ts *integrationTests) TestDeleteAllVectorsInNamespace() {
 	ctx := context.Background()
 	err := ts.idxConn.DeleteAllVectorsInNamespace(ctx)
 	assert.NoError(ts.T(), err)
@@ -138,21 +138,21 @@ func (ts *IntegrationTests) TestDeleteAllVectorsInNamespace() {
 
 }
 
-func (ts *IntegrationTests) TestDescribeIndexStats() {
+func (ts *integrationTests) TestDescribeIndexStats() {
 	ctx := context.Background()
 	res, err := ts.idxConn.DescribeIndexStats(ctx)
 	assert.NoError(ts.T(), err)
 	assert.NotNil(ts.T(), res)
 }
 
-func (ts *IntegrationTests) TestDescribeIndexStatsFiltered() {
+func (ts *integrationTests) TestDescribeIndexStatsFiltered() {
 	ctx := context.Background()
 	res, err := ts.idxConn.DescribeIndexStatsFiltered(ctx, &MetadataFilter{})
 	assert.NoError(ts.T(), err)
 	assert.NotNil(ts.T(), res)
 }
 
-func (ts *IntegrationTests) TestListVectors() {
+func (ts *integrationTests) TestListVectors() {
 	ts.T().Skip()
 	req := &ListVectorsRequest{}
 
@@ -162,7 +162,7 @@ func (ts *IntegrationTests) TestListVectors() {
 	assert.NotNil(ts.T(), res)
 }
 
-func (ts *IntegrationTests) TestMetadataAppliedToRequests() {
+func (ts *integrationTests) TestMetadataAppliedToRequests() {
 	apiKey := "test-api-key"
 	namespace := "test-namespace"
 	sourceTag := "test-source-tag"
@@ -194,7 +194,7 @@ func (ts *IntegrationTests) TestMetadataAppliedToRequests() {
 	require.NotNil(ts.T(), stats)
 }
 
-func (ts *IntegrationTests) TestUpdateVectorValues() {
+func (ts *integrationTests) TestUpdateVectorValues() {
 	ctx := context.Background()
 
 	expectedVals := []float32{7.2, 7.2, 7.2, 7.2, 7.2}
@@ -227,7 +227,7 @@ func (ts *IntegrationTests) TestUpdateVectorValues() {
 	})
 }
 
-func (ts *IntegrationTests) TestUpdateVectorMetadata() {
+func (ts *integrationTests) TestUpdateVectorMetadata() {
 	ctx := context.Background()
 
 	expectedMetadata := map[string]interface{}{
@@ -272,7 +272,7 @@ func (ts *IntegrationTests) TestUpdateVectorMetadata() {
 	})
 }
 
-func (ts *IntegrationTests) TestUpdateVectorSparseValues() {
+func (ts *integrationTests) TestUpdateVectorSparseValues() {
 	ctx := context.Background()
 
 	dims := int32(derefOrDefault(ts.dimension, 0))
@@ -314,7 +314,7 @@ func (ts *IntegrationTests) TestUpdateVectorSparseValues() {
 	})
 }
 
-func (ts *IntegrationTests) TestImportFlowHappyPath() {
+func (ts *integrationTests) TestImportFlowHappyPath() {
 	if ts.indexType != "serverless" {
 		ts.T().Skip("Skipping import flow test for non-serverless index")
 	}
@@ -342,7 +342,7 @@ func (ts *IntegrationTests) TestImportFlowHappyPath() {
 	assert.NoError(ts.T(), err)
 }
 
-func (ts *IntegrationTests) TestImportFlowNoUriError() {
+func (ts *integrationTests) TestImportFlowNoUriError() {
 	if ts.indexType != "serverless" {
 		ts.T().Skip("Skipping import flow test for non-serverless index")
 	}
@@ -353,7 +353,7 @@ func (ts *IntegrationTests) TestImportFlowNoUriError() {
 	assert.Contains(ts.T(), err.Error(), "must specify a uri")
 }
 
-func (ts *IntegrationTests) TestIntegratedInference() {
+func (ts *integrationTests) TestIntegratedInference() {
 	if ts.indexType != "serverless" {
 		ts.T().Skip("Running TestIntegratedInference once")
 	}
@@ -373,7 +373,7 @@ func (ts *IntegrationTests) TestIntegratedInference() {
 	assert.NoError(ts.T(), err)
 	assert.NotNil(ts.T(), index)
 
-	defer func(ts *IntegrationTests, name string) {
+	defer func(ts *integrationTests, name string) {
 		err := ts.deleteIndex(name)
 
 		require.NoError(ts.T(), err)
@@ -444,7 +444,7 @@ func (ts *IntegrationTests) TestIntegratedInference() {
 	})
 }
 
-func (ts *IntegrationTests) TestDescribeNamespace() {
+func (ts *integrationTests) TestDescribeNamespace() {
 	if ts.indexType != "serverless" {
 		ts.T().Skip("Namespace operations are only supported in serverless indexes")
 	}
@@ -458,7 +458,7 @@ func (ts *IntegrationTests) TestDescribeNamespace() {
 	require.Equal(ts.T(), namespace, namespaceDesc.Name, "Namespace name should match the requested namespace")
 }
 
-func (ts *IntegrationTests) TestListNamespaces() {
+func (ts *integrationTests) TestListNamespaces() {
 	if ts.indexType != "serverless" {
 		ts.T().Skip("Namespace operations are only supported in serverless indexes")
 	}
@@ -482,7 +482,7 @@ func (ts *IntegrationTests) TestListNamespaces() {
 	require.Greater(ts.T(), len(namespaces.Namespaces), 0, "ListNamespaces should return the second page of results")
 }
 
-func (ts *IntegrationTests) TestDeleteNamespace() {
+func (ts *integrationTests) TestDeleteNamespace() {
 	if ts.indexType != "serverless" {
 		ts.T().Skip("Namespace operations are only supported in serverless indexes")
 	}

--- a/pinecone/suite_runner_test.go
+++ b/pinecone/suite_runner_test.go
@@ -40,7 +40,7 @@ func RunSuites(t *testing.T) {
 	serverlessIdx := buildServerlessTestIndex(client, "serverless-"+generateTestIndexName(), indexTags)
 	podIdx := buildPodTestIndex(client, "pods-"+generateTestIndexName(), indexTags)
 
-	podTestSuite := &IntegrationTests{
+	podTestSuite := &integrationTests{
 		apiKey:    apiKey,
 		indexType: "pods",
 		host:      podIdx.Host,
@@ -51,7 +51,7 @@ func RunSuites(t *testing.T) {
 		indexTags: &indexTags,
 	}
 
-	serverlessTestSuite := &IntegrationTests{
+	serverlessTestSuite := &integrationTests{
 		apiKey:    apiKey,
 		indexType: "serverless",
 		host:      serverlessIdx.Host,
@@ -62,7 +62,7 @@ func RunSuites(t *testing.T) {
 		indexTags: &indexTags,
 	}
 
-	adminTestSuite := &AdminIntegrationTests{
+	adminTestSuite := &adminIntegrationTests{
 		clientId:     clientId,
 		clientSecret: clientSecret,
 		adminClient:  adminClient,

--- a/pinecone/test_suite.go
+++ b/pinecone/test_suite.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-type IntegrationTests struct {
+type integrationTests struct {
 	suite.Suite
 	apiKey         string
 	client         *Client
@@ -30,14 +30,14 @@ type IntegrationTests struct {
 	namespaces     []string
 }
 
-type AdminIntegrationTests struct {
+type adminIntegrationTests struct {
 	suite.Suite
 	clientId     string
 	clientSecret string
 	adminClient  *AdminClient
 }
 
-func (ts *IntegrationTests) SetupSuite() {
+func (ts *integrationTests) SetupSuite() {
 	ctx := context.Background()
 
 	_, err := waitUntilIndexReady(ts, ctx)
@@ -99,7 +99,7 @@ func (ts *IntegrationTests) SetupSuite() {
 	fmt.Printf("\n %s set up suite completed successfully\n", ts.indexType)
 }
 
-func (ts *IntegrationTests) TearDownSuite() {
+func (ts *integrationTests) TearDownSuite() {
 	ctx := context.Background()
 
 	// Close index connection
@@ -148,7 +148,7 @@ func generateTestIndexName() string {
 	return fmt.Sprintf("index-%d", time.Now().UnixMilli())
 }
 
-func upsertVectors(ts *IntegrationTests, ctx context.Context, vectors []*Vector) error {
+func upsertVectors(ts *integrationTests, ctx context.Context, vectors []*Vector) error {
 	_, err := waitUntilIndexReady(ts, ctx)
 	require.NoError(ts.T(), err)
 
@@ -166,7 +166,7 @@ func upsertVectors(ts *IntegrationTests, ctx context.Context, vectors []*Vector)
 	return nil
 }
 
-func createCollection(ts *IntegrationTests, ctx context.Context) {
+func createCollection(ts *integrationTests, ctx context.Context) {
 	name := uuid.New().String()
 	sourceIndex := ts.idxName
 
@@ -181,7 +181,7 @@ func createCollection(ts *IntegrationTests, ctx context.Context) {
 	require.Equal(ts.T(), name, collection.Name)
 }
 
-func createBackup(ts *IntegrationTests, ctx context.Context) {
+func createBackup(ts *integrationTests, ctx context.Context) {
 	backupName := fmt.Sprintf("backup-%s", uuid.New().String())
 	backupDesc := fmt.Sprintf("Backup created for index %s for Pinecone integration tests", ts.idxName)
 	fmt.Printf("Creating backup: %s for index: %s\n", backupName, ts.idxName)
@@ -215,7 +215,7 @@ func createBackup(ts *IntegrationTests, ctx context.Context) {
 	}
 }
 
-func waitUntilIndexReady(ts *IntegrationTests, ctx context.Context) (bool, error) {
+func waitUntilIndexReady(ts *integrationTests, ctx context.Context) (bool, error) {
 	start := time.Now()
 	delay := 5 * time.Second
 	maxWaitTimeSeconds := 280 * time.Second
@@ -342,7 +342,7 @@ func retryAssertionsWithDefaults(t *testing.T, fn func() error) {
 	retryAssertions(t, 30, 5*time.Second, fn)
 }
 
-func pollIndexForFreshness(ts *IntegrationTests, ctx context.Context, sampleId string) error {
+func pollIndexForFreshness(ts *integrationTests, ctx context.Context, sampleId string) error {
 	maxSleep := 240 * time.Second
 	delay := 5 * time.Second
 	totalWait := 0 * time.Second


### PR DESCRIPTION
## Problem
While implementing admin API functionality in the CLI through the Go SDK, I realized we need a way to provide an `AccessToken` directly rather than strictly `ClientId` and `ClientSecret`. In cases where the user has authenticated through the browser and OAuth, they already have the token and may not have provided `ClientId` and `ClientSecret`.

Additionally, I noticed a few things with our generated Go documentation that needed to be cleaned up. The interfaces for `ProjectClient`, `OrganizationClient`, and `ApiKeyClient` are somewhat buried in our generated documentation. Here's an example of `ProjectClient`: https://pkg.go.dev/github.com/pinecone-io/go-pinecone/v4/pinecone#ProjectClient.

The concrete implementations of the interfaces that all the methods are attached to need to be properly exported.

## Solution
- Update `NewAdminClientWithContext`, and `NewAdminClientParams` to support passing `AccessToken` instead of `ClientId` and `ClientSecret`, add new unit tests to cover `NewAdminClientParams` functionality.
- Update `ProjectClient`, `OrganizationClient`, and `ApiKeyClient` interfaces and concrete implementations to export things properly to correct documentation issues. Move detailed doc comments to the specific methods rather than having them in the interfaces.
- Un-export IntegrationTests and AdminIntegrationTests.
- Add unit tests for `NewAdminClientWithContext`.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
CI - integration & unit tests
