### PR TITLE
ci: add least-privilege workflow permissions (CodeQL)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,10 @@ name: ci
 on:
   pull_request: {}
 
+# Least-privilege default: CI only reads the repo to build and test.
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,10 @@ on:
         type: string
         default: ""
 
+# Release pushes the version-bump commit and tags back to the repo.
+permissions:
+  contents: write
+
 jobs:
   bump-version-and-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Resolves the two open CodeQL `actions/missing-workflow-permissions` alerts on this repo (alerts #1 and #2). Neither workflow declared explicit `permissions`, so both fell back to the repository default `GITHUB_TOKEN` scope.

## Changes
- **ci.yaml** → `permissions: contents: read` — builds and runs tests on `pull_request`; needs no write scope.
- **release.yaml** → `permissions: contents: write` — pushes the version-bump commit and tags (`git push --follow-tags`), so it needs write to `contents`.

## Verification
- YAML parses cleanly (`ruby -ryaml`).
- No behavior change beyond scoping the token: `ci` performs no writes; `release` writes only `contents`, matching its `git push` steps.

Part of PIN-16 (security tail), child of PIN-6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML-only hardening with no application or release logic changes; scopes the token to match existing read vs push behavior.
> 
> **Overview**
> Adds explicit **`GITHUB_TOKEN` permissions** to both GitHub Actions workflows so they no longer inherit the repo default (fixes CodeQL `actions/missing-workflow-permissions`).
> 
> **`ci.yaml`** sets `permissions: contents: read` for pull-request build/test jobs that only need checkout and read access.
> 
> **`release.yaml`** sets `permissions: contents: write` so the manual release workflow can push version-bump commits and tags (`git push --follow-tags` / `git push --tags`).
> 
> No workflow steps or triggers change—only token scope is narrowed on CI and declared on release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9900a0114e2dae648e020be3bdc04836312c7a05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->