### PR TITLE
Fix default namespace coercion

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(just test-unit *)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(just test-unit *)"
-    ]
-  }
-}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(just test-unit *)",
-      "Bash(gh pr *)"
-    ]
-  }
-}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(just test-unit *)",
+      "Bash(gh pr *)"
+    ]
+  }
+}

--- a/pinecone/client.go
+++ b/pinecone/client.go
@@ -124,7 +124,7 @@ type NewClientBaseParams struct {
 // See [Client.Index] for code example.
 type NewIndexConnParams struct {
 	Host               string            // required - obtained through DescribeIndex or ListIndexes
-	Namespace          string            // optional - if not provided the default namespace of "__default__" will be used
+	Namespace          string            // optional - if not provided the default namespace of "" will be used
 	AdditionalMetadata map[string]string // optional
 }
 
@@ -280,10 +280,6 @@ func NewClientBase(in NewClientBaseParams) (*Client, error) {
 func (c *Client) Index(in NewIndexConnParams, dialOpts ...grpc.DialOption) (*IndexConnection, error) {
 	if in.AdditionalMetadata == nil {
 		in.AdditionalMetadata = make(map[string]string)
-	}
-
-	if in.Namespace == "" {
-		in.Namespace = "__default__"
 	}
 
 	if in.Host == "" {

--- a/pinecone/index_connection.go
+++ b/pinecone/index_connection.go
@@ -551,7 +551,7 @@ func (idx *IndexConnection) FetchVectors(ctx context.Context, ids []string) (*Fe
 	return &FetchVectorsResponse{
 		Vectors:   vectors,
 		Usage:     toUsage(res.Usage),
-		Namespace: idx.namespace,
+		Namespace: res.Namespace,
 	}, nil
 }
 
@@ -684,7 +684,7 @@ func (idx *IndexConnection) FetchVectorsByMetadata(ctx context.Context, in *Fetc
 	return &FetchVectorsByMetadataResponse{
 		Vectors:    vectors,
 		Usage:      toUsage(res.Usage),
-		Namespace:  namespace,
+		Namespace:  res.Namespace,
 		Pagination: pagination,
 	}, nil
 }
@@ -2125,7 +2125,7 @@ func (idx *IndexConnection) query(ctx context.Context, req *db_data_grpc.QueryRe
 	return &QueryVectorsResponse{
 		Matches:   matches,
 		Usage:     toUsage(res.Usage),
-		Namespace: idx.namespace,
+		Namespace: res.Namespace,
 	}, nil
 }
 

--- a/pinecone/index_connection.go
+++ b/pinecone/index_connection.go
@@ -794,7 +794,7 @@ func (idx *IndexConnection) ListVectors(ctx context.Context, in *ListVectorsRequ
 		VectorIds:           vectorIds,
 		Usage:               toUsage(res.Usage),
 		NextPaginationToken: toPaginationTokenGrpc(res.Pagination),
-		Namespace:           idx.namespace,
+		Namespace:           res.Namespace,
 	}, nil
 }
 

--- a/pinecone/index_connection.go
+++ b/pinecone/index_connection.go
@@ -2448,7 +2448,8 @@ func toMetadataSchemaGrpc(schema *db_data_grpc.MetadataSchema) *MetadataSchema {
 }
 
 // restNamespace returns the namespace to use in REST URL path segments. Empty string is not a
-// valid path segment, so the default namespace is represented as "__default__" in REST URLs.
+// valid path segment, so the default namespace is represented as "__default__" in REST URLs
+// which maps to the default namespace on the server.
 func restNamespace(ns string) string {
 	if ns == "" {
 		return "__default__"

--- a/pinecone/index_connection.go
+++ b/pinecone/index_connection.go
@@ -1121,7 +1121,7 @@ func (idx *IndexConnection) UpsertRecords(ctx context.Context, records []*Integr
 		}
 	}
 
-	res, err := idx.restClient.UpsertRecordsNamespaceWithBody(ctx, idx.namespace, &db_data_rest.UpsertRecordsNamespaceParams{XPineconeApiVersion: gen.PineconeApiVersion}, "application/x-ndjson", &buffer)
+	res, err := idx.restClient.UpsertRecordsNamespaceWithBody(ctx, restNamespace(idx.namespace), &db_data_rest.UpsertRecordsNamespaceParams{XPineconeApiVersion: gen.PineconeApiVersion}, "application/x-ndjson", &buffer)
 	if err != nil {
 		return fmt.Errorf("failed to upsert records: %w", err)
 	}
@@ -1281,7 +1281,7 @@ func (idx *IndexConnection) SearchRecords(ctx context.Context, in *SearchRecords
 		}
 	}
 
-	res, err := (*idx.restClient).SearchRecordsNamespace(idx.akCtx(ctx), idx.namespace, &db_data_rest.SearchRecordsNamespaceParams{XPineconeApiVersion: gen.PineconeApiVersion}, req)
+	res, err := (*idx.restClient).SearchRecordsNamespace(idx.akCtx(ctx), restNamespace(idx.namespace), &db_data_rest.SearchRecordsNamespaceParams{XPineconeApiVersion: gen.PineconeApiVersion}, req)
 	if err != nil {
 		return nil, err
 	}
@@ -2445,4 +2445,13 @@ func toMetadataSchemaGrpc(schema *db_data_grpc.MetadataSchema) *MetadataSchema {
 	return &MetadataSchema{
 		Fields: fields,
 	}
+}
+
+// restNamespace returns the namespace to use in REST URL path segments. Empty string is not a
+// valid path segment, so the default namespace is represented as "__default__" in REST URLs.
+func restNamespace(ns string) string {
+	if ns == "" {
+		return "__default__"
+	}
+	return ns
 }

--- a/pinecone/index_connection_test.go
+++ b/pinecone/index_connection_test.go
@@ -1790,6 +1790,37 @@ func indexMetricPointer(metric IndexMetric) *IndexMetric {
 	return &metric
 }
 
+func TestRestNamespaceUnit(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty string maps to __default__",
+			input:    "",
+			expected: "__default__",
+		},
+		{
+			name:     "non-empty namespace is returned unchanged",
+			input:    "my-namespace",
+			expected: "my-namespace",
+		},
+		{
+			name:     "__default__ is returned unchanged",
+			input:    "__default__",
+			expected: "__default__",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := restNamespace(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func slicesEqual[T comparable](a, b []float32) bool {
 	if len(a) != len(b) {
 		return false


### PR DESCRIPTION
## Problem

When new API interfaces introduced namespace as a URI path segment, `""` could no longer serve as the canonical representation of the default namespace — an empty path segment is not a valid URL. The `"__default__"` alias was introduced in 2025-04 to address this: the server accepts `"__default__"` as input at `>= 2025-04` and maps \`""\` to `"__default__"` in responses for human-readable output.

The SDK was coercing `"" → "__default__"` client-side when creating an `IndexConnection`, which is correct for the URI-based REST interfaces but unnecessary for the gRPC data plane (which accepts `""` as the proto3 zero value on all versions). More importantly, `FetchVectors`, `FetchVectorsByMetadata`, and `QueryVectors` were echoing the client-side stored namespace back in responses rather than returning the namespace value the server actually sent.

## Solution

- Remove the client-side `"" → "__default__"` coercion in `Client.Index` so `""` is sent over the wire directly (the server handles it correctly at the current API version)
- Update `FetchVectors`, `FetchVectorsByMetadata`, and `query` to return `res.Namespace` from the server response instead of echoing `idx.namespace`

Since the server maps `"" → "__default__"` in responses at the current API version (2025-10), callers still see `"__default__"` in response `Namespace` fields — behavior is unchanged.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

- Unit tests pass (`just test-unit`)
- Integration tests against a live index should confirm that default-namespace operations (upsert, fetch, query) behave correctly and response `Namespace` fields reflect the server's value

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches namespace normalization used by data-plane calls; incorrect mapping could route requests to the wrong namespace or change response `Namespace` values.
> 
> **Overview**
> Fixes default-namespace behavior by **stopping client-side coercion** of `""` to `"__default__"` when creating an `IndexConnection`, so gRPC requests can send the proto3 zero value unchanged.
> 
> Updates gRPC-based responses (`FetchVectors`, `FetchVectorsByMetadata`, `ListVectors`, and query responses) to **return the server-provided `res.Namespace`** instead of echoing the connection’s stored namespace.
> 
> Introduces `restNamespace()` to map `"" -> "__default__"` *only* for REST URL path segments (used by `UpsertRecords`/`SearchRecords`) and adds a small unit test for this mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4bff8df8bbc5ede4231f12dff525686b175d069. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->