### PR TITLE
Fix `IndexConnection.UpsertRecords` swallowing errors

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(head:*)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(head:*)"
-    ]
-  }
-}

--- a/pinecone/admin_client.go
+++ b/pinecone/admin_client.go
@@ -746,6 +746,7 @@ func (a *DefaultApiKeyClient) List(ctx context.Context, projectId string) ([]*AP
 	if err != nil {
 		return nil, err
 	}
+	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
 		return nil, handleErrorResponseBody(res, "failed to list api keys: ")

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -2056,6 +2056,8 @@ func (c *Client) ListBackups(ctx context.Context, in *ListBackupsParams) (*Backu
 		}
 	}
 
+	defer response.Body.Close()
+
 	if response.StatusCode != http.StatusOK {
 		return nil, handleErrorResponseBody(response, "failed to list backups: ")
 	}

--- a/pinecone/index_connection.go
+++ b/pinecone/index_connection.go
@@ -1285,6 +1285,11 @@ func (idx *IndexConnection) SearchRecords(ctx context.Context, in *SearchRecords
 	if err != nil {
 		return nil, err
 	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, handleErrorResponseBody(res, "failed to search records: ")
+	}
 	return decodeSearchRecordsResponse(res.Body)
 }
 
@@ -1721,6 +1726,10 @@ func (idx *IndexConnection) DescribeImport(ctx context.Context, id string) (*Imp
 	}
 	defer res.Body.Close()
 
