### PR TITLE
Enable Dependabot version updates (PIN-4)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      gomod-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What
Adds `.github/dependabot.yml` enabling **weekly, grouped Dependabot version updates**.

Ecosystems covered: gomod, github-actions.

## Why
Part of standing up the security fast-patch process (**PIN-4**). Keeping dependencies close to their latest patched release shrinks the diff and time needed to ship a fix when a security advisory lands. Dependabot **security updates** (auto patch PRs on advisories) and **vulnerability alerts** are already enabled on this repo; this adds the routine version-update cadence.

Minor/patch updates are grouped into a single PR per ecosystem to keep review noise low; majors come as individual PRs.

## Review notes
Config only — no code changes. First run may open a batch of update PRs; that is expected. Adjust `open-pull-requests-limit` or `schedule` if the cadence is too noisy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change with no runtime or application code impact; first run may open a batch of dependency PRs as expected.
> 
> **Overview**
> Adds **`.github/dependabot.yml`** so Dependabot opens **weekly** version-update PRs for **Go modules** (`gomod`) and **GitHub Actions**, supporting the PIN-4 security fast-patch process alongside existing security alerts and advisory-driven updates.
> 
> For **gomod**, **minor and patch** bumps are **grouped** into one PR; **major** updates stay separate. Go module PRs are capped at **10 open** at a time. **GitHub Actions** updates are grouped into a single weekly PR per the `*` pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79d4cc0a486c7a0f5007b745623623ca6f148bfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->