+	if res.StatusCode != http.StatusOK {
+		return nil, handleErrorResponseBody(res, "failed to describe import: ")
+	}
+
 	importModel, err := decodeImportModel(res.Body)
 	if err != nil {
 		return nil, err
@@ -1803,6 +1812,11 @@ func (idx *IndexConnection) ListImports(ctx context.Context, limit *int32, pagin
 	res, err := (*idx.restClient).ListBulkImports(idx.akCtx(ctx), &params)
 	if err != nil {
 		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, handleErrorResponseBody(res, "failed to list imports: ")
 	}
 
 	listImportsResponse, err := decodeListImportsResponse(res.Body)

--- a/pinecone/index_connection.go
+++ b/pinecone/index_connection.go
@@ -1121,9 +1121,14 @@ func (idx *IndexConnection) UpsertRecords(ctx context.Context, records []*Integr
 		}
 	}
 
-	_, err := idx.restClient.UpsertRecordsNamespaceWithBody(ctx, idx.namespace, &db_data_rest.UpsertRecordsNamespaceParams{XPineconeApiVersion: gen.PineconeApiVersion}, "application/x-ndjson", &buffer)
+	res, err := idx.restClient.UpsertRecordsNamespaceWithBody(ctx, idx.namespace, &db_data_rest.UpsertRecordsNamespaceParams{XPineconeApiVersion: gen.PineconeApiVersion}, "application/x-ndjson", &buffer)
 	if err != nil {
-		return fmt.Errorf("failed to upsert records: %v", err)
+		return fmt.Errorf("failed to upsert records: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return handleErrorResponseBody(res, "failed to upsert records: ")
 	}
 	return nil
 }

--- a/pinecone/index_connection.go
+++ b/pinecone/index_connection.go
@@ -1127,7 +1127,7 @@ func (idx *IndexConnection) UpsertRecords(ctx context.Context, records []*Integr
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusOK {
+	if res.StatusCode != http.StatusCreated {
 		return handleErrorResponseBody(res, "failed to upsert records: ")
 	}
 	return nil

--- a/pinecone/index_connection_test.go
+++ b/pinecone/index_connection_test.go
@@ -593,11 +593,16 @@ func (ts *integrationTests) TestIntegratedInference() {
 			"category":   "nutrition",
 		},
 	}
-	err = ts.idxConn.UpsertRecords(ctx, records)
+
+	idxConn, err := ts.client.Index(NewIndexConnParams{Host: index.Host, Namespace: ts.namespaces[0]})
+	assert.NoError(ts.T(), err)
+	assert.NotNil(ts.T(), idxConn)
+
+	err = idxConn.UpsertRecords(ctx, records)
 	assert.NoError(ts.T(), err)
 
 	retryAssertionsWithDefaults(ts.T(), func() error {
-		res, err := ts.idxConn.SearchRecords(ctx, &SearchRecordsRequest{
+		res, err := idxConn.SearchRecords(ctx, &SearchRecordsRequest{
 			Query: SearchRecordsQuery{
 				TopK: 5,
 				Inputs: &map[string]interface{}{

--- a/pinecone/index_connection_test.go
+++ b/pinecone/index_connection_test.go
@@ -531,6 +531,10 @@ func (ts *integrationTests) TestIntegratedInference() {
 	assert.NoError(ts.T(), err)
 	assert.NotNil(ts.T(), index)
 
+	// Wait for the index to be fully ready before attempting data plane operations
+	_, err = waitUntilIndexReady(ts, ctx, indexName)
+	require.NoError(ts.T(), err)
+
 	// Verify Schema is returned when describing the index
 	retryAssertionsWithDefaults(ts.T(), func() error {
 		describedIndex, err := ts.client.DescribeIndex(ctx, indexName)
@@ -595,12 +599,12 @@ func (ts *integrationTests) TestIntegratedInference() {
 	}
 
 	idxConn, err := ts.client.Index(NewIndexConnParams{Host: index.Host, Namespace: ts.namespaces[0]})
-	assert.NoError(ts.T(), err)
-	assert.NotNil(ts.T(), idxConn)
+	require.NoError(ts.T(), err)
+	require.NotNil(ts.T(), idxConn)
 	defer idxConn.Close()
 
 	err = idxConn.UpsertRecords(ctx, records)
-	assert.NoError(ts.T(), err)
+	require.NoError(ts.T(), err)
 
 	retryAssertionsWithDefaults(ts.T(), func() error {
 		res, err := idxConn.SearchRecords(ctx, &SearchRecordsRequest{

--- a/pinecone/index_connection_test.go
+++ b/pinecone/index_connection_test.go
@@ -609,9 +609,6 @@ func (ts *integrationTests) TestIntegratedInference() {
 				Inputs: &map[string]interface{}{
 					"text": "Disease prevention",
 				},
-				MatchTerms: &SearchMatchTerms{
-					Terms: &[]string{"disease", "prevention"},
-				},
 			},
 		})
 		if err != nil {

--- a/pinecone/index_connection_test.go
+++ b/pinecone/index_connection_test.go
@@ -597,6 +597,7 @@ func (ts *integrationTests) TestIntegratedInference() {
 	idxConn, err := ts.client.Index(NewIndexConnParams{Host: index.Host, Namespace: ts.namespaces[0]})
 	assert.NoError(ts.T(), err)
 	assert.NotNil(ts.T(), idxConn)
+	defer idxConn.Close()
 
 	err = idxConn.UpsertRecords(ctx, records)
 	assert.NoError(ts.T(), err)


### PR DESCRIPTION
## Problem
The `IndexConnection.UpsertRecords` method is currently swallowing errors. For example, if you're trying to call `UpsertRecords` on a non-integrated index, the resulting 400 error is swallowed, and never surfaced to the user.

## Solution
- Make sure we're not swallowing errors on the `IndexConnection.UpsertRecords` method, check `res.StatusCode` directly to validate upsert response.
- Fix broken integration test that should have been failing the whole time.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
CI - unit & integration testing

The integration test that began failing with this error after making this change validates the approach. Previously, this test was running UpsertRecords against a non-integrated index, and failing silently with a successful test:

```
=== RUN   TestRunSuites/TestIntegratedInference#01
    index_connection_test.go:597: 
        	Error Trace:	/home/runner/work/go-pinecone/go-pinecone/pinecone/index_connection_test.go:597
        	Error:      	Received unexpected error:
        	            	{"status_code":400,"body":"{\"error\":{\"code\":\"INVALID_ARGUMENT\",\"message\":\"Integrated inference is not configured for this index\"},\"status\":400}","error_code":"INVALID_ARGUMENT","message":"failed to upsert records: Integrated inference is not configured for this index"}
        	Test:       	TestRunSuites/TestIntegratedInference#01
```

I've also built `go-pinecone` locally and validated the behavior running `UpsertRecords` against an integrated and non-integrated index.

### `UpsertRecords` against a non-integrated index
#### Before

Invalid upsert against a non-integrated index
```
go run main.go --indexName test-overload --upsertRecords
API Key: <REDACTED>
Upserted 100 records (1 of 2 batches)
Upserted 100 records (2 of 2 batches)
Upserted 200 records to namespaces [test-namespace]
```

#### After

Invalid upsert against a non-integrated index
```
go run main.go --indexName test-overload --upsertRecords
API Key: <REDACTED>
panic: {"status_code":400,"body":"{\"error\":{\"code\":\"INVALID_ARGUMENT\",\"message\":\"Integrated inference is not configured for this index\"},\"status\":400}","error_code":"INVALID_ARGUMENT","message":"failed to upsert records: Integrated inference is not configured for this index"}

goroutine 1 [running]:
main.upsertNumberOfRecordsToNewIndex(0xc8, {0x16d5df2f6, 0xd})
	/Users/austin/workspace/go-pinecone-consumer/main.go:1059 +0x5d4
main.main()
	/Users/austin/workspace/go-pinecone-consumer/main.go:143 +0x2d4
exit status 2
```

Valid upsert against an integrated index (`res.StatusCode == http.StatusCreated`)
```
go run main.go --indexName test-integrated --upsertRecords
API Key: <REDACTED>
Upserted 95 records (1 of 3 batches)
Upserted 95 records (2 of 3 batches)
Upserted 10 records (3 of 3 batches)
Upserted 200 records to namespaces [test-namespace]
```

The error'ing is the correct behavior here, and we properly surface the API errors when the status isn't successful.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes in `UpsertRecords` (and some other data-plane calls) now correctly return errors for non-success HTTP responses, which may break consumers that previously relied on silent success; scope is otherwise small and well-targeted.
> 
> **Overview**
> Fixes `IndexConnection.UpsertRecords` to **stop swallowing server-side failures** by checking the HTTP status (`201 Created`) and returning `handleErrorResponseBody(...)` when the API responds with an error; the upsert request error is also wrapped with `%w`.
> 
> Improves HTTP resource/error handling across related calls by adding missing `defer ...Body.Close()` and explicit non-200 status checks (notably `SearchRecords`, `DescribeImport`, `ListImports`, `Client.ListBackups`, and `AdminClient.APIKey.List`).
> 
> Updates the integrated inference integration test to wait for index readiness before data-plane calls and to create/close an `IndexConnection` from the newly created index host, ensuring failures are actually surfaced.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ee2602add1ad9ca5aabf4e09bec158411ddf015. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->